### PR TITLE
K way merge iterator using binary heap

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -5,5 +5,6 @@ mod benchmarks;
 criterion_main!(
     benchmarks::fenwick::all_fenwick,
     benchmarks::great_circle::distances,
+    benchmarks::k_way_merge::k_way_merge,
     benchmarks::radix_sort::all_sorts
 );

--- a/benches/benchmarks/k_way_merge.rs
+++ b/benches/benchmarks/k_way_merge.rs
@@ -1,34 +1,47 @@
-use criterion::{black_box, criterion_group, Criterion};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 use rand::{seq::SliceRandom, Rng};
 use toolbox_rs::k_way_merge::KWayMergeIterator;
 
+/// Create a list of random runs of numbers.
+///
+/// # Panics
+/// Panics if k == 0 or s == 0
 fn create_random_runs(s: usize, k: usize) -> Vec<impl Iterator<Item = i32>> {
+    assert!(k > 0, "k must be greater than 0");
+    assert!(s > 0, "s must be greater than 0");
+
     let mut rng = rand::rng();
     let mut numbers: Vec<i32> = (0..s as i32).collect();
     numbers.shuffle(&mut rng);
 
-    let mut runs = Vec::new();
+    let mut runs = Vec::with_capacity(k);
     let mut start = 0;
-    for _ in 0..k {
+    (0..k).for_each(|_| {
         let end = start + rng.random_range(1..=(s - start) / (k - runs.len()));
         let mut run: Vec<i32> = numbers[start..end].to_vec();
         run.sort();
         runs.push(run.into_iter());
         start = end;
-    }
+    });
 
     runs
 }
 
 fn k_way_merge_benchmark(c: &mut Criterion) {
-    let mut list = create_random_runs(1_000_000, 100);
+    let mut group = c.benchmark_group("k_way_merge");
 
-    c.bench_function("k_way_merge", |b| {
-        b.iter(|| {
-            let k_way_merge = KWayMergeIterator::new(black_box(&mut list));
-            let result: Vec<_> = k_way_merge.collect();
-            black_box(result);
-        })
-    });
+    for k in [10, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, &k| {
+            b.iter_with_setup(
+                || create_random_runs(1_000_000, k),
+                |mut list| {
+                    let k_way_merge = KWayMergeIterator::new(black_box(&mut list));
+                    black_box(k_way_merge.collect::<Vec<_>>())
+                },
+            )
+        });
+    }
+
+    group.finish();
 }
 criterion_group!(k_way_merge, k_way_merge_benchmark,);

--- a/benches/benchmarks/k_way_merge.rs
+++ b/benches/benchmarks/k_way_merge.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, criterion_group, Criterion};
+use rand::{seq::SliceRandom, Rng};
+use toolbox_rs::k_way_merge::KWayMergeIterator;
+
+fn create_random_runs(s: usize, k: usize) -> Vec<impl Iterator<Item = i32>> {
+    let mut rng = rand::rng();
+    let mut numbers: Vec<i32> = (0..s as i32).collect();
+    numbers.shuffle(&mut rng);
+
+    let mut runs = Vec::new();
+    let mut start = 0;
+    for _ in 0..k {
+        let end = start + rng.random_range(1..=(s - start) / (k - runs.len()));
+        let mut run: Vec<i32> = numbers[start..end].to_vec();
+        run.sort();
+        runs.push(run.into_iter());
+        start = end;
+    }
+
+    runs
+}
+
+fn k_way_merge_benchmark(c: &mut Criterion) {
+    let mut list = create_random_runs(1_000_000, 100);
+
+    c.bench_function("k_way_merge", |b| {
+        b.iter(|| {
+            let k_way_merge = KWayMergeIterator::new(black_box(&mut list));
+            let result: Vec<_> = k_way_merge.collect();
+            black_box(result);
+        })
+    });
+}
+criterion_group!(k_way_merge, k_way_merge_benchmark,);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,3 +1,4 @@
 pub mod fenwick;
 pub mod great_circle;
+pub mod k_way_merge;
 pub mod radix_sort;

