### PR TITLE
Build the graph on the cells a partition left behind

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -12,6 +12,73 @@
 
 use crate::{edge::TrivialEdge, level_directory::CellId};
 
+/// The graph on the cells a partition left behind: how large each cell is, and
+/// how many arcs of the graph run between two of them.
+///
+/// This is what says which cells may be merged, which the cells alone do not.
+/// Merging two cells that share an arc keeps the result in one piece as long as
+/// both of them were, and that is what a cell has to be for a search to cross
+/// it without leaving it.
+#[derive(Clone, Debug, Default)]
+pub struct CellGraph {
+    sizes: Vec<usize>,
+    /// the cells next to each one and how many arcs reach them, both ways round
+    neighbours: Vec<Vec<(usize, usize)>>,
+}
+
+impl CellGraph {
+    /// `arcs` holds how many arcs of the graph run between two cells, once per
+    /// pair and in either order.
+    #[must_use]
+    pub fn new(sizes: Vec<usize>, arcs: &[(usize, usize, usize)]) -> Self {
+        let mut neighbours = vec![Vec::new(); sizes.len()];
+        for &(left, right, weight) in arcs {
+            assert!(left != right, "a cell is not next to itself");
+            assert!(
+                left < sizes.len() && right < sizes.len(),
+                "an arc reaches a cell the graph does not have"
+            );
+            neighbours[left].push((right, weight));
+            neighbours[right].push((left, weight));
+        }
+        Self { sizes, neighbours }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.sizes.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.sizes.is_empty()
+    }
+
+    #[must_use]
+    pub fn size_of(&self, cell: usize) -> usize {
+        self.sizes[cell]
+    }
+
+    #[must_use]
+    pub fn neighbours_of(&self, cell: usize) -> &[(usize, usize)] {
+        &self.neighbours[cell]
+    }
+
+    /// The arcs between two cells, each pair once.
+    #[must_use]
+    pub fn arcs(&self) -> Vec<(usize, usize, usize)> {
+        let mut arcs = Vec::new();
+        for (left, neighbours) in self.neighbours.iter().enumerate() {
+            for &(right, weight) in neighbours {
+                if left < right {
+                    arcs.push((left, right, weight));
+                }
+            }
+        }
+        arcs
+    }
+}
+
 /// Splits the cells of a partition into the pieces they consist of, so that
 /// every piece is in one piece.
 ///
@@ -65,6 +132,68 @@ pub fn fragments(nodes: usize, arcs: &[TrivialEdge], cell_of_node: &[CellId]) ->
         .collect()
 }
 
