### PR TITLE
Check a partition with sound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ name = "graph_plier"
 path = "src/graph_plier/bin/main.rs"
 
 [[bin]]
+name = "sound"
+path = "src/sound/bin/main.rs"
+
+[[bin]]
 name = "solver"
 path = "src/solver/bin/main.rs"
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Generate GeoJSON file visualizing the cells:
 $ cargo r --release --bin scaffold -- -c /path/to/USA-road-d.USA.co.toolbox -g /path/to/USA-road-d.USA.gr.toolbox -p /path/to/USA-r30-m100.assignment.bin --convex-cells-geojson /path/to/bbox.geojson
 ```
 
+Check that the distances across the cells of a level say what the graph says:
+```
+$ cargo r --release --bin sound -- -g /path/to/USA-road-d.USA.gr.toolbox -d /path/to/USA-levels.bin -l 2
+```
+Each cell is worked out the way a query would have it, out of the cells below
+it, and then again from each of its border nodes by a plain search over the
+graph that knows nothing of levels. Leaving out `-l` checks every level, which
+on a coarse level of a continent is a long wait.
+
 
 ## Convex Hull Visualization
 ![Convex Hulls USA](https://user-images.githubusercontent.com/1067895/175577261-55e38f44-07ae-4ab2-b344-23d15f5d5c89.png)

--- a/src/sound/bin/command_line.rs
+++ b/src/sound/bin/command_line.rs
@@ -1,0 +1,38 @@
+use std::fmt::Display;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Arguments {
+    /// input graph file
+    #[clap(short, long, action)]
+    pub graph: String,
+
+    /// path to the level directory that chipper wrote
+    #[clap(short, long, action)]
+    pub directory: String,
+
+    /// The level to check, and every level of the directory when none is
+    /// given. A level is checked against the graph itself, so a coarse one
+    /// costs a search over each of its cells per border node it holds.
+    #[clap(short, long, action)]
+    pub level: Option<usize>,
+
+    /// how many mismatches to report before the rest is counted only
+    #[clap(short, long, default_value_t = 20, action)]
+    pub report: usize,
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "command line arguments:")?;
+        writeln!(f, "graph: {}", self.graph)?;
+        writeln!(f, "level directory: {}", self.directory)?;
+        match self.level {
+            Some(level) => writeln!(f, "level: {level}")?,
+            None => writeln!(f, "level: all of them")?,
+        }
+        writeln!(f, "report: {} mismatches", self.report)
+    }
+}

--- a/src/sound/bin/main.rs
+++ b/src/sound/bin/main.rs
@@ -48,10 +48,16 @@ struct LevelCheck {
     /// cells that hold no border node, which cannot be entered or left and so
     /// have nothing to check
     without_border: u64,
+    /// how many distances differ from the graph in all
+    wrong: u64,
+    /// the first of them, as many as were asked to be reported. A directory
+    /// that is broken through and through has as many mismatches as it has
+    /// pairs, and holding all of them to print twenty is a way to run out of
+    /// memory while reporting a fault.
     mismatches: Vec<Mismatch>,
 }
 
-fn check_level(customization: &Customization, level: usize) -> LevelCheck {
+fn check_level(customization: &Customization, level: usize, keep: usize) -> LevelCheck {
     let cells = customization.level(level);
     let count = cells.nodes_of_cell.len();
     info!(
@@ -70,26 +76,28 @@ fn check_level(customization: &Customization, level: usize) -> LevelCheck {
     let mut found = LevelCheck {
         pairs: 0,
         without_border: 0,
+        wrong: 0,
         mismatches: Vec::new(),
     };
-    for batch in (0..count as CellId).collect::<Vec<_>>().chunks(BATCH) {
-        let checks = batch
-            .par_iter()
-            .map(|&cell| customization.check(level, cell))
+    for start in (0..count as CellId).step_by(BATCH) {
+        let end = (start + BATCH as CellId).min(count as CellId);
+        let checks = (start..end)
+            .into_par_iter()
+            .map(|cell| customization.check(level, cell))
             .collect::<Vec<CellCheck>>();
 
         for check in checks {
             found.pairs += check.pairs;
             found.without_border += u64::from(!check.has_border);
-            found.mismatches.extend(check.mismatches);
+            found.wrong += check.mismatches.len() as u64;
+            let room = keep.saturating_sub(found.mismatches.len());
+            found
+                .mismatches
+                .extend(check.mismatches.into_iter().take(room));
         }
         customization.forget();
-        bar.inc(batch.len() as u64);
-        bar.set_message(format!(
-            "{} pairs, {} wrong",
-            found.pairs,
-            found.mismatches.len()
-        ));
+        bar.inc(u64::from(end - start));
+        bar.set_message(format!("{} pairs, {} wrong", found.pairs, found.wrong));
     }
     bar.finish();
     found
@@ -106,7 +114,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!(r#""`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-' "#);
     println!("build: {}", env!("GIT_HASH"));
     let args = <Arguments as clap::Parser>::parse();
