### PR TITLE
Write down how an agent works on this repository

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "attribution": {
+    "commit": ""
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "c=$(jq -r '.tool_input.command // empty'); printf '%s' \"$c\" | grep -q 'git commit' && printf '%s' \"$c\" | grep -qiE 'co-authored-by:[[:space:]]*claude|claude-session:' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo does not sign commits as an agent (see AGENTS.md). Drop the Co-Authored-By: Claude and Claude-Session trailers from the commit message and commit again. The agent-assistance note and the session link belong in the pull request description instead.\"}}'; exit 0",
+            "statusMessage": "Checking commit message for agent trailers"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.vscode
 Cargo.lock
+/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode
 Cargo.lock
 /.claude/settings.local.json
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+A library of data structures and algorithms, plus four binaries (`chipper`,
+`scaffold`, `graph_plier`, `solver`). Rust 2024 edition.
+
+## Building and testing
+
+```
+cargo build
+cargo test
+cargo fmt
+cargo clippy --all-features
+```
+
+CI runs all four on every pull request, on stable and nightly, on Linux,
+macOS and Windows. Run them locally before pushing.
+
+## Code
+
+- One module per file in `src/`, exported from `src/lib.rs`. A binary lives in
+  its own directory next to the modules it drives.
+- Tests go in an inline `#[cfg(test)] mod tests` at the foot of the file they
+  cover. Cover the edges, not only the happy path.
+- No `unsafe`. It has been removed from this codebase on purpose; if a change
+  seems to need it, say so instead of adding it.
+- Benchmarks are criterion, under `benches/`.
+
+## Commits
+
+Write the subject as a plain sentence saying what the change does — "Read a
+single rkyv value from a file", not a conventional-commit prefix. The body
+says why the change is worth making and what it rules out; wrap it at 72
+columns.
+
+Do not sign the commit as an agent. No `Co-authored-by:` line, no
+`Claude-Session:` trailer, no tool footer — the commit message is about the
+change alone.
+
+## Pull requests
+
+Say in the PR description that it was written with agent assistance, and link
+the session there. That is the place for it, and it keeps the history clean
+while the provenance stays where a reviewer looks for it.
+
+Otherwise the description carries the reasoning: what the change does, why,
+what it leaves for later, and which PR it is stacked on if any.
+
+Releases are cut by release-plz from `main`; do not bump the version in
+`Cargo.toml` by hand.


### PR DESCRIPTION
Nothing in the repository tells an agent what it is walking into, so every session rediscovers the same handful of facts: that fmt, clippy and the tests all gate a pull request, that a test lives at the foot of the file it covers, that unsafe was taken out on purpose, and that release-plz owns the version. `AGENTS.md` writes them down.

It also settles where the provenance of an agent-written change belongs. The commit says what the change does and nothing about who typed it; the pull request says an agent wrote it and links the session. The history stays about the code, and a reviewer still finds the provenance in the place they go looking for it.

The commit half is enforced rather than left to be remembered. `.claude/settings.json` empties `attribution.commit`, so the trailer is never written in the first place, and a `PreToolUse` hook denies a `git commit` whose message carries a `Co-Authored-By: Claude` or `Claude-Session:` trailer. The hook only sees the command string, so it catches `-m` messages; a message passed by `-F`, `-c`, or an editor falls to the setting alone.

`.gitignore` gains `.claude/settings.local.json` so that committing `.claude/` does not sweep up local permissions along with it.

This pull request is itself the first one written under the rule: the commit carries no trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)