### PR TITLE
Drop the redundant references from the log lines

### DIFF
--- a/src/chipper/bin/serialize.rs
+++ b/src/chipper/bin/serialize.rs
@@ -97,11 +97,11 @@ pub fn write_results(
         assignment_csv(&args.assignment_csv, partition_ids, coordinates);
     }
     if !args.cut_csv.is_empty() {
-        info!("writing cut csv to {}", &args.cut_csv);
+        info!("writing cut csv to {}", args.cut_csv);
         cut_csv(&args.cut_csv, edges, partition_ids, coordinates);
     }
     if !args.partition_file.is_empty() {
-        info!("writing partition ids to {}", &args.partition_file);
+        info!("writing partition ids to {}", args.partition_file);
         binary_partition_file(&args.partition_file, partition_ids);
     }
 }

--- a/src/scaffold/bin/main.rs
+++ b/src/scaffold/bin/main.rs
@@ -72,7 +72,7 @@ pub fn main() {
 
         info!("sorting convex cell hulls by Z-order");
         hulls.sort_by(|a, b| zorder_cmp(&a.1.center(), &b.1.center()));
-        info!("writing to {}", &args.convex_cells_geojson);
+        info!("writing to {}", args.convex_cells_geojson);
         serialize::convex_cell_hull_geojson(&hulls, &args.convex_cells_geojson);
     }
 


### PR DESCRIPTION
Clippy has been pointing at these for a while. A reference handed to a format string is dereferenced by the formatter anyway, so the borrow says nothing.

Leaves `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