--- a/src/k_way_merge.rs
+++ b/src/k_way_merge.rs
@@ -3,10 +3,10 @@ use std::{cmp::Reverse, collections::BinaryHeap};
 
 pub trait MergeTree<T> {
     /// Pushes an item onto the merge tree
-    fn push(&mut self, item: T);
+    fn push(&mut self, item: MergeEntry<T>);
 
     /// Removes and returns the minimum item from the tree
-    fn pop(&mut self) -> Option<T>;
+    fn pop(&mut self) -> Option<MergeEntry<T>>;
 
     /// Returns true if the tree is empty
     fn is_empty(&self) -> bool;
@@ -15,14 +15,33 @@ pub trait MergeTree<T> {
     fn len(&self) -> usize;
 }
 
+// impl<T: Ord> MergeTree<T> for BinaryHeap<T> {
+//     fn push(&mut self, item: T) {
+//         self.push(item);
+//     }
+
+//     fn pop(&mut self) -> Option<T> {
+//         self.pop()
+//     }
+
+//     fn is_empty(&self) -> bool {
+//         self.is_empty()
+//     }
+
+//     fn len(&self) -> usize {
+//         self.len()
+//     }
+// }
+
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct Entry<T> {
-    item: T,
-    index: usize,
+#[derive(Clone, Debug)]
+pub struct MergeEntry<T> {
+    pub item: T,
+    pub index: usize,
 }
 
 pub struct KWayMergeIterator<'a, T, I: Iterator<Item = T>> {
-    heap: BinaryHeap<Reverse<Entry<T>>>,
+    heap: BinaryHeap<Reverse<MergeEntry<T>>>,
     list: &'a mut [I],
 }
 
@@ -31,7 +50,7 @@ impl<'a, T: std::cmp::Ord, I: Iterator<Item = T>> KWayMergeIterator<'a, T, I> {
         let mut heap = BinaryHeap::new();
         for (i, iterator) in list.iter_mut().enumerate() {
             if let Some(first) = iterator.next() {
-                heap.push(Reverse(Entry {
+                heap.push(Reverse(MergeEntry {
                     item: first,
                     index: i,
                 }));
@@ -45,12 +64,12 @@ impl<T: std::cmp::Ord, I: Iterator<Item = T>> Iterator for KWayMergeIterator<'_,
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Reverse(Entry {
+        let Reverse(MergeEntry {
             item: value,
             index: list,
         }) = self.heap.pop()?;
         if let Some(next) = self.list[list].next() {
-            self.heap.push(Reverse(Entry {
+            self.heap.push(Reverse(MergeEntry {
                 item: next,
                 index: list,
             }));

--- a/src/k_way_merge.rs
+++ b/src/k_way_merge.rs
@@ -33,8 +33,7 @@ pub trait MergeTree<T> {
 //     }
 // }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct MergeEntry<T> {
     pub item: T,
     pub index: usize,

--- a/src/k_way_merge.rs
+++ b/src/k_way_merge.rs
@@ -1,11 +1,19 @@
 use std::iter::Iterator;
 use std::{cmp::Reverse, collections::BinaryHeap};
 
-// TODO: add trait to represent merge tree
-// trait MergeTree<T> {
-//     fn push(&mut self, t: T);
-//     fn pop(&mut self) -> Option<T>;
-// }
+pub trait MergeTree<T> {
+    /// Pushes an item onto the merge tree
+    fn push(&mut self, item: T);
+
+    /// Removes and returns the minimum item from the tree
+    fn pop(&mut self) -> Option<T>;
+
+    /// Returns true if the tree is empty
+    fn is_empty(&self) -> bool;
+
+    /// Returns the number of items in the tree
+    fn len(&self) -> usize;
+}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct Entry<T> {

--- a/src/k_way_merge.rs
+++ b/src/k_way_merge.rs
@@ -1,34 +1,51 @@
 use std::iter::Iterator;
 use std::{cmp::Reverse, collections::BinaryHeap};
 
-pub struct KWayMergeIterator<'a, T: Iterator<Item = i32>> {
-    heap: BinaryHeap<Reverse<(i32, usize)>>,
-    list: &'a mut [T],
+// TODO: add trait to represent merge tree
+// trait MergeTree<T> {
+//     fn push(&mut self, t: T);
+//     fn pop(&mut self) -> Option<T>;
+// }
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Entry<T> {
+    item: T,
+    index: usize,
 }
 
-impl<'a, T: Iterator<Item = i32>> KWayMergeIterator<'a, T> {
-    pub fn new(list: &'a mut [T]) -> Self {
+pub struct KWayMergeIterator<'a, T, I: Iterator<Item = T>> {
+    heap: BinaryHeap<Reverse<Entry<T>>>,
+    list: &'a mut [I],
+}
+
+impl<'a, T: std::cmp::Ord, I: Iterator<Item = T>> KWayMergeIterator<'a, T, I> {
+    pub fn new(list: &'a mut [I]) -> Self {
         let mut heap = BinaryHeap::new();
         for (i, iterator) in list.iter_mut().enumerate() {
             if let Some(first) = iterator.next() {
-                heap.push(Reverse((first, i)));
+                heap.push(Reverse(Entry {
+                    item: first,
+                    index: i,
+                }));
             }
         }
         Self { heap, list }
     }
-
-    pub fn has_next(&self) -> bool {
-        !self.heap.is_empty()
-    }
 }
 
-impl<T: Iterator<Item = i32>> Iterator for KWayMergeIterator<'_, T> {
-    type Item = i32;
+impl<T: std::cmp::Ord, I: Iterator<Item = T>> Iterator for KWayMergeIterator<'_, T, I> {
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Reverse((value, list)) = self.heap.pop()?;
+        let Reverse(Entry {
+            item: value,
+            index: list,
+        }) = self.heap.pop()?;
         if let Some(next) = self.list[list].next() {
-            self.heap.push(Reverse((next, list)));
+            self.heap.push(Reverse(Entry {
+                item: next,
+                index: list,
+            }));
         }
         Some(value)
     }
@@ -50,5 +67,25 @@ mod test {
             result,
             vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         );
+    }
+
+    #[test]
+    fn three_way_merge_of_differently_sized_sequences() {
+        let mut list = vec![
+            vec![1, 3, 5, 6, 7, 12].into_iter(),
+            vec![2, 4, 8, 11].into_iter(),
+            vec![9, 10].into_iter(),
+        ];
+        let k_way_merge = super::KWayMergeIterator::new(&mut list);
+        let result: Vec<_> = k_way_merge.collect();
+        assert_eq!(result, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    }
+
+    #[test]
+    fn merge_of_empty_sequences() {
+        let mut list: Vec<std::vec::IntoIter<u64>> = vec![vec![].into_iter(), vec![].into_iter()];
+        let k_way_merge = super::KWayMergeIterator::new(&mut list);
+        let result: Vec<_> = k_way_merge.collect();
+        assert_eq!(result, Vec::<u64>::new());
     }
 }

--- a/src/k_way_merge.rs
+++ b/src/k_way_merge.rs
@@ -1,0 +1,54 @@
+use std::iter::Iterator;
+use std::{cmp::Reverse, collections::BinaryHeap};
+
+pub struct KWayMergeIterator<'a, T: Iterator<Item = i32>> {
+    heap: BinaryHeap<Reverse<(i32, usize)>>,
+    list: &'a mut [T],
+}
+
+impl<'a, T: Iterator<Item = i32>> KWayMergeIterator<'a, T> {
+    pub fn new(list: &'a mut [T]) -> Self {
+        let mut heap = BinaryHeap::new();
+        for (i, iterator) in list.iter_mut().enumerate() {
+            if let Some(first) = iterator.next() {
+                heap.push(Reverse((first, i)));
+            }
+        }
+        Self { heap, list }
+    }
+
+    pub fn has_next(&self) -> bool {
+        !self.heap.is_empty()
+    }
+}
+
+impl<T: Iterator<Item = i32>> Iterator for KWayMergeIterator<'_, T> {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Reverse((value, list)) = self.heap.pop()?;
+        if let Some(next) = self.list[list].next() {
+            self.heap.push(Reverse((next, list)));
+        }
+        Some(value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn four_way_merge() {
+        let mut list = vec![
+            vec![1, 3, 5, 7, 9].into_iter(),
+            vec![2, 4, 6, 8, 10].into_iter(),
+            vec![11, 13, 15, 17, 19].into_iter(),
+            vec![12, 14, 16, 18, 20].into_iter(),
+        ];
+        let k_way_merge = super::KWayMergeIterator::new(&mut list);
+        let result: Vec<_> = k_way_merge.collect();
+        assert_eq!(
+            result,
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod great_circle;
 pub mod huffman_code;
 pub mod inertial_flow;
 pub mod io;
+pub mod k_way_merge;
 pub mod kruskal;
 pub mod level_directory;
 pub mod linked_list;


### PR DESCRIPTION
Initial implementation, loser tree to follow.

Timings using tests added in [ca5e9c7](https://github.com/DennisOSRM/toolbox-rs/pull/465/commits/ca5e9c773e12dca4a0b340147bae3aec4b314127):

![Bildschirmfoto 2025-02-14 um 13 50 46](https://github.com/user-attachments/assets/c976c462-32f6-4736-8968-fed59ce94ddc)
