### PR TITLE
Say which cells of a level lie in which cell above

### DIFF
--- a/src/level_directory.rs
+++ b/src/level_directory.rs
@@ -112,6 +112,26 @@ impl LevelDirectory {
         }
     }
 
+    /// For every cell of the given level, the cell of the level above that it
+    /// lies in. This is what lets the cells of one level be built out of the
+    /// cells of the one below it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the hierarchy has no such level, or if the level is the
+    /// topmost one, which nothing lies above.
+    #[must_use]
+    pub fn parents_on_level(&self, level: usize) -> &[CellId] {
+        // asked in this order, as a level the hierarchy does not have at all
+        // would otherwise be reported as its topmost one
+        assert!(level < self.levels(), "no level {level} in the hierarchy");
+        assert!(
+            level + 1 < self.levels(),
+            "level {level} is the topmost one"
+        );
+        &self.parents[level]
+    }
+
     /// The cell a node sits in on the given level.
     ///
     /// # Panics
@@ -300,6 +320,38 @@ mod tests {
     #[should_panic(expected = "no level 3 in the hierarchy")]
     fn counting_the_cells_of_a_level_that_is_not_there_is_caught() {
         let _ = directory().cells_on_level(3);
+    }
+
+    #[test]
+    fn a_level_says_which_cells_of_it_lie_in_which_cell_above() {
+        let directory = directory();
+        // cells 0 and 1 of the lowest level lie in cell 0 above, cell 2 in cell 1
+        assert_eq!(directory.parents_on_level(0), &[0, 0, 1]);
+        assert_eq!(directory.parents_on_level(1), &[0, 0]);
+    }
+
+    #[test]
+    fn the_cells_above_agree_with_walking_a_node_up() {
+        let directory = directory();
+        for level in 0..directory.levels() - 1 {
+            let parents = directory.parents_on_level(level);
+            for node in 0..directory.number_of_nodes() {
+                let below = directory.cell_of(node, level);
+                assert_eq!(parents[below as usize], directory.cell_of(node, level + 1));
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "level 2 is the topmost one")]
+    fn asking_above_the_topmost_level_is_caught() {
+        let _ = directory().parents_on_level(2);
+    }
+
+    #[test]
+    #[should_panic(expected = "no level 7 in the hierarchy")]
+    fn asking_for_a_level_that_is_not_there_says_so() {
+        let _ = directory().parents_on_level(7);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #552.

The nesting is already held this way round internally, and this hands it out.

A caller that builds the cells of one level out of the cells of the one below it wants the children of each cell, and inverting this table once is how it gets them. Walking every node and reading two levels off it would cost the nodes rather than the cells, which on a continent is eighteen million against a few hundred thousand.

Asking the topmost level panics rather than returning an empty slice, since nothing lies above it and a caller asking has miscounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
