### PR TITLE
Speed up the partitioner and remove its unsafe code

### DIFF
--- a/examples/partition_stats.rs
+++ b/examples/partition_stats.rs
@@ -1,0 +1,50 @@
+//! Reports statistics of a partition file produced by chipper.
+//! Usage: partition_stats <partition.bin> <graph.toolbox>
+use rustc_hash::FxHashMap;
+use toolbox_rs::{io, partition_id::PartitionID};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let partition_file = args.next().expect("partition file");
+    let graph_file = args.next().expect("graph file");
+
+    let ids = io::read_vec_from_file::<PartitionID>(&partition_file);
+    let edges = io::read_graph_into_trivial_edges(&graph_file);
+
+    let mut level_histogram = FxHashMap::default();
+    for id in &ids {
+        *level_histogram.entry(id.level()).or_insert(0usize) += 1;
+    }
+    let mut cell_sizes = FxHashMap::default();
+    for id in &ids {
+        *cell_sizes.entry(*id).or_insert(0usize) += 1;
+    }
+
+    let cut = edges
+        .iter()
+        .filter(|edge| ids[edge.source] != ids[edge.target])
+        .count();
+
+    let mut sizes = cell_sizes.values().copied().collect::<Vec<_>>();
+    sizes.sort_unstable();
+
+    println!("nodes: {}", ids.len());
+    println!("edges: {}", edges.len());
+    println!("cut edges: {cut}");
+    println!("cells: {}", sizes.len());
+    println!(
+        "cell size min/median/max: {}/{}/{}",
+        sizes.first().unwrap(),
+        sizes[sizes.len() / 2],
+        sizes.last().unwrap()
+    );
+    let mut levels = level_histogram.into_iter().collect::<Vec<_>>();
+    levels.sort_unstable();
+    println!("level histogram (level, node count): {levels:?}");
+
+    // checksum that is invariant to nothing: exact partition identity
+    let mut hasher = std::hash::DefaultHasher::new();
+    use std::hash::{Hash, Hasher};
+    ids.hash(&mut hasher);
+    println!("exact assignment hash: {:016x}", hasher.finish());
+}

--- a/src/chipper/bin/main.rs
+++ b/src/chipper/bin/main.rs
@@ -11,10 +11,12 @@ use itertools::Itertools;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, info};
 use rayon::prelude::*;
-use std::sync::{Arc, atomic::AtomicI32};
+use std::sync::{
+    Arc,
+    atomic::{AtomicI32, AtomicU32, Ordering},
+};
 use toolbox_rs::geometry::FPCoordinate;
 use toolbox_rs::io;
