### PR TITLE
Implement min cell size threshold and UnsafePartitionIDs container

### DIFF
--- a/src/chipper/bin/command_line.rs
+++ b/src/chipper/bin/command_line.rs
@@ -2,19 +2,19 @@ use std::{fmt::Display, ops::RangeInclusive};
 
 use clap::Parser;
 
-static LEVEL_RANGE: RangeInclusive<u8> = 1..=31;
+static RECURSION_RANGE: RangeInclusive<u8> = 1..=31;
 static BALANCE_RANGE: RangeInclusive<f64> = 0. ..=0.5;
 
-/// Checks whether the target level is within the expected range of (1, 31].
-pub fn target_level_in_range(s: &str) -> Result<u8, String> {
-    let target_level: u8 = s.parse().map_err(|_| format!("`{}` isn't a number", s))?;
-    if LEVEL_RANGE.contains(&target_level) {
-        Ok(target_level)
+/// Checks whether the recursion range is within the expected range of (1, 31].
+pub fn recursion_depth_in_range(s: &str) -> Result<u8, String> {
+    let recursion_depth: u8 = s.parse().map_err(|_| format!("`{}` isn't a number", s))?;
+    if RECURSION_RANGE.contains(&recursion_depth) {
+        Ok(recursion_depth)
     } else {
         Err(format!(
-            "target level not in range {}-{}",
-            LEVEL_RANGE.start(),
-            LEVEL_RANGE.end()
+            "recursion range not in range {}-{}",
+            RECURSION_RANGE.start(),
+            RECURSION_RANGE.end()
         ))
     }
 }
@@ -56,9 +56,10 @@ pub struct Arguments {
     #[clap(short, long, parse(try_from_str=balance_factor_in_range), default_value_t = 0.25)]
     pub b_factor: f64,
 
-    /// target level of the resulting partition
-    #[clap(short, long, parse(try_from_str=target_level_in_range), default_value_t = 1)]
-    pub target_level: u8,
+    /// depth of recursive partitioning; off by one from the level of a node
+    /// since the root node has level 1, e.g. depths of 1 gives cells on level 2
+    #[clap(short, long, parse(try_from_str=recursion_depth_in_range), default_value_t = 1)]
+    pub recursion_depth: u8,
 
     /// path to the output file with partition ids
     #[clap(short, long, default_value_t = String::new())]
@@ -74,7 +75,8 @@ impl Display for Arguments {
         writeln!(f, "command line arguments:")?;
         writeln!(f, "graph: {}", self.graph)?;
         writeln!(f, "coordinates: {}", self.coordinates)?;
-        writeln!(f, "target level: {}", self.target_level)?;
-        writeln!(f, "balance factor: {}", self.b_factor)
+        writeln!(f, "recursion range: {}", self.recursion_depth)?;
+        writeln!(f, "balance factor: {}", self.b_factor)?;
+        writeln!(f, "minimum_cell_size: {}", self.minimum_cell_size)
     }
 }

--- a/src/inertial_flow.rs
+++ b/src/inertial_flow.rs
@@ -12,7 +12,6 @@ use crate::{
     edge::InputEdge,
     geometry::primitives::FPCoordinate,
     max_flow::{MaxFlow, ResidualCapacity},
-    partition::PartitionID,
 };
 
 pub struct Coefficients([(i32, i32); 4]);
@@ -35,12 +34,6 @@ impl Index<usize> for Coefficients {
     fn index(&self, i: usize) -> &(i32, i32) {
         &self.0[i % self.0.len()]
     }
-}
-
-#[derive(Copy, Clone)]
-pub struct ProxyId {
-    pub node_id: usize,
-    pub partition_id: PartitionID,
 }
 
 pub struct FlowResult {
@@ -72,7 +65,7 @@ pub fn sub_step(
     axis: usize,
     input_edges: &[InputEdge<ResidualCapacity>],
     coordinates: &[FPCoordinate],
-    node_id_list: &[ProxyId],
+    node_id_list: &[usize],
     balance_factor: f64,
     upper_bound: Arc<AtomicI32>,
 ) -> FlowResult {
@@ -86,8 +79,7 @@ pub fn sub_step(
     // the iteration proxy list to be sorted. The coordinates vector itself is not touched.
     let mut node_id_list = node_id_list.to_vec();
     node_id_list.sort_unstable_by_key(|a| -> i32 {
-        coordinates[a.node_id].lon * current_coefficients.0
-            + coordinates[a.node_id].lat * current_coefficients.1
+        coordinates[*a].lon * current_coefficients.0 + coordinates[*a].lat * current_coefficients.1
     });
 
     let size_of_contraction = max(1, (node_id_list.len() as f64 * balance_factor) as usize);
@@ -103,10 +95,10 @@ pub fn sub_step(
     // the mapping is input id -> dinic id
 
     for s in sources {
-        renumbering_table[s.node_id] = 0;
+        renumbering_table[*s] = 0;
     }
     for t in targets {
-        renumbering_table[t.node_id] = 1;
+        renumbering_table[*t] = 1;
     }
 
     // each thread holds their own copy of the edge set
@@ -177,11 +169,11 @@ pub fn sub_step(
 
     // explode intermediate assigment
     for id in &node_id_list {
-        let index = renumbering_table[id.node_id];
+        let index = renumbering_table[*id];
         if index == usize::MAX {
-            assignment.set(id.node_id, id.node_id % 2 == 0);
+            assignment.set(*id, id % 2 == 0);
         } else {
-            assignment.set(id.node_id, intermediate_assignment[index]);
+            assignment.set(*id, intermediate_assignment[index]);
         }
     }
 
@@ -200,8 +192,6 @@ mod tests {
     use bitvec::prelude::*;
     use itertools::Itertools;
 
-    use crate::inertial_flow::ProxyId;
-    use crate::partition::PartitionID;
     use crate::{
         edge::InputEdge, geometry::primitives::FPCoordinate, inertial_flow::sub_step,
         max_flow::ResidualCapacity,
@@ -247,12 +237,7 @@ mod tests {
             FPCoordinate::new(0, 2),
             FPCoordinate::new(1, 3),
         ];
-        let node_id_list = (0..coordinates.len())
-            .map(|i| ProxyId {
-                node_id: i,
-                partition_id: PartitionID::root(),
-            })
-            .collect_vec();
+        let node_id_list = (0..coordinates.len()).collect_vec();
 
         let result = sub_step(3, &edges, &coordinates, &node_id_list, 0.25, upper_bound);
         assert_eq!(result.flow, 1);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,6 +1,6 @@
 use core::cmp::max;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::{cell::Cell, fmt::Display};
 
 /// represents the hiearchical partition id scheme. The root id has ID 1 and
 /// children are shifted to the left by one and plus 0/1. The parent child
@@ -45,6 +45,11 @@ impl PartitionID {
         self.0 += 0;
     }
 
+    /// Transform ID to its left-most descendant k levels down
+    pub fn make_leftmost_descendant(&mut self, k: usize) {
+        self.0 <<= k;
+    }
+
     /// Transform the ID into its right child
     pub fn make_right_child(&mut self) {
         self.0 <<= 1;
@@ -81,6 +86,30 @@ impl Display for PartitionID {
     }
 }
 
+// TODO: Make PartitionID vector a struct with inner mutability
+pub fn make_left_child(index: usize, partition_ids: &Cell<[PartitionID]>) {
+    unsafe {
+        (*(partition_ids.as_ptr()))[index].make_left_child();
+    }
+}
+
+pub fn make_right_child(index: usize, partition_ids: &Cell<[PartitionID]>) {
+    unsafe {
+        (*(partition_ids.as_ptr()))[index].make_right_child();
+    }
+}
+
+pub fn make_left_most_descendant_on_level_down(
+    slice_ids: &Cell<[PartitionID]>,
+    i: &usize,
+    level_difference: usize,
+) {
+    unsafe {
+        let mut temp = (*(slice_ids.as_ptr()))[*i];
+        temp.make_leftmost_descendant(level_difference);
+        (*(slice_ids.as_ptr()))[*i] = temp;
+    }
+}
 #[cfg(test)]
 mod tests {
     use crate::partition::PartitionID;


### PR DESCRIPTION
Also, speeds up the initial bisection by roughly 10% and lowers the memory consumption per thread. 