### PR TITLE
Increase dynamic_graph.rs line coverage to 100%

### DIFF
--- a/src/dynamic_graph.rs
+++ b/src/dynamic_graph.rs
@@ -406,6 +406,22 @@ mod tests {
     }
 
     #[test]
+    fn data_mut() {
+        type Graph = DynamicGraph<i32>;
+        let mut graph = Graph::new(6, EDGES.to_vec());
+        assert_eq!(6, graph.number_of_nodes());
+        assert_eq!(8, graph.number_of_edges());
+
+        let edge = graph.find_edge(1, 5);
+        assert!(edge.is_some());
+        assert_ne!(123, *graph.data(edge.unwrap()));
+
+        *graph.data_mut(edge.unwrap()) = 123;
+        assert_eq!(123, *graph.data(edge.unwrap()));
+    }
+
+
+    #[test]
     fn find_edge() {
         type Graph = DynamicGraph<i32>;
         let graph = Graph::new_from_sorted_list(6, &EDGES);

--- a/src/dynamic_graph.rs
+++ b/src/dynamic_graph.rs
@@ -352,6 +352,14 @@ mod tests {
     }
 
     #[test]
+    fn new() {
+        type Graph = DynamicGraph<i32>;
+        let graph = Graph::new(6, EDGES.to_vec());
+        assert_eq!(6, graph.number_of_nodes());
+        assert_eq!(8, graph.number_of_edges());
+    }
+
+    #[test]
     fn degree() {
         type Graph = DynamicGraph<i32>;
         let graph = Graph::new_from_sorted_list(6, &EDGES);

--- a/src/dynamic_graph.rs
+++ b/src/dynamic_graph.rs
@@ -4,7 +4,7 @@
 /// edge.
 use crate::{
     edge::{Edge, EdgeData},
-    graph::{EdgeArrayEntry, EdgeID, Graph, NodeID, INVALID_EDGE_ID, INVALID_NODE_ID},
+    graph::{EdgeArrayEntry, EdgeID, Graph, NodeID, INVALID_NODE_ID},
 };
 use core::ops::Range;
 
@@ -133,7 +133,7 @@ impl<T: Clone + Copy> DynamicGraph<T> {
 
     /// Inserts a node with an empty edge slice into the node array.
     pub fn insert_node(&mut self) {
-        self.node_array.push(NodeArrayEntry::new(INVALID_EDGE_ID));
+        self.node_array.push(NodeArrayEntry::new(self.node_array.last().unwrap().first_edge));
         self.number_of_nodes += 1;
     }
 
@@ -145,10 +145,10 @@ impl<T: Clone + Copy> DynamicGraph<T> {
     /// the beginning of the newly added extension of the edge array.
     pub fn insert_edge(&mut self, source: NodeID, target: NodeID, data: T) {
         // if the source of target nodes don't exist yet, then add them.
-        while self.number_of_nodes < source {
+        while self.number_of_nodes <= source {
             self.insert_node();
         }
-        while self.number_of_nodes < target {
+        while self.number_of_nodes <= target {
             self.insert_node();
         }
 
@@ -357,6 +357,25 @@ mod tests {
         let graph = Graph::new(6, EDGES.to_vec());
         assert_eq!(6, graph.number_of_nodes());
         assert_eq!(8, graph.number_of_edges());
+    }
+
+    #[test]
+    fn insert_node_edge() {
+        type Graph = DynamicGraph<i32>;
+        let mut graph = Graph::new(6, EDGES.to_vec());
+        assert_eq!(6, graph.number_of_nodes());
+        assert_eq!(8, graph.number_of_edges());
+
+        graph.insert_node();
+        assert_eq!(7, graph.number_of_nodes());
+
+        graph.insert_edge(5, 6, 20);
+        assert_eq!(9, graph.number_of_edges());
+
+        graph.insert_edge(10, 11, -1);
+        assert_eq!(12, graph.number_of_nodes());
+        assert_eq!(10, graph.number_of_edges());
+
     }
 
     #[test]

--- a/src/dynamic_graph.rs
+++ b/src/dynamic_graph.rs
@@ -133,7 +133,9 @@ impl<T: Clone + Copy> DynamicGraph<T> {
 
     /// Inserts a node with an empty edge slice into the node array.
     pub fn insert_node(&mut self) {
-        self.node_array.push(NodeArrayEntry::new(self.node_array.last().unwrap().first_edge));
+        self.node_array.push(NodeArrayEntry::new(
+            self.node_array.last().unwrap().first_edge,
+        ));
         self.number_of_nodes += 1;
     }
 
@@ -375,7 +377,6 @@ mod tests {
         graph.insert_edge(10, 11, -1);
         assert_eq!(12, graph.number_of_nodes());
         assert_eq!(10, graph.number_of_edges());
-
     }
 
     #[test]
@@ -419,7 +420,6 @@ mod tests {
         *graph.data_mut(edge.unwrap()) = 123;
         assert_eq!(123, *graph.data(edge.unwrap()));
     }
-
 
     #[test]
     fn find_edge() {

--- a/src/dynamic_graph.rs
+++ b/src/dynamic_graph.rs
@@ -390,6 +390,22 @@ mod tests {
     }
 
     #[test]
+    fn remove_edge() {
+        type Graph = DynamicGraph<i32>;
+        let mut graph = Graph::new(6, EDGES.to_vec());
+        assert_eq!(6, graph.number_of_nodes());
+        assert_eq!(8, graph.number_of_edges());
+
+        let edge = graph.find_edge(1, 5);
+        assert!(edge.is_some());
+        graph.remove_edge(1, edge.unwrap());
+        assert_eq!(7, graph.number_of_edges());
+
+        let edge = graph.find_edge(1, 5);
+        assert!(edge.is_none());
+    }
+
+    #[test]
     fn find_edge() {
         type Graph = DynamicGraph<i32>;
         let graph = Graph::new_from_sorted_list(6, &EDGES);


### PR DESCRIPTION
| revision | function coverage | line coverage | region coverage | functionality| 
|--------|-------|-------|------| ---- |
| HEAD    | 85.71 | 88.45 | 94.52 | HEAD |
|9882b9a3c5ad0f2fb9e20d4c6617316751d1d5c1| 88.89 | 91.56 | 95.35 | new() |
| aa532dd6e2a1c2a44825934b5c440a5ae994964b |  91.89 | 94.38 | 97.47 | add_node/edge() |
| d9b12f4ce20599a233a8692b622cc68b48b63dfc | 97.37 | 99.09 | 98.79 | remove_edge() |
| d82e7c77104610d53fd7ec9a05c53a645c39aa4e | 100.0 | 100.0 | 99.42 | data_mut() |