-use toolbox_rs::unsafe_slice::UnsafeSlice;
 use toolbox_rs::{
     inertial_flow::{self, Flow, flow_cmp},
     partition_id::PartitionID,
@@ -54,9 +56,16 @@ fn main() {
         coordinates.len()
     );
 
-    // enqueue initial job for partitioning of the root node into job queue
+    // enqueue initial job for partitioning of the root node into job queue. The
+    // root job takes ownership of the edge set, which is only needed again if
+    // the cut is to be written out.
     let id_vector = (0..coordinates.len()).collect_vec();
-    let job = (edges.clone(), id_vector);
+    let input_edges = if args.cut_csv.is_empty() {
+        Vec::new()
+    } else {
+        edges.clone()
+    };
+    let job = (edges, id_vector);
     let mut current_job_queue = vec![job];
 
     let sty = ProgressStyle::default_spinner()
@@ -65,8 +74,14 @@ fn main() {
         .progress_chars("#>-");
 
     let mut current_level = 0;
-    let mut partition_ids_vec = vec![PartitionID::root(); coordinates.len()];
-    let partition_ids = UnsafeSlice::new(&mut partition_ids_vec);
+    // Cells are disjoint, hence each entry is written by at most one thread per
+    // level. Relaxed atomics express that without an aliasing hazard and
+    // compile to plain loads and stores.
+    let partition_ids = (0..coordinates.len())
+        .map(|_| AtomicU32::new(PartitionID::root().0))
+        .collect_vec();
+    let load = |index: usize| PartitionID(partition_ids[index].load(Ordering::Relaxed));
+    let store = |index: usize, id: PartitionID| partition_ids[index].store(id.0, Ordering::Relaxed);
 
     while !current_job_queue.is_empty() && current_level < args.recursion_depth {
         let pb = ProgressBar::new(current_job_queue.len() as u64);
@@ -94,15 +109,22 @@ fn main() {
                             upper_bound.clone(),
                         )
                     })
-                    .filter(|result| result.is_ok())
-                    .map(|result| result.unwrap())
+                    .filter_map(Result::ok)
                     .min_by(flow_cmp);
 
-                if best_max_flow.is_none() {
+                let Some(result) = best_max_flow else {
+                    // No axis yielded a cut, e.g. because the cell has no edges
+                    // at all. The cell stays as it is, but its nodes still have
+                    // to descend to the bottom of the hierarchy.
+                    debug!("cell of {} nodes could not be cut", job.1.len());
+                    let level_difference = (args.recursion_depth - current_level) as usize;
+                    for i in &job.1 {
+                        let mut id = load(*i);
+                        id.make_leftmost_descendant(level_difference);
+                        store(*i, id);
+                    }
                     return Vec::new();
-                }
-
-                let result = best_max_flow.unwrap();
+                };
                 debug!(
                     "best max-flow: {}, balance: {:.3}",
                     result.flow, result.balance
@@ -110,47 +132,59 @@ fn main() {
 
                 debug!("partitioning and assigning ids for all nodes");
 
-                (result.left_ids).iter().for_each(|id| unsafe {
-                    partition_ids.get_mut(*id).make_left_child();
+                (result.left_ids).iter().for_each(|i| {
+                    let mut id = load(*i);
+                    id.make_left_child();
+                    store(*i, id);
                 });
-                (result.right_ids).iter().for_each(|id| unsafe {
-                    partition_ids.get_mut(*id).make_right_child();
+                (result.right_ids).iter().for_each(|i| {
+                    let mut id = load(*i);
+                    id.make_right_child();
+                    store(*i, id);
                 });
 
-                // partition edge and node id sets for the next iteration
+                // Partition edge and node id sets for the next iteration. The
+                // edge set of the parent is consumed here, so that it is freed
+                // right away instead of at the end of the level. Edges of the
+                // cut are dropped: their head is outside of the cell they would
+                // end up in, where they only inflate the flow graph by a node
+                // that no flow can pass through.
                 debug!("generating next level edges");
-                // TODO: don't copy, but partition in place
-                let (left_edges, right_edges): (Vec<_>, Vec<_>) = job
-                    .0
-                    .iter()
-                    .partition(|edge| partition_ids.get(edge.source).is_left_child());
+                let mut left_edges = Vec::new();
+                let mut right_edges = Vec::new();
+                for edge in std::mem::take(&mut job.0) {
+                    let tail_is_left = load(edge.source).is_left_child();
+                    if tail_is_left != load(edge.target).is_left_child() {
+                        continue;
+                    }
+                    if tail_is_left {
+                        left_edges.push(edge);
+                    } else {
+                        right_edges.push(edge);
+                    }
+                }
                 debug!("generating next level ids");
 
                 // iterate on left half if larger than the minimum cell size
                 let mut next_jobs = Vec::new();
+                let level_difference = (args.recursion_depth - current_level - 1) as usize;
                 if result.left_ids.len() > args.minimum_cell_size {
                     next_jobs.push((left_edges, result.left_ids));
                 } else {
-                    let level_difference = (args.recursion_depth - current_level - 1) as usize;
                     for i in &result.left_ids {
-                        unsafe {
-                            partition_ids
-                                .get_mut(*i)
-                                .make_leftmost_descendant(level_difference);
-                        }
+                        let mut id = load(*i);
+                        id.make_leftmost_descendant(level_difference);
+                        store(*i, id);
                     }
                 }
                 // iterate on right half if larger than the minimum cell size
                 if result.right_ids.len() > args.minimum_cell_size {
                     next_jobs.push((right_edges, result.right_ids));
                 } else {
-                    let level_difference = (args.recursion_depth - current_level - 1) as usize;
                     for i in &result.right_ids {
-                        unsafe {
-                            partition_ids
-                                .get_mut(*i)
-                                .make_rightmost_descendant(level_difference);
-                        }
+                        let mut id = load(*i);
+                        id.make_rightmost_descendant(level_difference);
+                        store(*i, id);
                     }
                 }
                 next_jobs
@@ -161,10 +195,14 @@ fn main() {
         current_job_queue = next_job_queue;
     }
 
-    write_results(&args, &partition_ids_vec, &coordinates, &edges);
-
+    let partition_ids_vec = partition_ids
+        .iter()
+        .map(|id| PartitionID(id.load(Ordering::Relaxed)))
+        .collect_vec();
     for id in &partition_ids_vec {
         debug_assert_eq!(id.level(), args.recursion_depth);
     }
+
+    write_results(&args, &partition_ids_vec, &coordinates, &input_edges);
     info!("done.");
 }

--- a/src/dinic.rs
+++ b/src/dinic.rs
@@ -8,12 +8,12 @@
 //! saturated edge that is closest to the source.
 use crate::{
     edge::InputEdge,
-    graph::{Graph, NodeID},
-    max_flow::{MaxFlow, ResidualEdgeData},
+    graph::{EdgeArrayEntry, EdgeID, Graph, NodeID},
+    max_flow::{MaxFlow, ResidualArcData, ResidualEdgeData},
     static_graph::StaticGraph,
 };
 use bitvec::vec::BitVec;
-use core::cmp::min;
+use core::cmp::{max, min};
 use log::debug;
 use std::{
     collections::VecDeque,
@@ -21,15 +21,16 @@ use std::{
         Arc,
         atomic::{AtomicI32, Ordering},
     },
-    time::Instant,
 };
 
 pub struct Dinic {
-    residual_graph: StaticGraph<ResidualEdgeData>,
+    residual_graph: StaticGraph<ResidualArcData>,
     max_flow: i32,
     finished: bool,
     level: Vec<usize>,
     parents: Vec<NodeID>,
+    /// arc on which the DFS entered a node, i.e. the arc (parents[v], v)
+    parent_edge: Vec<u32>,
     stack: Vec<(NodeID, i32)>,
     dfs_count: usize,
     bfs_count: usize,
@@ -41,7 +42,6 @@ pub struct Dinic {
 
 impl Dinic {
     fn bfs(&mut self) -> bool {
-        let start = Instant::now();
         self.bfs_count += 1;
         // init
         self.level.fill(usize::MAX);
@@ -49,9 +49,6 @@ impl Dinic {
 
         self.queue.clear();
         self.queue.push_back(self.target);
-
-        let duration = start.elapsed();
-        debug!("BFS init: {duration:?}");
 
         // label residual graph nodes in BFS order, but in reverse starting from the target
         while let Some(u) = self.queue.pop_front() {
@@ -63,8 +60,7 @@ impl Dinic {
                 }
 
                 // check capacity of reverse edge
-                let rev_edge = self.residual_graph.find_edge_unchecked(v, u);
-                let edge_capacity = self.residual_graph.data(rev_edge).capacity;
+                let edge_capacity = self.residual_graph.data(edge).reverse_capacity;
                 if edge_capacity < 1 {
                     // no capacity to use on this edge
                     continue;
@@ -75,16 +71,14 @@ impl Dinic {
                 }
             }
         }
-        let duration = start.elapsed();
         debug!(
-            "BFS took: {:?}, upper bound on path length: {}",
-            duration, self.level[self.source]
+            "BFS took {} runs, upper bound on path length: {}",
+            self.bfs_count, self.level[self.source]
         );
         self.level[self.source] != usize::MAX
     }
 
     fn dfs(&mut self) -> i32 {
-        let start = Instant::now();
         self.dfs_count += 1;
         self.stack.clear();
         self.stack.push((self.source, i32::MAX));
@@ -92,8 +86,6 @@ impl Dinic {
         self.parents.fill(NodeID::MAX);
         self.parents[self.source] = self.source;
 
-        let duration = start.elapsed();
-        debug!(" DFS init: {duration:?}");
         let mut blocking_flow = 0;
         while let Some((u, flow)) = self.stack.pop() {
             for edge in self.residual_graph.edge_range(u) {
@@ -112,10 +104,9 @@ impl Dinic {
                     continue;
                 }
                 self.parents[v] = u;
+                self.parent_edge[v] = edge as u32;
                 let flow = min(flow, available_capacity);
                 if v == self.target {
-                    let duration = start.elapsed();
-                    debug!(" reached target {v}: {duration:?}");
                     // reached a target. Unpack path in reverse order, assign flow
                     let mut v = v; // mutable shadow
                     let mut closest_tail = u;
@@ -124,17 +115,23 @@ impl Dinic {
                         if u == v {
                             break;
                         }
-                        let fwd_edge = self.residual_graph.find_edge_unchecked(u, v);
-                        self.residual_graph.data_mut(fwd_edge).capacity -= flow;
-                        if 0 == self.residual_graph.data_mut(fwd_edge).capacity {
+                        let fwd_edge = self.parent_edge[v] as EdgeID;
+                        let residual = self.residual_graph.data_mut(fwd_edge);
+                        residual.capacity -= flow;
+                        residual.reverse_capacity += flow;
+                        if 0 == residual.capacity {
                             closest_tail = u;
                         }
-                        let rev_edge = self.residual_graph.find_edge_unchecked(v, u);
-                        self.residual_graph.data_mut(rev_edge).capacity += flow;
+                        // keep the cached capacities of the arc pair in sync
+                        let rev_edge = self
+                            .residual_graph
+                            .find_edge_sorted(v, u)
+                            .expect("residual graph is not symmetric");
+                        let residual = self.residual_graph.data_mut(rev_edge);
+                        residual.capacity += flow;
+                        residual.reverse_capacity -= flow;
                         v = u;
                     }
-                    let duration = start.elapsed();
-                    debug!(" augmentation took: {duration:?}");
 
                     // unwind stack till tail node, then continue the search
                     let before = self.stack.len();
@@ -157,62 +154,111 @@ impl Dinic {
             }
         }
 
-        let duration = start.elapsed();
-        debug!("DFS took: {duration:?} (unsuccessful)");
         blocking_flow
     }
 }
 
 impl MaxFlow for Dinic {
     fn from_edge_list(
-        mut edge_list: Vec<InputEdge<ResidualEdgeData>>,
+        edge_list: Vec<InputEdge<ResidualEdgeData>>,
         source: usize,
         target: usize,
     ) -> Self {
         debug_assert!(!edge_list.is_empty());
-        let number_of_edges = edge_list.len();
 
-        debug!("extending {} edges", edge_list.len());
-        // blindly generate reverse edges for all edges with zero capacity
-        edge_list.extend_from_within(..);
-        debug!("into {} edges", edge_list.len());
+        // The residual graph holds a reverse arc of zero capacity for each input
+        // arc. Instead of materializing those and then sorting 2|E| entries, the
+        // adjacency array is built directly by a counting sort in O(V + E).
+        let number_of_nodes = 1 + edge_list
+            .iter()
+            .map(|edge| max(edge.source, edge.target))
+            .max()
+            .expect("edge list is empty");
+        debug!("counting degrees of {number_of_nodes} nodes");
 
-        edge_list.iter_mut().skip(number_of_edges).for_each(|edge| {
-            edge.reverse();
-            edge.data.capacity = 0;
-        });
-        debug!("sorting after reversing");
+        // count the residual degree of each node in node_array[node + 1], then
+        // turn the counts into the offsets of the adjacency blocks
+        let mut node_array = vec![0_usize; number_of_nodes + 1];
+        for edge in &edge_list {
+            node_array[edge.source + 1] += 1;
+            node_array[edge.target + 1] += 1;
+        }
+        for i in 1..node_array.len() {
+            node_array[i] += node_array[i - 1];
+        }
 
-        // dedup-merge edge set, by using the following trick: not the dedup(.) call
-        // below takes the second argument as mut. When deduping equivalent values
-        // a and b, then a is accumulated onto b.
-        edge_list.sort_unstable_by(|a, b| {
-            if a.source == b.source {
-                return a.target.cmp(&b.target);
+        debug!("scattering {} arcs", 2 * edge_list.len());
+        // Scatter the arcs into their blocks. node_array[u] serves as the write
+        // cursor of node u and thus ends up pointing at the end of u's block.
+        // Each input arc contributes its capacity to the forward arc and to the
+        // cached reverse capacity of the reverse arc, which is why the cache
+        // comes for free.
+        let mut edge_array = vec![
+            EdgeArrayEntry {
+                target: 0,
+                data: ResidualArcData::default()
+            };
+            2 * edge_list.len()
+        ];
+        for edge in &edge_list {
+            let forward = node_array[edge.source];
+            node_array[edge.source] += 1;
+            edge_array[forward] = EdgeArrayEntry {
+                target: edge.target,
+                data: ResidualArcData {
+                    capacity: edge.data.capacity,
+                    reverse_capacity: 0,
+                },
+            };
+
+            let reverse = node_array[edge.target];
+            node_array[edge.target] += 1;
+            edge_array[reverse] = EdgeArrayEntry {
+                target: edge.source,
+                data: ResidualArcData {
+                    capacity: 0,
+                    reverse_capacity: edge.data.capacity,
+                },
+            };
+        }
+        drop(edge_list);
+
+        // each cursor now points at the end of its block, which is the begin of
+        // the next one. Shifting by one restores the adjacency array.
+        node_array.rotate_right(1);
+        node_array[0] = 0;
+
+        debug!("merging parallel arcs");
+        // sort each adjacency block by target and merge parallel arcs into a
+        // single one that carries the accumulated capacity. Note that this is
+        // fine, as we are looking to compute a node partition. Blocks are short,
+        // hence sorting them is cheap.
+        let mut write = 0;
+        let mut begin = 0;
+        for node in 0..number_of_nodes {
+            let end = node_array[node + 1];
+            edge_array[begin..end].sort_unstable_by_key(|entry| entry.target);
+
+            let block_begin = write;
+            for read in begin..end {
+                if write > block_begin && edge_array[write - 1].target == edge_array[read].target {
+                    edge_array[write - 1].data.capacity += edge_array[read].data.capacity;
+                    edge_array[write - 1].data.reverse_capacity +=
+                        edge_array[read].data.reverse_capacity;
+                } else {
+                    edge_array[write] = edge_array[read];
+                    write += 1;
+                }
             }
-            a.source.cmp(&b.source)
-        });
-        debug!("start dedup");
-        edge_list.dedup_by(|a, b| {
-            // edges a and b are assumed to be equivalent in the residual graph if
-            // (and only if) they are parallel. In other words, this removes parallel
-            // edges in the residual graph and accumulates capacities on the remaining
-            // egde.
-            let edges_are_parallel = a.is_parallel_to(b);
-            if edges_are_parallel {
-                b.data.capacity += a.data.capacity;
-            }
-            edges_are_parallel
-        });
-        edge_list.shrink_to_fit();
-        debug!("dedup done");
+            begin = end;
+            node_array[node + 1] = write;
+        }
+        edge_array.truncate(write);
+        edge_array.shrink_to_fit();
+        debug!("residual graph has {write} arcs");
 
-        // at this point the edge set of the residual graph doesn't have any
-        // duplicates anymore. Note that this is fine, as we are looking to
-        // compute a node partition.
-
-        let residual_graph = StaticGraph::new_from_sorted_list(edge_list);
-        let number_of_nodes = residual_graph.number_of_nodes();
+        debug_assert!(write <= u32::MAX as usize, "arc ids have to fit into u32");
+        let residual_graph = StaticGraph::from_adjacency_array(node_array, edge_array);
 
         Self {
             residual_graph,
@@ -220,6 +266,7 @@ impl MaxFlow for Dinic {
             finished: false,
             level: Vec::with_capacity(number_of_nodes),
             parents: Vec::with_capacity(number_of_nodes),
+            parent_edge: Vec::with_capacity(number_of_nodes),
             stack: Vec::with_capacity(number_of_nodes),
             dfs_count: 0,
             bfs_count: 0,
@@ -246,8 +293,8 @@ impl MaxFlow for Dinic {
 
         let number_of_nodes = self.residual_graph.number_of_nodes();
         self.parents.resize(number_of_nodes, 0);
+        self.parent_edge.resize(number_of_nodes, 0);
         self.level.resize(number_of_nodes, usize::MAX);
-        self.queue.reserve(number_of_nodes);
 
         let mut flow = 0;
         while self.bfs() {

--- a/src/dinic.rs
+++ b/src/dinic.rs
@@ -72,7 +72,7 @@ impl Dinic {
             }
         }
         debug!(
-            "BFS took {} runs, upper bound on path length: {}",
+            "BFS run {}, upper bound on path length: {}",
             self.bfs_count, self.level[self.source]
         );
         self.level[self.source] != usize::MAX
@@ -257,7 +257,9 @@ impl MaxFlow for Dinic {
         edge_array.shrink_to_fit();
         debug!("residual graph has {write} arcs");
 
-        debug_assert!(write <= u32::MAX as usize, "arc ids have to fit into u32");
+        // the DFS stores arc ids in parent_edge as u32, so a larger graph would
+        // silently index the wrong arc
+        assert!(write <= u32::MAX as usize, "arc ids have to fit into u32");
         let residual_graph = StaticGraph::from_adjacency_array(node_array, edge_array);
 
         Self {

--- a/src/inertial_flow.rs
+++ b/src/inertial_flow.rs
@@ -26,6 +26,8 @@ pub enum FlowError {
     AxisOutOfBounds,
     /// the cell does not induce any edge, thus it cannot be cut
     EmptyGraph,
+    /// the graph has more nodes than the node ids of a cell can address
+    GraphTooLarge,
     String(String),
 }
 
@@ -77,6 +79,12 @@ pub fn sub_step(
         // solver from being handed an empty graph.
         return Err(FlowError::EmptyGraph);
     }
+    if coordinates.len() > u32::MAX as usize {
+        // Node ids are narrowed to u32 while sorting the nodes of the cell.
+        // Every id addresses a coordinate, so checking the coordinates covers
+        // all of them at once.
+        return Err(FlowError::GraphTooLarge);
+    }
 
     let comparator = ROTATED_COMPARATORS[axis];
     debug!("[{axis}] sorting cooefficient: {comparator:?}");
@@ -88,6 +96,7 @@ pub fn sub_step(
         .iter()
         .map(|id| {
             let projection = comparator(coordinates[*id].lat, coordinates[*id].lon);
+            // the check on the number of coordinates above rules this out
             let id: u32 = (*id).try_into().expect("node id does not fit into u32");
             (projection, id)
         })

--- a/src/inertial_flow.rs
+++ b/src/inertial_flow.rs
@@ -24,6 +24,8 @@ const ROTATED_COMPARATORS: [fn(i32, i32) -> i32; 4] = [
 #[derive(Debug)]
 pub enum FlowError {
     AxisOutOfBounds,
+    /// the cell does not induce any edge, thus it cannot be cut
+    EmptyGraph,
     String(String),
 }
 
@@ -70,13 +72,27 @@ pub fn sub_step(
     if axis >= 4 {
         return Err(FlowError::AxisOutOfBounds);
     }
+    if input_edges.is_empty() {
+        // a cell without edges has no cut. Bailing out here keeps the max-flow
+        // solver from being handed an empty graph.
+        return Err(FlowError::EmptyGraph);
+    }
 
     let comparator = ROTATED_COMPARATORS[axis];
     debug!("[{axis}] sorting cooefficient: {comparator:?}");
-    // the iteration proxy list to be sorted. The coordinates vector itself is not touched.
-    let mut node_id_list = node_id_list.to_vec();
-    node_id_list
-        .sort_unstable_by_key(|a| -> i32 { comparator(coordinates[*a].lat, coordinates[*a].lon) });
+    // The iteration proxy list to be sorted. The coordinates vector itself is
+    // not touched. Sorting the ids by a key that is looked up in the coordinate
+    // list costs a cache miss on every comparison, thus the ids are decorated
+    // with their projection and the pairs are sorted instead.
+    let mut node_id_list = node_id_list
+        .iter()
+        .map(|id| {
+            let projection = comparator(coordinates[*id].lat, coordinates[*id].lon);
+            let id: u32 = (*id).try_into().expect("node id does not fit into u32");
+            (projection, id)
+        })
+        .collect_vec();
+    node_id_list.sort_unstable();
 
     let size_of_contraction = max(1, (node_id_list.len() as f64 * balance_factor) as usize);
     let sources = &node_id_list[0..size_of_contraction];
@@ -92,11 +108,11 @@ pub fn sub_step(
     // nodes in the in the graph have to be numbered consecutively.
     // the mapping is input id -> dinic id
 
-    for s in sources {
-        renumbering_table.set(*s, 0);
+    for (_projection, s) in sources {
+        renumbering_table.set(*s as usize, 0);
     }
-    for t in targets {
-        renumbering_table.set(*t, 1);
+    for (_projection, t) in targets {
+        renumbering_table.set(*t as usize, 1);
     }
 
     // each thread holds their own copy of the edge set
@@ -155,10 +171,32 @@ pub fn sub_step(
         .expect("max flow computation did not run");
 
     // TODO: don't copy, but partition in place
-    let (left_ids, right_ids): (Vec<_>, Vec<_>) = node_id_list
-        .into_iter()
-        .filter(|id| renumbering_table.contains_key(*id))
-        .partition(|id| intermediate_assignment[renumbering_table.get(*id)]);
+    let mut left_ids = Vec::new();
+    let mut right_ids = Vec::new();
+    // nodes that no edge of the cell is incident to are not part of the flow
+    // graph and thus have no assignment
+    let mut isolated_ids = Vec::new();
+    for (_projection, id) in node_id_list {
+        let id = id as usize;
+        if !renumbering_table.contains_key(id) {
+            isolated_ids.push(id);
+        } else if intermediate_assignment[renumbering_table.get(id)] {
+            left_ids.push(id);
+        } else {
+            right_ids.push(id);
+        }
+    }
+    // Isolated nodes are cut off either way, so they join the smaller side.
+    // Dropping them here would take them out of the recursion and leave them
+    // behind on a level of their own.
+    if !isolated_ids.is_empty() {
+        debug!("[{axis}] {} isolated nodes in cell", isolated_ids.len());
+        if left_ids.len() <= right_ids.len() {
+            left_ids.append(&mut isolated_ids);
+        } else {
+            right_ids.append(&mut isolated_ids);
+        }
+    }
 
     debug_assert!(!left_ids.is_empty());
     debug_assert!(!right_ids.is_empty());
@@ -265,6 +303,43 @@ mod tests {
         assert_eq!(result.left_ids, vec![4, 5, 3]);
         assert_eq!(result.right_ids.len(), 3);
         assert_eq!(result.right_ids, vec![2, 0, 1]);
+    }
+
+    #[test]
+    fn isolated_nodes_stay_in_the_recursion() {
+        // node 6 carries a coordinate, but no edge is incident to it
+        static COORDINATES_WITH_ISOLATED: [FPCoordinate; 7] = [
+            FPCoordinate::new(1, 0),
+            FPCoordinate::new(2, 1),
+            FPCoordinate::new(0, 1),
+            FPCoordinate::new(2, 2),
+            FPCoordinate::new(0, 2),
+            FPCoordinate::new(1, 3),
+            FPCoordinate::new(3, 3),
+        ];
+        static NODE_ID_LIST_WITH_ISOLATED: [usize; 7] = [0, 1, 2, 3, 4, 5, 6];
+
+        let upper_bound = Arc::new(AtomicI32::new(7));
+        let result = sub_step(
+            &EDGES,
+            &NODE_ID_LIST_WITH_ISOLATED,
+            &COORDINATES_WITH_ISOLATED,
+            3,
+            0.25,
+            upper_bound,
+        )
+        .expect("error should not happen");
+
+        // no node may be dropped, or it would be left behind on its level
+        assert_eq!(result.left_ids.len() + result.right_ids.len(), 7);
+        assert!(result.left_ids.contains(&6) || result.right_ids.contains(&6));
+    }
+
+    #[test]
+    fn cell_without_edges_is_reported() {
+        let upper_bound = Arc::new(AtomicI32::new(6));
+        let result = sub_step(&[], &NODE_ID_LIST, &COORDINATES, 0, 0.25, upper_bound);
+        assert!(matches!(result, Err(super::FlowError::EmptyGraph)));
     }
 
     #[test]

--- a/src/max_flow.rs
+++ b/src/max_flow.rs
@@ -18,6 +18,16 @@ impl ResidualEdgeData {
     }
 }
 
+/// An arc of a residual graph that caches the capacity of its reverse arc. The
+/// BFS of a max-flow computation checks the reverse capacity of every arc it
+/// relaxes and looking that arc up dominated its run time. Note that caching is
+/// free of charge, as the padding of the adjacency array entry is used up.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ResidualArcData {
+    pub capacity: i32,
+    pub reverse_capacity: i32,
+}
+
 pub trait MaxFlow {
     fn run(&mut self);
     fn run_with_upper_bound(&mut self, bound: Arc<AtomicI32>);

--- a/src/renumbering_table.rs
+++ b/src/renumbering_table.rs
@@ -17,7 +17,10 @@ impl RenumberingTable {
         if factor > 8 {
             // the table will filled with at most 12.5% of the number of elements
             return Self {
-                table: Implementation::Map(FxHashMap::default()),
+                table: Implementation::Map(FxHashMap::with_capacity_and_hasher(
+                    usage_bound,
+                    Default::default(),
+                )),
             };
         }
 

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -42,9 +42,15 @@ impl<T: Ord + Copy> StaticGraph<T> {
                 .windows(2)
                 .all(|pair| pair[0].first_edge <= pair[1].first_edge)
             && self.node_range().all(|node| {
-                self.edge_array[self.edge_range(node)]
-                    .windows(2)
-                    .all(|pair| pair[0].target <= pair[1].target)
+                // an offset that points past the edge array is a failed check
+                // and not a reason to panic
+                self.edge_array
+                    .get(self.edge_range(node))
+                    .is_some_and(|block| {
+                        block
+                            .windows(2)
+                            .all(|pair| pair[0].target <= pair[1].target)
+                    })
             })
     }
 
@@ -223,6 +229,22 @@ mod tests {
         let graph = Graph::new(edges);
         assert_eq!(6, graph.number_of_nodes());
         assert_eq!(8, graph.number_of_edges());
+    }
+
+    #[test]
+    fn integrity_check_reports_broken_offsets() {
+        use crate::graph::EdgeArrayEntry;
+        use crate::static_graph::NodeArrayEntry;
+
+        // a single node whose block claims five arcs while there are only two
+        let graph = StaticGraph::<i32> {
+            node_array: vec![NodeArrayEntry::new(0), NodeArrayEntry::new(5)],
+            edge_array: vec![
+                EdgeArrayEntry { target: 0, data: 1 },
+                EdgeArrayEntry { target: 0, data: 1 },
+            ],
+        };
+        assert!(!graph.check_integrity());
     }
 
     #[test]

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -30,7 +30,8 @@ impl<T: Ord + Clone> Default for StaticGraph<T> {
 impl<T: Ord + Copy> StaticGraph<T> {
     // In time O(V+E) check that the following invariants hold:
     // a) the target node of each edge is smaller than the number of nodes
-    // b) index values for nodes first_edges are strictly increasing
+    // b) index values for nodes first_edges are non-decreasing, as a node
+    //    without any outgoing edge shares its offset with the next node
     // c) the targets within each adjacency block are sorted ascendingly
     pub fn check_integrity(&self) -> bool {
         self.edge_array

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -31,6 +31,7 @@ impl<T: Ord + Copy> StaticGraph<T> {
     // In time O(V+E) check that the following invariants hold:
     // a) the target node of each edge is smaller than the number of nodes
     // b) index values for nodes first_edges are strictly increasing
+    // c) the targets within each adjacency block are sorted ascendingly
     pub fn check_integrity(&self) -> bool {
         self.edge_array
             .iter()
@@ -39,6 +40,25 @@ impl<T: Ord + Copy> StaticGraph<T> {
                 .node_array
                 .windows(2)
                 .all(|pair| pair[0].first_edge <= pair[1].first_edge)
+            && self.node_range().all(|node| {
+                self.edge_array[self.edge_range(node)]
+                    .windows(2)
+                    .all(|pair| pair[0].target <= pair[1].target)
+            })
+    }
+
+    /// Finds the edge (s,t) by a binary search over the adjacency block of s.
+    /// This requires the targets within a block to be sorted, which holds for
+    /// all of this type's constructors.
+    pub fn find_edge_sorted(&self, s: NodeID, t: NodeID) -> Option<EdgeID> {
+        if s >= self.number_of_nodes() {
+            return None;
+        }
+        let range = self.edge_range(s);
+        self.edge_array[range.clone()]
+            .binary_search_by_key(&t, |entry| entry.target)
+            .ok()
+            .map(|offset| range.start + offset)
     }
 
     pub fn new(mut input: Vec<impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord>) -> Self {
@@ -47,6 +67,24 @@ impl<T: Ord + Copy> StaticGraph<T> {
         input.sort();
 
         Self::new_from_sorted_list(input)
+    }
+
+    /// Assembles a graph from a prebuilt adjacency array. The caller has to
+    /// guarantee that `node_array` is non-decreasing, starts at zero, ends at
+    /// `edge_array.len()` and that the targets within each adjacency block are
+    /// sorted ascendingly.
+    pub fn from_adjacency_array(
+        node_array: Vec<EdgeID>,
+        edge_array: Vec<EdgeArrayEntry<T>>,
+    ) -> Self {
+        let graph = Self {
+            // the layouts of EdgeID and NodeArrayEntry match, thus the
+            // allocation is reused instead of copied
+            node_array: node_array.into_iter().map(NodeArrayEntry::new).collect(),
+            edge_array,
+        };
+        debug_assert!(graph.check_integrity());
+        graph
     }
 
     pub fn new_from_sorted_list(

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -29,14 +29,24 @@ impl<T: Ord + Clone> Default for StaticGraph<T> {
 
 impl<T: Ord + Copy> StaticGraph<T> {
     // In time O(V+E) check that the following invariants hold:
-    // a) the target node of each edge is smaller than the number of nodes
-    // b) index values for nodes first_edges are non-decreasing, as a node
+    // a) the node array spans the edge array, from zero up to its length. An
+    //    empty node array fails here, as it lacks even the sentinel.
+    // b) the target node of each edge is smaller than the number of nodes
+    // c) index values for nodes first_edges are non-decreasing, as a node
     //    without any outgoing edge shares its offset with the next node
-    // c) the targets within each adjacency block are sorted ascendingly
+    // d) the targets within each adjacency block are sorted ascendingly
     pub fn check_integrity(&self) -> bool {
-        self.edge_array
-            .iter()
-            .all(|edge_entry| (edge_entry.target) < self.number_of_nodes())
+        self.node_array
+            .first()
+            .is_some_and(|entry| entry.first_edge == 0)
+            && self
+                .node_array
+                .last()
+                .is_some_and(|entry| entry.first_edge == self.edge_array.len())
+            && self
+                .edge_array
+                .iter()
+                .all(|edge_entry| (edge_entry.target) < self.number_of_nodes())
             && self
                 .node_array
                 .windows(2)
@@ -245,6 +255,9 @@ mod tests {
             ],
         };
         assert!(!graph.check_integrity());
+
+        // a default constructed graph has no sentinel at all
+        assert!(!StaticGraph::<i32>::default().check_integrity());
     }
 
     #[test]

--- a/src/unsafe_slice.rs
+++ b/src/unsafe_slice.rs
@@ -32,10 +32,11 @@ impl<'a, T> UnsafeSlice<'a, T> {
 
     /// Returns a shared reference to the element at the given index.
     ///
-    /// This function is safe to call because it returns an immutable reference,
-    /// which can be shared between multiple threads. However, it's important to note
-    /// that this safety relies on the exclusive access guarantee provided by the
-    /// mutable reference passed to `UnsafeSlice::new()`.
+    /// # Safety
+    /// This type is `Sync`, so a shared reference handed out here can be alive
+    /// while another thread writes the very same index through `get_mut`. That
+    /// is a data race, which is why this is not a safe function. The caller has
+    /// to guarantee that no thread writes the index while the reference lives.
     ///
     /// # Arguments
     ///
@@ -55,10 +56,13 @@ impl<'a, T> UnsafeSlice<'a, T> {
     /// # use toolbox_rs::unsafe_slice::UnsafeSlice;
     /// let mut data = vec![1, 2, 3];
     /// let slice = UnsafeSlice::new(&mut data);
-    /// assert_eq!(*slice.get(0), 1);
+    /// // SAFETY: no other thread accesses the slice
+    /// assert_eq!(unsafe { *slice.get(0) }, 1);
     /// ```
-    pub fn get(&self, index: usize) -> &T {
-        unsafe { &mut *self.slice[index].get() }
+    pub unsafe fn get(&self, index: usize) -> &T {
+        // note that going through a &mut here would be a second aliasing
+        // violation on top of the concurrent one
+        unsafe { &*self.slice[index].get() }
     }
 }
 
@@ -70,14 +74,14 @@ mod tests {
     fn instantiate() {
         let mut data = vec![0, 1, 23, 83, 38, 3, 8947, 2762];
         let slice = UnsafeSlice::new(&mut data);
-        assert_eq!(*slice.get(0), 0);
-        assert_eq!(*slice.get(1), 1);
-        assert_eq!(*slice.get(2), 23);
-        assert_eq!(*slice.get(3), 83);
-        assert_eq!(*slice.get(4), 38);
-        assert_eq!(*slice.get(5), 3);
-        assert_eq!(*slice.get(6), 8947);
-        assert_eq!(*slice.get(7), 2762);
+        assert_eq!(unsafe { *slice.get(0) }, 0);
+        assert_eq!(unsafe { *slice.get(1) }, 1);
+        assert_eq!(unsafe { *slice.get(2) }, 23);
+        assert_eq!(unsafe { *slice.get(3) }, 83);
+        assert_eq!(unsafe { *slice.get(4) }, 38);
+        assert_eq!(unsafe { *slice.get(5) }, 3);
+        assert_eq!(unsafe { *slice.get(6) }, 8947);
+        assert_eq!(unsafe { *slice.get(7) }, 2762);
     }
 
     #[test]
@@ -92,10 +96,10 @@ mod tests {
             *slice.get_mut(2) = 30;
         }
 
-        assert_eq!(*slice.get(0), 10);
-        assert_eq!(*slice.get(1), 2);
-        assert_eq!(*slice.get(2), 30);
-        assert_eq!(*slice.get(3), 4);
+        assert_eq!(unsafe { *slice.get(0) }, 10);
+        assert_eq!(unsafe { *slice.get(1) }, 2);
+        assert_eq!(unsafe { *slice.get(2) }, 30);
+        assert_eq!(unsafe { *slice.get(3) }, 4);
 
         // Verify we can read the modified values
         assert_eq!(data[0], 10);


### PR DESCRIPTION
## Summary

The recursive bisection in chipper got faster and lost all of its unsafe code. The partition it produces is also a little better than before.

Every change in this PR was measured on the USA road network, and the result was confirmed on the Europe PTV instance. Three ideas were tried, measured and dropped again. They are listed at the end.

## Measurements

Two instances, both preprocessed with `graph_plier`, both partitioned with the command from the README, `-r30 -m100`. Same machine with 8 cores.

| instance | format | nodes | arcs |
| --- | --- | --- | --- |
| USA-road-t.USA | DIMACS | 23,947,347 | 58,333,344 |
| europe.ptv.time | DDSG | 18,010,173 | 42,188,664 |

| metric | USA before | USA after | change | Europe before | Europe after | change |
| --- | --- | --- | --- | --- | --- | --- |
| wall clock | 332.1 s | 226.7 s | 31.7 percent less | 274.7 s | 186.6 s | 32.1 percent less |
| CPU time | 1892.2 s | 1171.3 s | 38.1 percent less | 1572.0 s | 1028.2 s | 34.6 percent less |
| instructions retired | 6,441.8 G | 3,009.7 G | 53.3 percent less | 4,827.5 G | 2,322.0 G | 51.9 percent less |
| peak memory | 10.26 GB | 11.02 GB | 7.4 percent more | 7.37 GB | 7.05 GB | 4.3 percent less |
| unsafe blocks in the partitioner | 4 | 0 | | 4 | 0 | |

The instruction counts are the number to trust. They vary by less than one percent between repeated runs, while wall clock varied by up to 26 percent. The USA figures come from one pair of runs done back to back. The Europe figures are the best of two runs per variant, interleaved, and both after runs beat both before runs.

Quality of the partition:

| metric | USA before | USA after | Europe before | Europe after |
| --- | --- | --- | --- | --- |
| cut edges | 2,667,702 | 2,667,614 | 1,959,596 | 1,959,521 |
| cells | 365,299 | 365,279 | 273,521 | 273,509 |
| cell size, min / median / max | 25 / 66 / 100 | 25 / 66 / 100 | 25 / 66 / 100 | 25 / 66 / 100 |

The cut gets slightly smaller on both instances, by 88 edges on USA and by 75 edges on Europe. Every node ends up on level 30 in all four runs, so neither instance contains an isolated node.

Peak memory is a wash. It is 7 percent up on USA and 4 percent down on Europe, and the same baseline binary was measured between 9.2 GB and 10.3 GB on USA over three runs, an 11 percent spread, so neither direction is outside the noise.

An earlier version of this description explained the opposite directions by claiming that the DDSG file lists each arc once while the DIMACS file lists both. That is wrong. Both files list both directions, the DDSG one as two separate lines carrying a forward only flag, so the deduplication has the same work to do on either input.

## The changes

| change | measured effect | output |
| --- | --- | --- |
| build the residual graph in O(V + E) | 37.9 percent fewer instructions | bit identical |
| cache the reverse capacity in each arc | 9.5 percent fewer instructions, 13 percent less CPU time | bit identical |
| sort node ids by a decorated key | 16 percent fewer instructions | 52 fewer cut edges |
| replace UnsafeSlice by relaxed atomics | none, 0.03 percent which is noise | bit identical |
| drop the edges of the cut when descending | 2.0 percent fewer instructions, 0.44 GB less memory | 36 fewer cut edges |

### Build the residual graph in O(V + E)

`Dinic::from_edge_list` duplicated the whole edge list to create the reverse arcs, then sorted 2|E| entries by source and target, then removed the duplicates again. A profile showed that this sort alone was about 24 percent of the total run time.

The adjacency array is now built directly by a counting sort. The degrees are counted, the counts are turned into block offsets, and the arcs are scattered into their blocks. Only the blocks themselves get sorted, and they are short.

### Cache the capacity of the reverse arc inside each arc

After the change above, `Dinic::bfs` was the most expensive function at 26.9 percent of the run time. Most of that was `find_edge_unchecked`, which the BFS called for every arc it relaxed just to read the capacity of the reverse arc. That call is a linear scan through the adjacency block of the head.

Each arc now carries the capacity of its reverse arc, so the BFS needs no lookup at all. The cache is free in both directions. It is filled while the arcs are scattered into their blocks, and the adjacency array entry had padding to spare, so the entry is still 16 bytes.

The DFS keeps the two arcs of a pair in sync when it pushes flow. It looks the partner arc up by a binary search, which is possible because the targets inside a block are sorted. That is much rarer than a BFS relaxation.

### Sort the node ids by a decorated key

`sub_step` sorted the node ids with `sort_unstable_by_key`, and the key read the coordinate of the node. That is a cache miss on every comparison. The ids are now decorated with their projection once and the pairs are sorted.

This changes how ties are broken, so the resulting partition is not identical. It has 52 fewer cut edges.

### Replace UnsafeSlice by relaxed atomics

The partition ids were written through `UnsafeSlice`, which hands out `&mut` from a shared reference. Cells are disjoint, so each entry really is written by at most one thread per level. Relaxed atomics say exactly that without an aliasing hazard, and they compile to plain loads and stores. The measured cost was 0.03 percent, which is noise.

`UnsafeSlice` now has no user left in the crate. It is kept, because it is public, but its `get` is now `unsafe`. It was a safe method on a `Sync` type, so two threads could call `get(i)` and `get_mut(i)` on the same index without writing `unsafe` anywhere. It also built a `&mut` only to hand out a `&T`.

### Drop the edges of the cut when descending

Edges were split by their tail only, so an edge from the left half to the right half stayed with the left half. At the next level its head was renumbered into the flow graph as an extra node. Such a node is a dead end, because its only outgoing arc has zero capacity, so it never carried flow. It only made the graph bigger.

Both endpoints are now checked and the edges of the cut are dropped.

## Correctness fixes

These are covered by new unit tests. The USA road network triggers none of them, so the tests are the only evidence.

| problem | what happened before |
| --- | --- |
| a node that no edge of its cell is incident to | it was dropped from both halves, never descended again and kept an id from a higher level |
| a cell that no axis could cut | same problem, its nodes stayed on the level they were on |
| a cell without any edge | the max-flow solver was handed an empty graph and panicked on an out of bounds index |

The first one is reachable with any input that has an isolated node, and such nodes are common in extracted road networks. The `debug_assert_eq!(id.level(), args.recursion_depth)` at the end of `main` was the only thing catching it, and only in debug builds.

Isolated nodes now join the smaller half. A cell that cannot be cut stays as it is, but its nodes still descend to the bottom of the hierarchy. A cell without edges reports `FlowError::EmptyGraph`.

## Tried, measured and dropped

| idea | why it was dropped |
| --- | --- |
| a table with the id of the reverse arc | instructions went down by 4 percent but CPU time went up by 2.5 percent, because building the table costs a binary search per arc. The cache described above is strictly better |
| a recursive driver without the per level barrier | wall clock went from 194.2 s to 202.7 s and the core utilization went down from 6.02 to 5.74 of 8 cores |

The recursive driver was written to recover idle time, because about a quarter of the machine is idle. Two profiles show why it did not help. Idle time is 54.6 percent during the first levels and only 7.9 percent in the middle of the run. The threads are not waiting at the level barrier, they are waiting at the top of the recursion, where the algorithm offers four way parallelism at most, one task per axis. Fixing that needs parallelism inside a single cell.

## Known leftovers

Peak memory is unchanged within the noise. The largest single allocation left is the copy of the edge list that `sub_step` builds for every axis, at 1.4 GB per axis on the root cell. It exists only to carry the renumbered endpoints into the graph builder. Feeding the trivial edges and the renumbering table straight into the builder would remove it, but that changes the signature of the `MaxFlow` constructor, so it is not part of this PR.

About a quarter of the machine stays idle, for the reason given above.

## Verification

- `cargo test` passes, 393 unit tests and 64 doc tests
- `cargo clippy --all-targets` reports only the three warnings that were there before
- the exact partition was compared between all runs by hashing the assignment
- the cut size was cross checked against the `-o` output of the tool, 5,335,229 lines for 2,667,614 cut edges plus the header

`examples/partition_stats.rs` is the tool used for the verification. It reports cut size, cell count, cell size distribution, the level histogram and a hash of the assignment. Happy to drop it from this PR if it is not wanted.