+/// Builds the graph on the cells: how large each one is, and how many arcs run
+/// between two of them.
+///
+/// The count is of directed arcs, so a pair joined by a road that runs both
+/// ways weighs twice what a pair joined by a one way street does.
+#[must_use]
+pub fn cell_graph(arcs: &[TrivialEdge], cell_of_node: &[CellId]) -> CellGraph {
+    let cells = cell_of_node
+        .iter()
+        .copied()
+        .max()
+        .map_or(0, |cell| cell as usize + 1);
+    let mut sizes = vec![0; cells];
+    for &cell in cell_of_node {
+        sizes[cell as usize] += 1;
+    }
+
+    // Collect the pairs and count the runs rather than hashing them, as a road
+    // network cut into pieces of a dozen nodes has more arcs leaving a piece
+    // than staying inside it.
+    //
+    // The ends are put in order rather than the arc being taken only when they
+    // already are: an arc that runs from a higher numbered cell to a lower one
+    // is an arc between them all the same, and dropping it leaves cells looking
+    // like they have no neighbour at all.
+    //
+    // What comes out counts directed arcs, so a pair joined by a road that runs
+    // both ways counts twice and one joined by a one way street counts once.
+    // That is not a uniform doubling of an undirected count, and on a network
+    // where one arc in twenty carries no reverse it does move which pair is
+    // merged first. It is left that way on purpose: two cells joined by roads
+    // that can be driven in both directions are more strongly joined than two
+    // held together by a single one way street, and the weight says so.
+    let mut pairs = Vec::new();
+    for arc in arcs {
+        let (left, right) = (cell_of_node[arc.source], cell_of_node[arc.target]);
+        if left != right {
+            pairs.push((left.min(right), left.max(right)));
+        }
+    }
+    pairs.sort_unstable();
+
+    let mut between = Vec::new();
+    let mut run = pairs.first().copied();
+    let mut count = 0;
+    for pair in &pairs {
+        if Some(*pair) == run {
+            count += 1;
+        } else {
+            let (left, right) = run.expect("a run has a pair");
+            between.push((left as usize, right as usize, count));
+            run = Some(*pair);
+            count = 1;
+        }
+    }
+    if let Some((left, right)) = run {
+        between.push((left as usize, right as usize, count));
+    }
+
+    CellGraph::new(sizes, &between)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +206,88 @@ mod tests {
     #[should_panic(expected = "the partition does not cover the graph")]
     fn a_partition_that_leaves_a_node_out_is_caught() {
         let _ = fragments(3, &[edge(0, 1)], &[0, 0]);
+    }
+
+    #[test]
+    fn the_graph_on_the_cells_counts_the_arcs_between_them() {
+        // two cells of two, joined by two arcs
+        let arcs = [
+            edge(0, 1),
+            edge(1, 0),
+            edge(2, 3),
+            edge(3, 2),
+            edge(1, 2),
+            edge(2, 1),
+            edge(0, 3),
+            edge(3, 0),
+        ];
+        let graph = cell_graph(&arcs, &[0, 0, 1, 1]);
+        assert_eq!(graph.len(), 2);
+        assert_eq!(graph.size_of(0), 2);
+        assert_eq!(graph.size_of(1), 2);
+        // The arcs inside a cell are not counted. The two between them are, and
+        // the list holds both of their directions, so they come to four.
+        assert_eq!(graph.neighbours_of(0), &[(1, 4)]);
+    }
+
+    #[test]
+    fn cells_with_nothing_between_them_are_no_neighbours() {
+        let arcs = [edge(0, 1), edge(1, 0)];
+        let graph = cell_graph(&arcs, &[0, 0, 1]);
+        assert_eq!(graph.len(), 2);
+        assert!(graph.neighbours_of(0).is_empty());
+        assert!(graph.neighbours_of(1).is_empty());
+    }
+
+    /// An arc is an arc between two cells whichever way round its ends are
+    /// numbered. Taking only the ones that happen to run from a lower numbered
+    /// cell to a higher one leaves cells looking like they have no neighbour,
+    /// and a cell with no neighbour can never be merged into anything.
+    #[test]
+    fn an_arc_counts_whichever_way_round_it_runs() {
+        // one arc, and it runs from the higher numbered cell to the lower one
+        let arcs = [edge(1, 0)];
+        let graph = cell_graph(&arcs, &[0, 1]);
+        assert_eq!(graph.len(), 2);
+        assert_eq!(graph.neighbours_of(0), &[(1, 1)]);
+        assert_eq!(graph.neighbours_of(1), &[(0, 1)]);
+    }
+
+    #[test]
+    fn a_list_that_holds_both_directions_joins_the_same_cells() {
+        let one_way = cell_graph(&[edge(0, 1)], &[0, 1]);
+        let both_ways = cell_graph(&[edge(0, 1), edge(1, 0)], &[0, 1]);
+        // the weight doubles, which is the same for every pair, and the cells
+        // are neighbours either way
+        assert_eq!(one_way.neighbours_of(0), &[(1, 1)]);
+        assert_eq!(both_ways.neighbours_of(0), &[(1, 2)]);
+    }
+
+    /// A cell graph built from a connected graph has to be connected too, or
+    /// the merging has nothing to work with.
+    #[test]
+    fn a_connected_graph_gives_a_connected_cell_graph() {
+        // a path whose cells are numbered so that arcs run both up and down
+        let nodes = 12;
+        let arcs = (0..nodes - 1)
+            .map(|node| edge(node, node + 1))
+            .collect::<Vec<_>>();
+        let cells = (0..nodes)
+            .map(|node| ((nodes - node) % 4) as CellId)
+            .collect::<Vec<_>>();
+
+        let graph = cell_graph(&arcs, &cells);
+        let mut union = crate::union_find::UnionFind::new(graph.len());
+        for (left, right, _) in graph.arcs() {
+            union.union(left, right);
+        }
+        assert_eq!(union.number_of_sets(), 1, "the cell graph fell apart");
+        for cell in 0..graph.len() {
+            assert!(
+                !graph.neighbours_of(cell).is_empty(),
+                "cell {cell} has no neighbour"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #555.

Merging cells is a question about the graph whose nodes are the cells and whose arc weights count how many arcs of the graph run between two of them. This builds it: how large each cell is, and what lies next to it.

The pairs are collected and their runs counted rather than hashed. A road network cut into pieces of a dozen nodes has more arcs leaving a piece than staying inside it, so this list is long and a sort beats a hash map on it.

### The part worth reading twice

An arc counts whichever way round its ends are numbered:

```rust
if left != right {
    pairs.push((left.min(right), left.max(right)));
}
```

Taking only the arcs that happen to run from a lower numbered cell to a higher one drops half of them, and it does not drop them evenly: it leaves whole cells looking like they have no neighbour at all, and a cell with no neighbour can never be merged into anything. `an_arc_counts_whichever_way_round_it_runs` pins that down with a single arc, and `a_connected_graph_gives_a_connected_cell_graph` checks the property that motivates it, that a cell graph built from a connected graph is connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
