### PR TITLE
Cut chipper by size and assemble the levels that were asked for

### DIFF
--- a/src/chipper/bin/command_line.rs
+++ b/src/chipper/bin/command_line.rs
@@ -72,6 +72,18 @@ pub struct Arguments {
     /// Minimum size of a cell
     #[clap(short, long, default_value_t = 50, action)]
     pub minimum_cell_size: usize,
+
+    /// Sizes of the levels to assemble, from the finest up, e.g.
+    /// 50,250,1000,10000,100000,1000000. Giving them cuts the graph down to
+    /// cells of a quarter of the finest size instead of to the minimum cell
+    /// size, and assembles the levels out of those cells. The recursion depth
+    /// still caps how deep the cutting may go.
+    #[clap(short = 'L', long, value_delimiter = ',')]
+    pub level_sizes: Vec<usize>,
+
+    /// path to write the level directory to
+    #[clap(short = 'd', long, default_value_t = String::new(), action)]
+    pub level_directory: String,
 }
 
 impl Display for Arguments {
@@ -93,6 +105,12 @@ impl Display for Arguments {
         writeln!(f, "coordinates: {}", self.coordinates)?;
         writeln!(f, "recursion depth: {}", self.recursion_depth)?;
         writeln!(f, "balance factor: {}", self.b_factor)?;
+        if !self.level_sizes.is_empty() {
+            writeln!(f, "level sizes: {:?}", self.level_sizes)?;
+        }
+        if !self.level_directory.is_empty() {
+            writeln!(f, "level directory: {}", self.level_directory)?;
+        }
         writeln!(f, "minimum_cell_size: {}", self.minimum_cell_size)
     }
 }

