### PR TITLE
Prepare fully parallel inertial flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bool_ext"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aaa5af5d1705aba49bace04f3d29c8fa9c0c20829fdea161b89718b2955ef1"
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,7 +836,6 @@ version = "0.1.4"
 dependencies = [
  "bincode",
  "bitvec",
- "bool_ext",
  "clap 3.1.18",
  "criterion",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/chipper/bin/main.rs"
 [dependencies]
 bincode = "1.3.3"
 bitvec = "1.0.0"
-bool_ext = "0.5.1"
 clap = { version = "3.1.18", features = ["derive"] }
 criterion = "0.3.5"
 env_logger = "0.9.0"

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 /// represents the hiearchical partition id scheme. The root id has ID 1 and
 /// children are shifted to the left by one and plus 0/1. The parent child
 /// relationship can thus be queried in constant time.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PartitionID(u32);
 
 impl PartitionID {


### PR DESCRIPTION
This change reworks the internals of the main inertial flow loop. After this PR, full parallelization can be activated by changing the outer `.iter()` call into `.par_iter()`. The current level job queue is then processed concurrently.
<img width="1194" alt="Bildschirmfoto 2022-05-27 um 22 50 51" src="https://user-images.githubusercontent.com/1067895/170787871-b5ea52d6-c972-4171-8226-7d264d691972.png">

