### PR TITLE
Increase test coverage for several files, fix top-k implementation

### DIFF
--- a/src/addressable_binary_heap.rs
+++ b/src/addressable_binary_heap.rs
@@ -534,6 +534,9 @@ mod tests {
             heap.insert(*i, *i, *i);
         }
 
+        // never inserted
+        assert!(!heap.contains(16));
+
         // rebind list of input values as mutable
         let mut input = input;
         input.sort();

--- a/src/edmonds_karp.rs
+++ b/src/edmonds_karp.rs
@@ -162,6 +162,9 @@ impl MaxFlow for EdmondsKarp {
 #[cfg(test)]
 mod tests {
 
+    use std::sync::atomic::AtomicI32;
+    use std::sync::Arc;
+
     use crate::edge::InputEdge;
     use crate::edmonds_karp::EdmondsKarp;
     use crate::max_flow::MaxFlow;
@@ -201,6 +204,34 @@ mod tests {
             .expect("assignment computation did not run");
 
         assert_eq!(assignment, bits![1, 1, 1, 0, 1, 0]);
+    }
+
+    #[test]
+    fn run_with_upper_bound_no_effect() {
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(16)),
+            InputEdge::new(0, 2, ResidualEdgeData::new(13)),
+            InputEdge::new(1, 2, ResidualEdgeData::new(10)),
+            InputEdge::new(1, 3, ResidualEdgeData::new(12)),
+            InputEdge::new(2, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 4, ResidualEdgeData::new(14)),
+            InputEdge::new(3, 2, ResidualEdgeData::new(9)),
+            InputEdge::new(3, 5, ResidualEdgeData::new(20)),
+            InputEdge::new(4, 3, ResidualEdgeData::new(7)),
+            InputEdge::new(4, 5, ResidualEdgeData::new(4)),
+        ];
+
+        let source = 0;
+        let target = 5;
+        let mut max_flow_solver = EdmondsKarp::from_edge_list(edges, source, target);
+        let upper_bound = Arc::new(AtomicI32::new(1));
+        max_flow_solver.run_with_upper_bound(upper_bound);
+
+        // it's OK to expect the solver to have run
+        let max_flow = max_flow_solver
+            .max_flow()
+            .expect("max flow computation did not run");
+        assert_eq!(23, max_flow);
     }
 
     #[test]

--- a/src/ford_fulkerson.rs
+++ b/src/ford_fulkerson.rs
@@ -159,6 +159,9 @@ impl MaxFlow for FordFulkerson {
 #[cfg(test)]
 mod tests {
 
+    use std::sync::atomic::AtomicI32;
+    use std::sync::Arc;
+
     use crate::edge::InputEdge;
     use crate::ford_fulkerson::FordFulkerson;
     use crate::max_flow::MaxFlow;
@@ -198,6 +201,34 @@ mod tests {
             .expect("assignment computation did not run");
 
         assert_eq!(assignment, bits![1, 1, 1, 0, 1, 0]);
+    }
+
+    #[test]
+    fn run_with_upper_bound_no_effect() {
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(16)),
+            InputEdge::new(0, 2, ResidualEdgeData::new(13)),
+            InputEdge::new(1, 2, ResidualEdgeData::new(10)),
+            InputEdge::new(1, 3, ResidualEdgeData::new(12)),
+            InputEdge::new(2, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 4, ResidualEdgeData::new(14)),
+            InputEdge::new(3, 2, ResidualEdgeData::new(9)),
+            InputEdge::new(3, 5, ResidualEdgeData::new(20)),
+            InputEdge::new(4, 3, ResidualEdgeData::new(7)),
+            InputEdge::new(4, 5, ResidualEdgeData::new(4)),
+        ];
+
+        let source = 0;
+        let target = 5;
+        let mut max_flow_solver = FordFulkerson::from_edge_list(edges, source, target);
+        let upper_bound = Arc::new(AtomicI32::new(1));
+        max_flow_solver.run_with_upper_bound(upper_bound);
+
+        // it's OK to expect the solver to have run
+        let max_flow = max_flow_solver
+            .max_flow()
+            .expect("max flow computation did not run");
+        assert_eq!(23, max_flow);
     }
 
     #[test]

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -170,6 +170,19 @@ mod test {
     use super::LinkedList;
 
     #[test]
+    fn default_init_cursor_noop() {
+        let mut list = LinkedList::default();
+
+        assert_eq!(list.len(), 0);
+        assert_eq!(list.pop_back(), None);
+        assert_eq!(list.len(), 0);
+        let cursor = list.push_front(10);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.pop_back(), Some(10));
+        list.move_to_front(&cursor); // no-op since list is empty
+    }
+
+    #[test]
     fn test_basic_front() {
         let mut list = LinkedList::new();
 


### PR DESCRIPTION
### before 
|Filename|Function Coverage|Line Coverage|Region Coverage| 
|-|-|-|-|
|addressable_binary_heap.rs| 100.00% (39/39)|  99.75% (397/398)|  99.60% (249/250)|
|edmonds_karp.rs|  93.33% (14/15)|  98.18% (269/274)|  84.93% (62/73)| 
|ford_fulkerson.rs|  93.33% (14/15)|  98.18% (269/274)|  84.93% (62/73)| 
|io.rs|  25.00% (1/4)|  25.93% (7/27)|  60.00% (6/10)| 
|linked_list.rs|  93.75% (15/16)|  97.35% (184/189)|  96.59% (85/88)| 
|top_k.rs| 100.00% (5/5)|  90.57% (48/53)|  84.21% (16/19)| 
|...|...|...|...|
|Totals|  88.07% (561/637)|  90.80% (6636/7308)|  84.51% (2438/2885)|

### after
|Filename|Function Coverage|Line Coverage|Region Coverage| 
|-|-|-|-|
|addressable_binary_heap.rs| 100.00% (39/39)| 100.00% (399/399)| 100.00% (251/251)|
|edmonds_karp.rs| 100.00% (16/16)| 100.00% (300/300)|  88.00% (66/75)| 
|ford_fulkerson.rs| 100.00% (16/16)| 100.00% (300/300)|  88.00% (66/75)| 
|io.rs| 100.00% (13/13)| 100.00% (124/124)| 100.00% (31/31)| 
|linked_list.rs| 100.00% (17/17)|  99.50% (199/200)|  98.94% (93/94)| 
|top_k.rs| 100.00% (8/8)| 100.00% (68/68)| 100.00% (29/29)| 
|...|...|...|...|
|Totals|  89.26% (582/652)|  91.56% (6852/7484)|  85.21% (2494/2927)|