### PR TITLE
Split the edges on the side of the cut, not on the partition id

### DIFF
--- a/src/chipper/bin/main.rs
+++ b/src/chipper/bin/main.rs
@@ -13,7 +13,7 @@ use log::{debug, info};
 use rayon::prelude::*;
 use std::sync::{
     Arc,
-    atomic::{AtomicI32, AtomicU32, Ordering},
+    atomic::{AtomicI32, AtomicU8, AtomicU32, Ordering},
 };
 use toolbox_rs::geometry::FPCoordinate;
 use toolbox_rs::io;
@@ -83,6 +83,19 @@ fn main() {
     let load = |index: usize| PartitionID(partition_ids[index].load(Ordering::Relaxed));
     let store = |index: usize, id: PartitionID| partition_ids[index].store(id.0, Ordering::Relaxed);
 
+    // The side of the latest cut that a node ended up on, which is all that
+    // splitting the edge set needs. Reading it off the partition id instead
+    // only works while the id has room: it shifts left by one per level and
+    // packs the whole path into a u32, so it cannot record a bisection deeper
+    // than 31 and the lowest bit stops meaning the latest cut.
+    const LEFT: u8 = 0;
+    const RIGHT: u8 = 1;
+    let sides = (0..coordinates.len())
+        .map(|_| AtomicU8::new(LEFT))
+        .collect_vec();
+    let side_of = |index: usize| sides[index].load(Ordering::Relaxed);
+    let set_side = |index: usize, side: u8| sides[index].store(side, Ordering::Relaxed);
+
     while !current_job_queue.is_empty() && current_level < args.recursion_depth {
         let pb = ProgressBar::new(current_job_queue.len() as u64);
         pb.set_style(sty.clone());
@@ -136,11 +149,13 @@ fn main() {
                     let mut id = load(*i);
                     id.make_left_child();
                     store(*i, id);
+                    set_side(*i, LEFT);
                 });
                 (result.right_ids).iter().for_each(|i| {
                     let mut id = load(*i);
                     id.make_right_child();
                     store(*i, id);
+                    set_side(*i, RIGHT);
                 });
 
                 // Partition edge and node id sets for the next iteration. The
@@ -153,11 +168,11 @@ fn main() {
                 let mut left_edges = Vec::new();
                 let mut right_edges = Vec::new();
                 for edge in std::mem::take(&mut job.0) {
-                    let tail_is_left = load(edge.source).is_left_child();
-                    if tail_is_left != load(edge.target).is_left_child() {
+                    let tail_side = side_of(edge.source);
+                    if tail_side != side_of(edge.target) {
                         continue;
                     }
-                    if tail_is_left {
+                    if tail_side == LEFT {
                         left_edges.push(edge);
                     } else {
                         right_edges.push(edge);


### PR DESCRIPTION
Splitting the edge set for the next level only needs to know which side of the **latest** cut each end of an edge landed on. That was read off the partition id:

```rust
let tail_is_left = load(edge.source).is_left_child();
```

`is_left_child` is the lowest bit of the id, which is the latest cut — but only while the id has room. A `PartitionID` shifts left by one per level and packs the whole path into a `u32`, so it cannot record a bisection deeper than 31 levels. Past that the lowest bit stops meaning the latest cut, and the edge set gets split on nothing in particular.

A byte per node says it outright and says it at any depth. Same relaxed-atomic treatment as the ids: cells are disjoint, so each entry is written by at most one thread per level.

The partition ids are still kept and still written, so nothing about the output changes.

### Checked against main

DIMACS USA travel time graph, 23947347 nodes and 58333344 edges, cut to six levels with a minimum cell size of 100. The cut csv is byte for byte identical to the one main's chipper writes.

This is worth having on its own, and it is also what lets the recursion go deeper than 31 levels, which cutting down to small cells before assembling levels needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
