### PR TITLE
Hold the nodes of the linked list in a vector

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -27,11 +27,14 @@
 //! # Cursors outliving their node
 //!
 //! A cursor stays valid while its node is in the list. Popping the node ends
-//! that, and a later push may hand the freed slot to another element, so a
-//! cursor kept across a pop may end up naming whatever moved in. That is a
-//! wrong answer rather than the undefined behaviour the pointers used to give,
+//! that, and what a cursor does afterwards depends on what became of its slot.
+//! While the slot is still free, the cursor names nothing: [`LinkedList::get`]
+//! reads it as `None` and [`LinkedList::move_to_front`] leaves the list alone.
+//! Once a later push has taken the slot over, the cursor names that push's
+//! element, which is a wrong answer rather than the undefined behaviour the
+//! pointers used to give. Telling those two apart would cost a count per slot,
 //! and a caller that hands out cursors is expected to drop them along with
-//! their nodes, which is what [`crate::lru::LRU`] does when it evicts.
+//! their nodes anyway, which is what [`crate::lru::LRU`] does when it evicts.
 
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
@@ -189,16 +192,24 @@ impl<T> LinkedList<T> {
 
     /// Moves the node a cursor names to the front of the list.
     ///
-    /// Does nothing if the list is empty or the node is already at the front.
+    /// Does nothing when the node is already at the front, and nothing when
+    /// the cursor no longer names a node of this list, i.e. when its node has
+    /// been popped without the slot being taken over since.
     pub fn move_to_front(&mut self, cursor: &ListCursor<T>) {
-        if self.is_empty() || self.front == Some(cursor.index) {
+        let index = cursor.index;
+        // A cursor whose node has been popped names a free slot, and one from
+        // a list that has been cleared may name no slot at all. Moving either
+        // of them would splice a free slot into the list, leaving it in the
+        // list and on the free list at once for the next push to hand out from
+        // under it. The list is checked rather than asserted over, as the
+        // caller holding the stale cursor is the one who cannot tell.
+        let occupied = self
+            .nodes
+            .get(index)
+            .is_some_and(|node| node.elem.is_some());
+        if !occupied || self.front == Some(index) {
             return;
         }
-        let index = cursor.index;
-        debug_assert!(
-            self.nodes[index].elem.is_some(),
-            "the node this cursor names has been popped"
-        );
 
         // close the gap the node leaves behind
         let newer = self.nodes[index].newer;
@@ -498,6 +509,43 @@ mod test {
         list.push_front(4);
         assert_eq!(list.nodes.len(), 2);
         assert_eq!(drained(&mut list), vec![3, 4]);
+    }
+
+    /// A stale cursor must not splice its slot back into the list. The slot is
+    /// on the free list, so a list that took it back would hand it to the next
+    /// push while it was still linked, and the damage would only show up in a
+    /// later pop.
+    #[test]
+    fn moving_a_node_that_was_popped_leaves_the_list_alone() {
+        let mut list = LinkedList::new();
+        let popped = list.push_front(1);
+        list.push_front(2);
+        list.push_front(3);
+        assert_eq!(list.pop_back(), Some(1));
+
+        list.move_to_front(&popped);
+
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get_front(), &3);
+        assert_eq!(drained(&mut list), vec![2, 3]);
+    }
+
+    #[test]
+    fn a_cursor_from_before_a_clear_leaves_the_list_alone() {
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        list.push_front(2);
+        let far = list.push_front(3);
+
+        // clear gives up the slots, so the cursor now names one that is not
+        // there at all rather than one that is free
+        list.clear();
+        list.push_front(4);
+        list.move_to_front(&far);
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.get_front(), &4);
+        assert_eq!(drained(&mut list), vec![4]);
     }
 
     #[test]

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,137 +1,260 @@
-/// Simplified implementation of a linked list that is suitable for a textbook
-/// implementation of an LRU cache. The code below implements three important
-/// functions upon which the cache is built:
-///
-/// 1) push_front(): insert an element to the front of the list
-/// 2) pop_back(): remove the back element if it exists, and
-/// 3) move_to_front(): move an existing element to the front of the list
-///
-/// The implementation is modelled after the excellent writeup on implementing
-/// linked lists called "Learn Rust With Entirely Too Many Linked Lists" which
-/// can be found at https://rust-unofficial.github.io/too-many-lists/index.html
-///
-/// Since linked lists use pointers and are self-referential, there's a ton of
-/// unsafe code in the implementation. Please be mindful, when changing the code.
-///
-/// Once the standard library contains a stable implementation of linked lists
-/// with cursors this code could be removed. We are not there yet as of writing.
+//! A doubly linked list whose nodes live in one vector and name each other by
+//! index. It carries the three operations an LRU cache is built on:
+//!
+//! 1) [`LinkedList::push_front`]: insert an element at the front of the list
+//! 2) [`LinkedList::pop_back`]: remove the back element if there is one, and
+//! 3) [`LinkedList::move_to_front`]: move an element that is already in the
+//!    list to the front
+//!
+//! all of them in constant time, and each of them handing out or taking a
+//! [`ListCursor`] that names a node for as long as it is in the list.
+//!
+//! # Why the nodes are indexed rather than pointed at
+//!
+//! Boxing each node and joining them with raw pointers is the usual way to
+//! write this, and it is how this module started out. It costs `unsafe` on
+//! every link, and it costs `Send`: a `NonNull` is not `Send`, so neither the
+//! list nor anything built on it could be handed to another thread or shared
+//! behind a lock. That ruled out the one use this list has, as the tile server
+//! shares a single [`crate::lru::LRU`] of drawn tiles between its workers.
+//!
+//! Holding the nodes in a vector and naming them by position gives up nothing
+//! a cache asks of a list, and leaves the module in safe code that a server can
+//! share across threads. A popped node leaves its slot behind for the next push
+//! to take, so a list held at a capacity settles at that many slots and stops
+//! allocating.
+//!
+//! # Cursors outliving their node
+//!
+//! A cursor stays valid while its node is in the list. Popping the node ends
+//! that, and a later push may hand the freed slot to another element, so a
+//! cursor kept across a pop may end up naming whatever moved in. That is a
+//! wrong answer rather than the undefined behaviour the pointers used to give,
+//! and a caller that hands out cursors is expected to drop them along with
+//! their nodes, which is what [`crate::lru::LRU`] does when it evicts.
+
+use std::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::ptr::NonNull;
 
-pub struct LinkedList<T> {
-    front: Link<T>,
-    back: Link<T>,
-    len: usize,
-    _ghost: PhantomData<T>,
+/// Names a node of a [`LinkedList`] for as long as that node is in the list.
+///
+/// It is only a position in the list's vector. The element type it carries is
+/// what keeps a cursor of one list from being handed to a list of another kind,
+/// and costs nothing at run time.
+pub struct ListCursor<T> {
+    index: usize,
+    /// `fn() -> T` rather than `T`, so that a cursor is `Send`, `Sync` and
+    /// `Copy` whatever the element type is: it holds no element, it names one.
+    _ghost: PhantomData<fn() -> T>,
 }
-pub type ListCursor<T> = NonNull<Node<T>>;
-type Link<T> = Option<ListCursor<T>>;
 
+impl<T> ListCursor<T> {
+    const fn new(index: usize) -> Self {
+        Self {
+            index,
+            _ghost: PhantomData,
+        }
+    }
+}
+
+// The derives would all demand `T: Trait`, which a cursor has no need of: it
+// holds an index, not an element.
+impl<T> Clone for ListCursor<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for ListCursor<T> {}
+
+impl<T> Debug for ListCursor<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ListCursor").field(&self.index).finish()
+    }
+}
+
+impl<T> PartialEq for ListCursor<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> Eq for ListCursor<T> {}
+
+impl<T> Hash for ListCursor<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+/// A slot of the list's vector: an element and the two nodes it sits between.
+///
+/// The links run by index, and the element is taken out of the slot when the
+/// node is popped, which is what marks the slot as free.
 pub struct Node<T> {
-    next: Link<T>,
-    prev: Link<T>,
-    elem: T,
+    /// the node one step towards the front, i.e. the more recently used one
+    newer: Option<usize>,
+    /// the node one step towards the back, i.e. the one used longer ago
+    older: Option<usize>,
+    /// the element, or `None` while the slot waits to be used again
+    elem: Option<T>,
+}
+
+/// A doubly linked list over a vector of nodes. See the [module
+/// documentation](self) for what it is for.
+///
+/// # Examples
+///
+/// ```
+/// use toolbox_rs::linked_list::LinkedList;
+///
+/// let mut list = LinkedList::new();
+/// list.push_front(1);
+/// list.push_front(2);
+/// list.push_front(3);
+///
+/// // the first element is the one that has waited longest
+/// assert_eq!(list.pop_back(), Some(1));
+///
+/// // unless it is asked for again before the next pop
+/// let mut list = LinkedList::new();
+/// let first = list.push_front(1);
+/// list.push_front(2);
+/// list.move_to_front(&first);
+/// assert_eq!(list.pop_back(), Some(2));
+/// ```
+pub struct LinkedList<T> {
+    nodes: Vec<Node<T>>,
+    front: Option<usize>,
+    back: Option<usize>,
+    /// the slots that pops have left behind, newest first
+    free: Vec<usize>,
+    len: usize,
 }
 
 impl<T> LinkedList<T> {
     pub fn new() -> Self {
         Self {
+            nodes: Vec::new(),
             front: None,
             back: None,
+            free: Vec::new(),
             len: 0,
-            _ghost: PhantomData,
         }
     }
 
+    /// A list that can hold `capacity` nodes before it has to grow.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            nodes: Vec::with_capacity(capacity),
+            front: None,
+            back: None,
+            free: Vec::new(),
+            len: 0,
+        }
+    }
+
+    /// Takes a slot for a new node, reusing one that a pop left behind before
+    /// growing the vector.
+    fn claim_slot(&mut self, node: Node<T>) -> usize {
+        if let Some(index) = self.free.pop() {
+            debug_assert!(self.nodes[index].elem.is_none());
+            self.nodes[index] = node;
+            return index;
+        }
+        self.nodes.push(node);
+        self.nodes.len() - 1
+    }
+
+    /// Inserts an element at the front of the list and hands back the cursor
+    /// that names it.
     pub fn push_front(&mut self, elem: T) -> ListCursor<T> {
-        // SAFETY: it's a linked-list, what do you want?
-        unsafe {
-            let new = NonNull::new_unchecked(Box::into_raw(Box::new(Node {
-                next: None,
-                prev: None,
-                elem,
-            })));
-            if let Some(old) = self.front {
-                // Put the new front before the old one
-                (*old.as_ptr()).next = Some(new);
-                (*new.as_ptr()).prev = Some(old);
-            } else {
-                // If there's no front, then we're the empty list and need
-                // to set the back too.
-                self.back = Some(new);
-            }
-            // These things always happen!
-            self.front = Some(new);
-            self.len += 1;
+        let index = self.claim_slot(Node {
+            newer: None,
+            older: self.front,
+            elem: Some(elem),
+        });
 
-            new
+        match self.front {
+            Some(old_front) => self.nodes[old_front].newer = Some(index),
+            // an empty list gains a back as well as a front
+            None => self.back = Some(index),
         }
+        self.front = Some(index);
+        self.len += 1;
+
+        ListCursor::new(index)
     }
 
-    pub fn move_to_front(&mut self, b: &ListCursor<T>) {
-        if self.is_empty() {
+    /// Moves the node a cursor names to the front of the list.
+    ///
+    /// Does nothing if the list is empty or the node is already at the front.
+    pub fn move_to_front(&mut self, cursor: &ListCursor<T>) {
+        if self.is_empty() || self.front == Some(cursor.index) {
             return;
         }
+        let index = cursor.index;
+        debug_assert!(
+            self.nodes[index].elem.is_some(),
+            "the node this cursor names has been popped"
+        );
 
-        if let Some(front) = self.front {
-            // Is node B already in front?
-            if front == *b {
-                return;
-            }
+        // close the gap the node leaves behind
+        let newer = self.nodes[index].newer;
+        let older = self.nodes[index].older;
+        if let Some(newer) = newer {
+            self.nodes[newer].older = older;
+        }
+        if let Some(older) = older {
+            self.nodes[older].newer = newer;
+        }
+        if self.back == Some(index) {
+            // the node was the one that had waited longest, so whatever sat in
+            // front of it has now
+            debug_assert!(older.is_none());
+            self.back = newer;
         }
 
-        // SAFETY: it's a linked-list, what do you want?
-        unsafe {
-            // cut node b from list by short-cutting a<->c
-            let a = (*b.as_ptr()).next;
-            (*a.unwrap().as_ptr()).prev = (*b.as_ptr()).prev;
-            if let Some(c) = (*b.as_ptr()).prev {
-                (*c.as_ptr()).next = (*b.as_ptr()).next;
-            }
-
-            // if the last element is moved to front, then update it with the next element in row
-            if self.back.unwrap() == *b {
-                debug_assert!((*b.as_ptr()).prev.is_none());
-                self.back = a;
-            }
-        }
-
-        // SAFETY: it's a linked-list, what do you want?
-        unsafe {
-            // move now-floating node b to the front of the linked list
-            let x = self.front;
-
-            (*b.as_ptr()).prev = x;
-            (*b.as_ptr()).next = None;
-            (*x.unwrap().as_ptr()).next = Some(*b);
-            self.front = Some(*b);
-        }
+        // and put it in front of what used to be the front. The list is not
+        // empty and the node is not the front, so there is one.
+        let front = self.front.expect("a list that is not empty has a front");
+        self.nodes[index].newer = None;
+        self.nodes[index].older = Some(front);
+        self.nodes[front].newer = Some(index);
+        self.front = Some(index);
     }
 
+    /// Removes the element at the back of the list, i.e. the one that has gone
+    /// longest without being asked for.
     pub fn pop_back(&mut self) -> Option<T> {
-        unsafe {
-            // Only have to do stuff if there is a back node to pop.
-            self.back.map(|node| {
-                // Bring the Box front to life so we can move out its value and
-                // Drop it (Box continues to magically understand this for us).
-                let boxed_node = Box::from_raw(node.as_ptr());
-                let result = boxed_node.elem;
+        let index = self.back?;
+        let elem = self.nodes[index]
+            .elem
+            .take()
+            .expect("a node in the list holds an element");
 
-                // Make the next node into the new back.
-                self.back = boxed_node.next;
-                if let Some(new) = self.back {
-                    // Cleanup its reference to the removed node
-                    (*new.as_ptr()).prev = None;
-                } else {
-                    // If the back is now null, then this list is now empty!
-                    self.front = None;
-                }
-
-                self.len -= 1;
-                result
-                // Box gets implicitly freed here, knows there is no T.
-            })
+        self.back = self.nodes[index].newer;
+        match self.back {
+            Some(new_back) => self.nodes[new_back].older = None,
+            // the list has run empty, so it has no front either
+            None => self.front = None,
         }
+
+        self.nodes[index].newer = None;
+        self.nodes[index].older = None;
+        self.free.push(index);
+        self.len -= 1;
+
+        Some(elem)
+    }
+
+    /// The element a cursor names, or `None` once its node has been popped.
+    ///
+    /// A slot that a later push has taken over holds that push's element, which
+    /// is why a cursor is only worth keeping while its node is in the list.
+    pub fn get(&self, cursor: &ListCursor<T>) -> Option<&T> {
+        self.nodes.get(cursor.index)?.elem.as_ref()
     }
 
     pub fn len(&self) -> usize {
@@ -142,25 +265,39 @@ impl<T> LinkedList<T> {
         self.len == 0
     }
 
+    /// Empties the list, keeping the room it has already taken so that filling
+    /// it again does not allocate.
     pub fn clear(&mut self) {
-        // Oh look it's drop again
-        while self.pop_back().is_some() {}
+        self.nodes.clear();
+        self.free.clear();
+        self.front = None;
+        self.back = None;
+        self.len = 0;
     }
 
+    /// The element at the front, i.e. the one most recently pushed or moved
+    /// there.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the list is empty.
     pub fn get_front(&self) -> &T {
-        // TODO: decide whether this returns a reference or a copy
-        unsafe { &self.front.unwrap().as_ref().elem }
+        let front = self.front.expect("an empty list has no front");
+        self.nodes[front]
+            .elem
+            .as_ref()
+            .expect("a node in the list holds an element")
     }
 
+    /// # Panics
+    ///
+    /// Panics if the list is empty.
     pub fn get_front_mut(&mut self) -> &mut T {
-        // SAFETY: get_front() already ensures front exists and is valid
-        unsafe { &mut self.front.unwrap().as_mut().elem }
-    }
-}
-
-impl<T> Drop for LinkedList<T> {
-    fn drop(&mut self) {
-        self.clear()
+        let front = self.front.expect("an empty list has no front");
+        self.nodes[front]
+            .elem
+            .as_mut()
+            .expect("a node in the list holds an element")
     }
 }
 
@@ -172,7 +309,16 @@ impl<T> Default for LinkedList<T> {
 
 #[cfg(test)]
 mod test {
-    use super::LinkedList;
+    use super::{LinkedList, ListCursor};
+
+    /// Reads the list from the back, which is the order the pops come in.
+    fn drained<T>(list: &mut LinkedList<T>) -> Vec<T> {
+        let mut result = Vec::new();
+        while let Some(element) = list.pop_back() {
+            result.push(element);
+        }
+        result
+    }
 
     #[test]
     fn default_init_cursor_noop() {
@@ -241,12 +387,7 @@ mod test {
 
         list.push_front(0);
 
-        let mut result = Vec::new();
-        while let Some(element) = list.pop_back() {
-            result.push(element);
-        }
-
-        assert_eq!(result, vec![5, 4, 3, 2, 1, 0]);
+        assert_eq!(drained(&mut list), vec![5, 4, 3, 2, 1, 0]);
     }
 
     #[test]
@@ -265,18 +406,13 @@ mod test {
         handles.push(list.push_front(4));
         handles.push(list.push_front(3));
 
-        handles.sort_by_key(|h| unsafe { h.as_ref().elem });
+        handles.sort_by_key(|handle| *list.get(handle).expect("handle went stale"));
 
         handles.iter().for_each(|handle| {
             list.move_to_front(handle);
         });
 
-        let mut result = Vec::new();
-        while let Some(element) = list.pop_back() {
-            result.push(element);
-        }
-
-        assert_eq!(result, vec![1, 2, 3, 4, 5]);
+        assert_eq!(drained(&mut list), vec![1, 2, 3, 4, 5]);
     }
 
     #[test]
@@ -309,5 +445,122 @@ mod test {
 
         // Verify other elements are unchanged
         assert_eq!(list.pop_back(), Some(20));
+    }
+
+    #[test]
+    fn moving_the_back_to_the_front_leaves_the_back_behind_it() {
+        let mut list = LinkedList::new();
+        let oldest = list.push_front(1);
+        list.push_front(2);
+        list.push_front(3);
+
+        list.move_to_front(&oldest);
+
+        // 2 has become the one that has waited longest
+        assert_eq!(list.get_front(), &1);
+        assert_eq!(drained(&mut list), vec![2, 3, 1]);
+    }
+
+    #[test]
+    fn moving_the_front_to_the_front_changes_nothing() {
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        let front = list.push_front(2);
+
+        list.move_to_front(&front);
+
+        assert_eq!(list.len(), 2);
+        assert_eq!(drained(&mut list), vec![1, 2]);
+    }
+
+    #[test]
+    fn moving_a_node_out_of_the_middle_joins_its_neighbours() {
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        let middle = list.push_front(2);
+        list.push_front(3);
+
+        list.move_to_front(&middle);
+
+        assert_eq!(drained(&mut list), vec![1, 3, 2]);
+    }
+
+    #[test]
+    fn a_popped_slot_is_used_again_rather_than_grown_into() {
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        list.push_front(2);
+        assert_eq!(list.pop_back(), Some(1));
+        assert_eq!(list.pop_back(), Some(2));
+
+        // both slots are free, so filling the list again reuses them
+        list.push_front(3);
+        list.push_front(4);
+        assert_eq!(list.nodes.len(), 2);
+        assert_eq!(drained(&mut list), vec![3, 4]);
+    }
+
+    #[test]
+    fn a_cursor_whose_node_was_popped_holds_nothing() {
+        let mut list = LinkedList::new();
+        let cursor = list.push_front(1);
+        assert_eq!(list.get(&cursor), Some(&1));
+
+        assert_eq!(list.pop_back(), Some(1));
+        assert_eq!(list.get(&cursor), None);
+    }
+
+    #[test]
+    fn clear_empties_the_list() {
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        list.push_front(2);
+
+        list.clear();
+
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
+        assert_eq!(list.pop_back(), None);
+        // and it can be filled again afterwards
+        list.push_front(3);
+        assert_eq!(list.get_front(), &3);
+    }
+
+    #[test]
+    fn a_list_of_elements_that_are_not_copy_is_still_a_list() {
+        let mut list = LinkedList::new();
+        list.push_front("first".to_owned());
+        let second = list.push_front("second".to_owned());
+
+        // a cursor is Copy even when the element it names is not
+        let also_second: ListCursor<String> = second;
+        list.move_to_front(&also_second);
+
+        assert_eq!(list.get_front(), "second");
+        assert_eq!(drained(&mut list), vec!["first", "second"]);
+    }
+
+    /// The list is only worth having if it can be handed to another thread,
+    /// which is what the whole module is indexed rather than pointed at for.
+    #[test]
+    fn a_list_and_its_cursors_can_be_sent_between_threads() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<LinkedList<usize>>();
+        assert_sync::<LinkedList<usize>>();
+        assert_send::<ListCursor<usize>>();
+        assert_sync::<ListCursor<usize>>();
+
+        let mut list = LinkedList::new();
+        list.push_front(1);
+        let moved = std::thread::spawn(move || {
+            let mut list = list;
+            list.push_front(2);
+            drained(&mut list)
+        })
+        .join()
+        .expect("the thread holding the list panicked");
+        assert_eq!(moved, vec![1, 2]);
     }
 }


### PR DESCRIPTION
`LinkedList` joined its nodes with raw pointers. That cost `unsafe` on every
link, and it cost `Send`: a `NonNull` is not `Send`, so neither the list nor the
`LRU` built on it could be shared between threads. The tile server wants one
cache of drawn tiles across its workers, and `Mutex<LRU<..>>` does not compile.

The nodes now live in one `Vec` and refer to each other by index. `push_front`,
`pop_back` and `move_to_front` stay constant time. A popped node leaves its slot
on a free list for the next push, so a list held at a capacity stops allocating.
The module is safe code and `Drop` is gone with the boxes.

A cursor is an index in a newtype, not a bare `usize`, so a cursor of one list
cannot be passed to a list of another element type. Its phantom is `fn() -> T`,
which keeps the cursor `Copy`, `Send` and `Sync` for any `T`. The traits are
written out rather than derived, because the derives would require them of `T`.

A cursor whose node was popped no longer causes undefined behaviour. While the
slot is free, `get` returns `None` and `move_to_front` does nothing. Once a later
push takes the slot over, the cursor names that push's element. `LRU` never hits
either case, because it drops a handle when it evicts the key.

Left for later: `LRU::new_with_capacity` still calls `LinkedList::new()`, so the
cache grows into its capacity instead of reserving it. `LinkedList::with_capacity`
is there when someone wants to wire it through.

Tests: the existing tests pass unchanged, except the one that read an element
through a cursor with `unsafe`, which now uses the new `get`. Added tests cover
moving the back, the front and the middle, reuse of a freed slot, a stale cursor,
a cursor kept across a clear, clearing and refilling, a non-`Copy` element type,
and sending a list to another thread.

Written with agent assistance.