-    print!("{args}");
+    info!("{args}");
 
     let edges = io::read_vec_from_file::<InputEdge<usize>>(&args.graph);
     info!("loaded {} graph edges", edges.len());
@@ -123,12 +131,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         graph.number_of_nodes(),
         graph.number_of_edges()
     );
-    assert_eq!(
-        graph.number_of_nodes(),
-        directory.number_of_nodes(),
-        "the directory was built over another graph"
-    );
-
     let levels = match args.level {
         Some(level) => {
             assert!(
@@ -144,24 +146,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     let started = Instant::now();
     let mut sound = true;
     for level in levels {
-        let found = check_level(&customization, level);
+        let found = check_level(&customization, level, args.report);
         info!(
             "level {level}: checked {} pairs over {} cells, leaving out {} that hold no border node",
             found.pairs,
             customization.level(level).nodes_of_cell.len() as u64 - found.without_border,
             found.without_border
         );
-        if found.mismatches.is_empty() {
+        if found.wrong == 0 {
             info!("level {level} says what the graph says");
             continue;
         }
 
         sound = false;
-        warn!(
-            "level {level}: {} pairs differ from the graph",
-            found.mismatches.len()
-        );
-        for wrong in found.mismatches.iter().take(args.report) {
+        warn!("level {level}: {} pairs differ from the graph", found.wrong);
+        for wrong in &found.mismatches {
             let expected = if wrong.expected == usize::MAX {
                 "unreachable".to_owned()
             } else {
@@ -172,8 +171,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 wrong.cell, wrong.from, wrong.to, wrong.built
             );
         }
-        if found.mismatches.len() > args.report {
-            warn!("  and {} more", found.mismatches.len() - args.report);
+        if found.wrong > found.mismatches.len() as u64 {
+            warn!("  and {} more", found.wrong - found.mismatches.len() as u64);
         }
     }
 

--- a/src/sound/bin/main.rs
+++ b/src/sound/bin/main.rs
@@ -1,0 +1,191 @@
+//! Checks that the cell distances of a partition say what the graph says.
+//!
+//! A cell is summarized by the distances between the nodes on its border, and
+//! every level above the finest is worked out from the cells below rather than
+//! from the graph. That is what makes a query fast and what makes it possible
+//! to be quietly wrong: a cell of a million nodes is searched over a few
+//! thousand, and nothing in that search ever looks at the graph again.
+//!
+//! So this tool goes the slow way round. Each cell is worked out the way a
+//! query would have it, and then again from each of its border nodes by a
+//! plain Dijkstra over the graph itself that knows nothing of levels. The two
+//! have to agree on every ordered pair.
+//!
+//! ```text
+//! sound -g graph.toolbox -d levels.bin -l 2
+//! ```
+//!
+//! Without a level it checks all of them, which on a coarse level of a
+//! continent is a long wait. It exits non-zero when a cell disagrees.
+
+mod command_line;
+
+use command_line::Arguments;
+use env_logger::{Builder, Env};
+use indicatif::{ProgressBar, ProgressStyle};
+use log::{info, warn};
+use rayon::prelude::*;
+use std::{error::Error, time::Instant};
+use toolbox_rs::{
+    customization::{CellCheck, Customization, Mismatch},
+    edge::InputEdge,
+    graph::Graph,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    static_graph,
+};
+
+/// How many cells are checked before what was worked out below them is
+/// dropped. A cell of a level belongs to exactly one cell of the level above,
+/// so nothing is thrown away that a later batch would have asked for again,
+/// and the tables of a whole level of a continent never have to be held at
+/// once.
+const BATCH: usize = 256;
+
+/// What checking a whole level came to.
+struct LevelCheck {
+    pairs: u64,
+    /// cells that hold no border node, which cannot be entered or left and so
+    /// have nothing to check
+    without_border: u64,
+    mismatches: Vec<Mismatch>,
+}
+
+fn check_level(customization: &Customization, level: usize) -> LevelCheck {
+    let cells = customization.level(level);
+    let count = cells.nodes_of_cell.len();
+    info!(
+        "checking {count} cells of level {level}, the largest holding {} nodes",
+        cells.nodes_of_cell.iter().map(Vec::len).max().unwrap_or(0)
+    );
+
+    let bar = ProgressBar::new(count as u64);
+    bar.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} [{elapsed_precise}] {wide_bar:.green/yellow} {msg}")
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    let mut found = LevelCheck {
+        pairs: 0,
+        without_border: 0,
+        mismatches: Vec::new(),
+    };
+    for batch in (0..count as CellId).collect::<Vec<_>>().chunks(BATCH) {
+        let checks = batch
+            .par_iter()
+            .map(|&cell| customization.check(level, cell))
+            .collect::<Vec<CellCheck>>();
+
+        for check in checks {
+            found.pairs += check.pairs;
+            found.without_border += u64::from(!check.has_border);
+            found.mismatches.extend(check.mismatches);
+        }
+        customization.forget();
+        bar.inc(batch.len() as u64);
+        bar.set_message(format!(
+            "{} pairs, {} wrong",
+            found.pairs,
+            found.mismatches.len()
+        ));
+    }
+    bar.finish();
+    found
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    println!(r#"                             _  "#);
+    println!(r#"  ___    ___    _  _   _ _  | | "#);
+    println!(r#" (_-<   / _ \  | +| | | ' \ |_| "#);
+    println!(r#" /__/_  \___/   \_,_| |_||_|(_) "#);
+    println!(r#"_|"""""|"""""|_|"""""|_|"""""|  "#);
+    println!(r#""`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-' "#);
+    println!("build: {}", env!("GIT_HASH"));
+    let args = <Arguments as clap::Parser>::parse();
+    print!("{args}");
+
+    let edges = io::read_vec_from_file::<InputEdge<usize>>(&args.graph);
+    info!("loaded {} graph edges", edges.len());
+    let directory: LevelDirectory = io::read_from_file(&args.directory);
+    info!(
+        "loaded a directory of {} levels over {} nodes",
+        directory.levels(),
+        directory.number_of_nodes()
+    );
+
+    let graph = static_graph::StaticGraph::new(edges);
+    info!(
+        "loaded static graph with {} nodes and {} edges",
+        graph.number_of_nodes(),
+        graph.number_of_edges()
+    );
+    assert_eq!(
+        graph.number_of_nodes(),
+        directory.number_of_nodes(),
+        "the directory was built over another graph"
+    );
+
+    let levels = match args.level {
+        Some(level) => {
+            assert!(
+                level < directory.levels(),
+                "the directory has no level {level}"
+            );
+            level..level + 1
+        }
+        None => 0..directory.levels(),
+    };
+    let customization = Customization::new(graph, directory);
+
+    let started = Instant::now();
+    let mut sound = true;
+    for level in levels {
+        let found = check_level(&customization, level);
+        info!(
+            "level {level}: checked {} pairs over {} cells, leaving out {} that hold no border node",
+            found.pairs,
+            customization.level(level).nodes_of_cell.len() as u64 - found.without_border,
+            found.without_border
+        );
+        if found.mismatches.is_empty() {
+            info!("level {level} says what the graph says");
+            continue;
+        }
+
+        sound = false;
+        warn!(
+            "level {level}: {} pairs differ from the graph",
+            found.mismatches.len()
+        );
+        for wrong in found.mismatches.iter().take(args.report) {
+            let expected = if wrong.expected == usize::MAX {
+                "unreachable".to_owned()
+            } else {
+                wrong.expected.to_string()
+            };
+            warn!(
+                "  cell {}, node {} to node {}: built {}, graph {expected}",
+                wrong.cell, wrong.from, wrong.to, wrong.built
+            );
+        }
+        if found.mismatches.len() > args.report {
+            warn!("  and {} more", found.mismatches.len() - args.report);
+        }
+    }
+
+    info!(
+        "customized {} cells in {:.1?}, checked in {:.1?}",
+        customization.customized_cells(),
+        customization.customization_time(),
+        started.elapsed()
+    );
+    if sound {
+        Ok(())
+    } else {
+        Err("the cell distances do not match the graph".into())
+    }
+}


### PR DESCRIPTION
Stacked on #566. The tool that does the checking over a whole level.

```
sound -g graph.toolbox -d levels.bin -l 2
```

`-l` picks a level, leaving it out checks all of them, `-r` caps how many mismatches are printed before the rest is counted. It exits non-zero when a cell disagrees, so it can go in a script.

The cells are walked in batches across all cores and what was worked out below them is dropped between batches. A cell of one level belongs to exactly one cell of the level above, so nothing is thrown away that a later batch would ask for again, and a level of a continent can be checked without holding all of it at once.

### On the PTV Europe network

Against a directory of six levels over 18010173 nodes and 42188664 arcs:

```
level 0: checked 28274874 pairs over 526671 cells, clean, 5.4s
level 2: checked 17078244 pairs over  25018 cells, clean, 16.2s
```

Level 2 leaves out 2008 cells that hold no border node, which are pieces of the network entirely cut off from the rest. Level 0 has none, which is consistent: an isolated island still has borders between the fine cells inside it, just none to the outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