--- a/src/chipper/bin/main.rs
+++ b/src/chipper/bin/main.rs
@@ -9,7 +9,7 @@ use env_logger::Env;
 use itertools::Itertools;
 
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{debug, info};
+use log::{debug, info, warn};
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use std::sync::{
@@ -19,10 +19,27 @@ use std::sync::{
 use toolbox_rs::geometry::FPCoordinate;
 use toolbox_rs::io;
 use toolbox_rs::{
+    assembly,
     inertial_flow::{self, Flow, flow_cmp},
+    level_directory::CellId,
     partition_id::PartitionID,
 };
-use {command_line::Arguments, serialize::write_results};
+use {
+    command_line::Arguments,
+    serialize::{write_level_directory, write_results},
+};
+
+/// Numbers whatever the bisection left behind from zero without a gap.
+fn compact(of_node: &[usize]) -> Vec<CellId> {
+    let mut cell_of = rustc_hash::FxHashMap::default();
+    of_node
+        .iter()
+        .map(|leaf| {
+            let next = cell_of.len() as CellId;
+            *cell_of.entry(*leaf).or_insert(next)
+        })
+        .collect()
+}
 
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -61,11 +78,31 @@ fn main() {
     // root job takes ownership of the edge set, which is only needed again if
     // the cut is to be written out.
     let id_vector = (0..coordinates.len()).collect_vec();
-    let input_edges = if args.cut_csv.is_empty() {
+    // The assembly walks the arcs to find which cells hold together and which
+    // of them are neighbours, so they are kept for it as well as for the cut
+    // csv. Nothing else needs them and a copy of the arcs of a continent is
+    // not worth keeping for nobody.
+    let input_edges = if args.cut_csv.is_empty() && args.level_sizes.is_empty() {
         Vec::new()
     } else {
         edges.clone()
     };
+    let node_count = coordinates.len();
+    // The size a cell has to reach before the cutting stops. Assembling a level
+    // out of cells a quarter of its size leaves the assembly room to come close
+    // to the size that was asked for.
+    let stop_at = args
+        .level_sizes
+        .iter()
+        .min()
+        .map_or(args.minimum_cell_size, |smallest| (smallest / 4).max(1));
+    if !args.level_sizes.is_empty() {
+        info!(
+            "cutting down to cells of {stop_at} nodes, then assembling {:?}",
+            args.level_sizes
+        );
+    }
+
     // Which cell of the bisection each node has ended up in so far. A cell is
     // numbered when it is created, so the number of a node is the number of the
     // deepest cell it has landed in, and after the cutting that is its leaf.
@@ -188,14 +225,14 @@ fn main() {
                 debug!("generating next level ids");
 
                 let level_difference = (args.recursion_depth - current_level - 1) as usize;
-                if result.left_ids.len() <= args.minimum_cell_size {
+                if result.left_ids.len() <= stop_at {
                     for i in &result.left_ids {
                         let mut id = load(*i);
                         id.make_leftmost_descendant(level_difference);
                         store(*i, id);
                     }
                 }
-                if result.right_ids.len() <= args.minimum_cell_size {
+                if result.right_ids.len() <= stop_at {
                     for i in &result.right_ids {
                         let mut id = load(*i);
                         id.make_rightmost_descendant(level_difference);
@@ -229,7 +266,7 @@ fn main() {
                 for &node in &ids {
                     leaf_of_node[node] = cell;
                 }
-                if ids.len() > args.minimum_cell_size {
+                if ids.len() > stop_at {
                     next_job_queue.push((edges, ids, cell));
                 }
             }
@@ -244,6 +281,32 @@ fn main() {
     // read off the tally.
     let leaves = leaf_of_node.iter().copied().collect::<FxHashSet<_>>().len();
     info!("the cutting left {leaves} cells over {cells_created} it made on the way");
+
+    if !args.level_sizes.is_empty() {
+        // The cells of the bisection need not hold together, as a minimum cut
+        // puts everything the source cannot reach on the far side whether it
+        // hangs together with the rest or not. Merging such a cell into a
+        // larger one carries the split upwards, so they are taken apart first.
+        let base_cells = compact(&leaf_of_node);
+        let pieces = assembly::fragments(node_count, &input_edges, &base_cells);
+        let piece_count = pieces.iter().copied().max().map_or(0, |p| p as usize + 1);
+        info!("those cells hold together in {piece_count} pieces");
+
+        let cells = assembly::cell_graph(&input_edges, &pieces);
+        let directory = assembly::assemble_connected(&cells, &pieces, &args.level_sizes);
+        for level in 0..directory.levels() {
+            info!(
+                "level {level} of {} nodes: {} cells",
+                args.level_sizes[level],
+                directory.cells_on_level(level)
+            );
+        }
+        if args.level_directory.is_empty() {
+            warn!("no level directory was asked for, so the levels are dropped");
+        } else {
+            write_level_directory(&args.level_directory, &directory);
+        }
+    }
 
     let partition_ids_vec = partition_ids
         .iter()

--- a/src/chipper/bin/serialize.rs
+++ b/src/chipper/bin/serialize.rs
@@ -4,7 +4,10 @@ use std::{
     fs::File,
     io::{BufWriter, Write},
 };
-use toolbox_rs::{edge::TrivialEdge, geometry::FPCoordinate, partition_id::PartitionID};
+use toolbox_rs::{
+    edge::TrivialEdge, geometry::FPCoordinate, level_directory::LevelDirectory,
+    partition_id::PartitionID,
+};
 
 use crate::command_line::Arguments;
 
@@ -104,4 +107,13 @@ pub fn write_results(
         info!("writing partition ids to {}", args.partition_file);
         binary_partition_file(&args.partition_file, partition_ids);
     }
+}
+
+/// Writes the cells of every level, so that a query can look up which cell a
+/// node sits in on a level and which level two nodes meet on.
+pub fn write_level_directory(path: &str, directory: &LevelDirectory) {
+    info!("writing level directory to {path}");
+    let mut file = BufWriter::new(File::create(path).expect("output file cannot be opened"));
+    let bytes = rkyv::to_bytes::<rancor::Error>(directory).unwrap();
+    file.write_all(&bytes).unwrap();
 }


### PR DESCRIPTION
Stacked on #573. The last piece: chipper can be asked for the levels one actually wants.

```
chipper -g graph.toolbox -c coordinates.toolbox -r 30 \
        -L 50,250,1000,10000,100000,1000000 -d levels.bin
```

A recursive bisection to a fixed depth gives levels whose sizes are whatever the graph happens to make them. This is the other way round: cut down to cells of a quarter of the finest size, then merge neighbours until each cell is as large as its level allows. A quarter leaves the assembly room to come close to the size asked for.

Merging along arcs is what keeps a cell in one piece, and the cells of the bisection are taken apart into their pieces first — a minimum cut puts everything the source cannot reach on the far side whether it hangs together with the rest or not.

### End to end on the DIMACS USA travel time graph

23947347 nodes, cut to cells of 12, assembled into `[50, 250, 1000, 10000, 100000, 1000000]`:

```
level 0:  718770 cells, sizes 1/41/62      (smallest/median/largest)
level 1:  155959 cells, sizes 1/196/250
level 2:   38297 cells, sizes 1/796/1000
level 3:    4476 cells, sizes 3/6693/10000
level 4:     497 cells, sizes 8/54730/100000
level 5:      36 cells, sizes 21741/821394/996034
```

`cell_components` says every cell of every level holds together. `sound` says level 1 agrees with the graph over 26391921 pairs.

### One thing worth pointing at

The arcs are now kept when levels are asked for, not only when a cut csv is:

```rust
let input_edges = if args.cut_csv.is_empty() && args.level_sizes.is_empty() { ... }
```

Without that the assembly gets an empty arc list, finds no cell joined to any other, and reports every node as a piece of its own — which is exactly what the first run did, silently producing six levels of 23947347 cells each. Worth knowing that the failure mode is a plausible looking directory rather than a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
