### PR TITLE
Let a tree be told which measure to search in

### DIFF
--- a/src/bounding_box.rs
+++ b/src/bounding_box.rs
@@ -130,20 +130,29 @@ impl BoundingBox {
         if self.contains(coordinate) {
             return 0.;
         }
+        self.nearest_point(coordinate).distance_to(coordinate)
+    }
 
-        // The point of the box nearest the coordinate, which is a corner only
-        // when the coordinate lies past one. Beside an edge it is the point on
-        // that edge level with the coordinate, and asking the corners alone
-        // hands back half the length of the edge for a coordinate that sits
-        // right up against the middle of it. That is not merely a loose
-        // answer: a nearest first walk keys its nodes on this, and a key that
-        // overshoots what lies under the node hands out a far element before a
-        // near one.
-        let nearest = FPCoordinate::new(
+    /// The point of the box nearest the coordinate, taken axis by axis.
+    ///
+    /// It is a corner only when the coordinate lies past one. Beside an edge
+    /// it is the point on that edge level with the coordinate, and asking the
+    /// corners alone hands back half the length of the edge for a coordinate
+    /// that sits right up against the middle of it. That is not merely a loose
+    /// answer: a nearest first walk keys its nodes on this, and a key that
+    /// overshoots what lies under the node hands out a far element before a
+    /// near one.
+    ///
+    /// Clamping each axis in turn is the nearest point of a rectangle in the
+    /// plane. It is not the nearest point of the patch of a sphere the same
+    /// four numbers describe, so a measure taken over the sphere still reads a
+    /// little long from here.
+    #[must_use]
+    pub fn nearest_point(&self, coordinate: &FPCoordinate) -> FPCoordinate {
+        FPCoordinate::new(
             coordinate.lat.max(self.min.lat).min(self.max.lat),
             coordinate.lon.max(self.min.lon).min(self.max.lon),
-        );
-        nearest.distance_to(coordinate)
+        )
     }
 
     pub fn is_valid(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod mercator;
 pub mod merge_entry;
 pub mod merge_tree;
 pub mod metis;
+pub mod metric;
 pub mod mvt;
 pub mod one_iterator;
 pub mod one_to_many_dijkstra;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,0 +1,155 @@
+//! The measure a spatial search works in.
+//!
+//! A search that hands out elements nearest first needs two numbers: how far
+//! away a thing is, and how far away the nearest thing under a box could
+//! possibly be. The walk keys every node on the second and opens the queue in
+//! order, which is only right while the second is never larger than the first
+//! for anything under that node. A key that overshoots holds a whole subtree
+//! back behind elements that are further away.
+//!
+//! The two therefore have to agree, and keeping them in separate places is how
+//! they stop agreeing: measuring in one and bounding in another is a pairing
+//! nothing checks. A metric holds both, so the pairing is a property of the
+//! implementation rather than a coincidence between two modules.
+
+use crate::{bounding_box::BoundingBox, geometry::FPCoordinate};
+
+/// How far apart two points are, and how near a box could be.
+///
+/// # Contract
+///
+/// `min_distance(box, p)` must never exceed `distance(q, p)` for any point `q`
+/// of the box. Being under is allowed and only costs a node opened too early;
+/// being over is what puts the answers in the wrong order.
+pub trait Metric {
+    /// How far apart two points are.
+    fn distance(first: &FPCoordinate, second: &FPCoordinate) -> f64;
+
+    /// How near the box could be, which is never further than anything in it.
+    fn min_distance(bbox: &BoundingBox, coordinate: &FPCoordinate) -> f64;
+}
+
+/// Great-circle distance over a sphere, in kilometres.
+///
+/// The bound is the distance to the box's nearest point taken axis by axis,
+/// which is the nearest point of a flat rectangle and not of a spherical one:
+/// it can read too large beside a long meridian, over a pole, and across the
+/// antimeridian, which breaks the contract above. See the tracking issue on
+/// `min_distance`. It is the measure the tree has always used and the bound it
+/// has always used, kept together here so the mismatch has somewhere to be
+/// fixed.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Haversine;
+
+impl Metric for Haversine {
+    fn distance(first: &FPCoordinate, second: &FPCoordinate) -> f64 {
+        first.distance_to(second)
+    }
+
+    fn min_distance(bbox: &BoundingBox, coordinate: &FPCoordinate) -> f64 {
+        bbox.min_distance(coordinate)
+    }
+}
+
+/// Straight-line distance treating latitude and longitude as a plane, in the
+/// fixed-point units the coordinates are held in rather than in metres.
+///
+/// Nothing on a sphere is being approximated here, so a degree of longitude
+/// counts the same at the equator and at the pole. That makes it the wrong
+/// measure for ground distance and the right one for data already projected,
+/// for an ordering that only has to be consistent, and for a test that wants
+/// an answer it can work out by hand.
+///
+/// Its bound is exact: clamping each axis in turn does give the nearest point
+/// of a rectangle in the plane.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Planar;
+
+impl Metric for Planar {
+    fn distance(first: &FPCoordinate, second: &FPCoordinate) -> f64 {
+        let lat = f64::from(first.lat) - f64::from(second.lat);
+        let lon = f64::from(first.lon) - f64::from(second.lon);
+        lat.hypot(lon)
+    }
+
+    fn min_distance(bbox: &BoundingBox, coordinate: &FPCoordinate) -> f64 {
+        Self::distance(&bbox.nearest_point(coordinate), coordinate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn box_of(min_lat: i32, min_lon: i32, max_lat: i32, max_lon: i32) -> BoundingBox {
+        BoundingBox::from_coordinates(&[
+            FPCoordinate::new(min_lat, min_lon),
+            FPCoordinate::new(max_lat, max_lon),
+        ])
+    }
+
+    #[test]
+    fn a_point_of_the_box_is_no_nearer_than_the_bound_says() {
+        let bbox = box_of(0, 0, 100, 200);
+        for lat in [-50, 0, 50, 100, 150] {
+            for lon in [-50, 0, 100, 200, 300] {
+                let coordinate = FPCoordinate::new(lat, lon);
+                let bound = Planar::min_distance(&bbox, &coordinate);
+                for corner_lat in [0, 50, 100] {
+                    for corner_lon in [0, 100, 200] {
+                        let inside = FPCoordinate::new(corner_lat, corner_lon);
+                        assert!(
+                            bound <= Planar::distance(&inside, &coordinate) + 1e-9,
+                            "bound {bound} beats {inside:?} from {coordinate:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_planar_bound_is_the_nearest_point_and_not_a_corner() {
+        // beside the middle of a long edge, where the nearest corner is far
+        // along it and the nearest point is straight across
+        let bbox = box_of(0, 0, 1000, 10);
+        let beside = FPCoordinate::new(500, -10);
+        assert!((Planar::min_distance(&bbox, &beside) - 10.).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_point_inside_the_box_is_no_distance_from_it() {
+        let bbox = box_of(0, 0, 100, 100);
+        let inside = FPCoordinate::new(50, 50);
+        assert_eq!(Planar::min_distance(&bbox, &inside), 0.);
+        assert_eq!(Haversine::min_distance(&bbox, &inside), 0.);
+    }
+
+    #[test]
+    fn the_planar_measure_counts_a_degree_the_same_everywhere() {
+        // what the haversine does not do, and the reason to have both
+        let equator = Planar::distance(&FPCoordinate::new(0, 0), &FPCoordinate::new(0, 1_000_000));
+        let far_north = Planar::distance(
+            &FPCoordinate::new(80_000_000, 0),
+            &FPCoordinate::new(80_000_000, 1_000_000),
+        );
+        assert_eq!(equator, far_north);
+        assert!(
+            Haversine::distance(&FPCoordinate::new(0, 0), &FPCoordinate::new(0, 1_000_000))
+                > 4. * Haversine::distance(
+                    &FPCoordinate::new(80_000_000, 0),
+                    &FPCoordinate::new(80_000_000, 1_000_000)
+                )
+        );
+    }
+
+    #[test]
+    fn the_haversine_metric_is_what_the_coordinates_already_answer() {
+        let first = FPCoordinate::new_from_lat_lon(50.1, 8.6);
+        let second = FPCoordinate::new_from_lat_lon(48.1, 11.5);
+        assert_eq!(
+            Haversine::distance(&first, &second),
+            first.distance_to(&second)
+        );
+    }
+}

--- a/src/r_tree.rs
+++ b/src/r_tree.rs
@@ -1,13 +1,16 @@
 use log::debug;
 use num::integer::Roots;
-use std::{cmp::Ordering, collections::BinaryHeap};
+use std::{cmp::Ordering, collections::BinaryHeap, marker::PhantomData};
 use thiserror::Error;
 
 const BRANCHING_FACTOR: usize = 30;
 const LEAF_PACK_FACTOR: usize = 30;
 
 use crate::{
-    bounding_box::BoundingBox, geometry::FPCoordinate, partition_id::PartitionID,
+    bounding_box::BoundingBox,
+    geometry::FPCoordinate,
+    metric::{Haversine, Metric},
+    partition_id::PartitionID,
     space_filling_curve::zorder_cmp,
 };
 
@@ -27,7 +30,7 @@ pub struct Leaf<T> {
     elements: Vec<T>,
 }
 
-impl<T: RTreeElement> Leaf<T> {
+impl<T> Leaf<T> {
     pub fn new(bbox: BoundingBox, elements: Vec<T>) -> Self {
         Self { bbox, elements }
     }
@@ -126,11 +129,17 @@ impl Ord for QueueElement {
 }
 
 /// Trait for elements that can be stored in an RTree
-pub trait RTreeElement {
+///
+/// The element is written against the measure the tree searches in, so that
+/// how far away an element is and how near a box could be are answers in the
+/// same units. An element with nothing of its own to say can hand the work
+/// straight to `M`.
+pub trait RTreeElement<M: Metric = Haversine> {
     /// Returns the bounding box of this element
     fn bbox(&self) -> BoundingBox;
 
-    /// Returns the distance from this element to the given coordinate
+    /// Returns the distance from this element to the given coordinate,
+    /// measured the way `M` measures
     fn distance_to(&self, coordinate: &FPCoordinate) -> f64;
 
     /// Returns the center coordinate of this element
@@ -138,12 +147,15 @@ pub trait RTreeElement {
 }
 
 #[derive(Debug)]
-pub struct RTree<T: RTreeElement> {
+pub struct RTree<T, M: Metric = Haversine> {
     leaf_nodes: Vec<Leaf<T>>,
     search_nodes: Vec<SearchNode>,
+    /// the measure the tree was packed and is searched in, which is a choice
+    /// rather than a value and so takes up no room
+    metric: PhantomData<M>,
 }
 
-impl<T: RTreeElement + std::clone::Clone> RTree<T> {
+impl<T: RTreeElement<M> + std::clone::Clone, M: Metric> RTree<T, M> {
     /// Creates a new R-tree from an iterator of elements.
     ///
     /// # Arguments
@@ -172,6 +184,7 @@ impl<T: RTreeElement + std::clone::Clone> RTree<T> {
             return RTree {
                 leaf_nodes: Vec::new(),
                 search_nodes: Vec::new(),
+                metric: PhantomData,
             };
         }
         debug!("sorting by z-order");
@@ -260,11 +273,15 @@ impl<T: RTreeElement + std::clone::Clone> RTree<T> {
         RTree {
             leaf_nodes,
             search_nodes,
+            metric: PhantomData,
         }
     }
 
     /// Returns an iterator over elements in ascending order of distance from the given coordinate
-    pub fn nearest_iter<'a>(&'a self, coordinate: &'a FPCoordinate) -> RTreeNearestIterator<'a, T> {
+    pub fn nearest_iter<'a>(
+        &'a self,
+        coordinate: &'a FPCoordinate,
+    ) -> RTreeNearestIterator<'a, T, M> {
         RTreeNearestIterator::new(self, coordinate)
     }
 
@@ -283,15 +300,18 @@ impl<T: RTreeElement + std::clone::Clone> RTree<T> {
     /// the nearest part of it, so a large element whose middle lies far off
     /// comes late or not at all. A cell of a partition that covers a country is
     /// exactly that element.
-    pub fn intersecting<'a>(&'a self, bbox: &'a BoundingBox) -> RTreeIntersectionIterator<'a, T> {
+    pub fn intersecting<'a>(
+        &'a self,
+        bbox: &'a BoundingBox,
+    ) -> RTreeIntersectionIterator<'a, T, M> {
         RTreeIntersectionIterator::new(self, bbox)
     }
 }
 
 /// Walks the elements whose box shares ground with the one asked about.
 #[derive(Debug)]
-pub struct RTreeIntersectionIterator<'a, T: RTreeElement> {
-    tree: &'a RTree<T>,
+pub struct RTreeIntersectionIterator<'a, T, M: Metric = Haversine> {
+    tree: &'a RTree<T, M>,
     bbox: &'a BoundingBox,
     /// the subtrees still to look at
     stack: Vec<SearchNode>,
@@ -301,8 +321,8 @@ pub struct RTreeIntersectionIterator<'a, T: RTreeElement> {
     leaf: Option<(usize, usize)>,
 }
 
-impl<'a, T: RTreeElement> RTreeIntersectionIterator<'a, T> {
-    fn new(tree: &'a RTree<T>, bbox: &'a BoundingBox) -> Self {
+impl<'a, T: RTreeElement<M>, M: Metric> RTreeIntersectionIterator<'a, T, M> {
+    fn new(tree: &'a RTree<T, M>, bbox: &'a BoundingBox) -> Self {
         let mut stack = Vec::new();
         if let Some(&root) = tree.search_nodes.last() {
             stack.push(root);
@@ -317,7 +337,7 @@ impl<'a, T: RTreeElement> RTreeIntersectionIterator<'a, T> {
     }
 }
 
-impl<'a, T: RTreeElement> Iterator for RTreeIntersectionIterator<'a, T> {
+impl<'a, T: RTreeElement<M>, M: Metric> Iterator for RTreeIntersectionIterator<'a, T, M> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -372,13 +392,13 @@ impl<'a, T: RTreeElement> Iterator for RTreeIntersectionIterator<'a, T> {
 }
 
 // Implement RTreeElement for the original (FPCoordinate, PartitionID) tuple
-impl RTreeElement for (FPCoordinate, PartitionID) {
+impl<M: Metric> RTreeElement<M> for (FPCoordinate, PartitionID) {
     fn bbox(&self) -> BoundingBox {
         BoundingBox::from_coordinate(&self.0)
     }
 
     fn distance_to(&self, coordinate: &FPCoordinate) -> f64 {
-        self.0.distance_to(coordinate)
+        M::distance(&self.0, coordinate)
     }
 
     fn center(&self) -> &FPCoordinate {
@@ -387,14 +407,14 @@ impl RTreeElement for (FPCoordinate, PartitionID) {
 }
 
 #[derive(Debug)]
-pub struct RTreeNearestIterator<'a, T: RTreeElement> {
-    tree: &'a RTree<T>,
+pub struct RTreeNearestIterator<'a, T, M: Metric = Haversine> {
+    tree: &'a RTree<T, M>,
     input_coordinate: &'a FPCoordinate,
     queue: BinaryHeap<QueueElement>,
 }
 
-impl<'a, T: RTreeElement> RTreeNearestIterator<'a, T> {
-    fn new(tree: &'a RTree<T>, input_coordinate: &'a FPCoordinate) -> Self {
+impl<'a, T: RTreeElement<M>, M: Metric> RTreeNearestIterator<'a, T, M> {
+    fn new(tree: &'a RTree<T, M>, input_coordinate: &'a FPCoordinate) -> Self {
         let capacity = (tree.leaf_nodes.len() * LEAF_PACK_FACTOR).sqrt();
         let mut queue = BinaryHeap::with_capacity(capacity);
 
@@ -403,14 +423,14 @@ impl<'a, T: RTreeElement> RTreeNearestIterator<'a, T> {
             match last_node {
                 SearchNode::TreeNode(root) => {
                     queue.push(QueueElement::new(
-                        root.bbox.min_distance(input_coordinate),
+                        M::min_distance(&root.bbox, input_coordinate),
                         root.index,
                         QueueNodeType::TreeNode(root.children),
                     ));
                 }
                 SearchNode::LeafNode(leaf) => {
                     queue.push(QueueElement::new(
-                        leaf.bbox.min_distance(input_coordinate),
+                        M::min_distance(&leaf.bbox, input_coordinate),
                         leaf.index,
                         QueueNodeType::LeafNode,
                     ));
@@ -426,7 +446,7 @@ impl<'a, T: RTreeElement> RTreeNearestIterator<'a, T> {
     }
 }
 
-impl<T: RTreeElement + Clone> Iterator for RTreeNearestIterator<'_, T> {
+impl<T: RTreeElement<M> + Clone, M: Metric> Iterator for RTreeNearestIterator<'_, T, M> {
     /// Returns the next nearest element and its distance from the query point.
     /// Elements are returned in ascending order of distance.
     ///
@@ -447,12 +467,12 @@ impl<T: RTreeElement + Clone> Iterator for RTreeNearestIterator<'_, T> {
                     for i in 0..children {
                         match &self.tree.search_nodes[child_start_index + i] {
                             SearchNode::LeafNode(node) => self.queue.push(QueueElement::new(
-                                node.bbox.min_distance(self.input_coordinate),
+                                M::min_distance(&node.bbox, self.input_coordinate),
                                 node.index,
                                 QueueNodeType::LeafNode,
                             )),
                             SearchNode::TreeNode(node) => self.queue.push(QueueElement::new(
-                                node.bbox.min_distance(self.input_coordinate),
+                                M::min_distance(&node.bbox, self.input_coordinate),
                                 node.index,
                                 QueueNodeType::TreeNode(node.children),
                             )),
@@ -494,6 +514,7 @@ mod tests {
     use super::*;
     use crate::bounding_box::BoundingBox;
     use crate::geometry::FPCoordinate;
+    use crate::metric::Planar;
     use crate::partition_id::PartitionID;
 
     #[derive(Clone, Debug, PartialEq)]
@@ -574,6 +595,9 @@ mod tests {
         let coord = FPCoordinate::new_from_lat_lon(3.0, 4.0);
         let pid = PartitionID(7);
         let tuple = (coord, pid);
+        // the tuple answers for whatever measure it is asked about, so the
+        // measure has to be named here where no tree is naming it
+        let tuple = &tuple as &dyn RTreeElement<Haversine>;
         assert_eq!(tuple.bbox(), BoundingBox::from_coordinate(&coord));
         assert_eq!(tuple.center(), &coord);
         let origin = FPCoordinate::new_from_lat_lon(0.0, 0.0);
@@ -777,12 +801,22 @@ mod tests {
         name: usize,
     }
 
-    impl RTreeElement for Patch {
-        fn bbox(&self) -> BoundingBox {
+    impl Patch {
+        /// The same box the trait hands back, reachable without naming a
+        /// measure, as the box does not depend on one.
+        fn box_of(&self) -> BoundingBox {
             BoundingBox::from_coordinates(&[self.low, self.high])
         }
+    }
+
+    impl<M: Metric> RTreeElement<M> for Patch {
+        fn bbox(&self) -> BoundingBox {
+            self.box_of()
+        }
         fn distance_to(&self, coordinate: &FPCoordinate) -> f64 {
-            self.bbox().min_distance(coordinate)
+            // a patch has extent, so it is as far away as its nearest part,
+            // and it asks the same measure the tree keys its nodes on
+            M::min_distance(&self.box_of(), coordinate)
         }
         fn center(&self) -> &FPCoordinate {
             &self.center
@@ -811,14 +845,14 @@ mod tests {
     fn found_by_hand(patches: &[Patch], bbox: &BoundingBox) -> Vec<usize> {
         let mut names = patches
             .iter()
-            .filter(|patch| patch.bbox().intersects(bbox))
+            .filter(|patch| patch.box_of().intersects(bbox))
             .map(|patch| patch.name)
             .collect::<Vec<_>>();
         names.sort_unstable();
         names
     }
 
-    fn found_by_tree(tree: &RTree<Patch>, bbox: &BoundingBox) -> Vec<usize> {
+    fn found_by_tree<M: Metric>(tree: &RTree<Patch, M>, bbox: &BoundingBox) -> Vec<usize> {
         let mut names = tree
             .intersecting(bbox)
             .map(|patch| patch.name)
@@ -840,7 +874,7 @@ mod tests {
             patch(1, 100, 100, 110, 110),
             patch(2, 5, 5, 200, 200),
         ];
-        let tree = RTree::from_elements(patches.clone());
+        let tree: RTree<Patch> = RTree::from_elements(patches.clone());
 
         // over the first patch only, though the third reaches across it
         assert_eq!(found_by_tree(&tree, &window(0, 0, 1, 1)), vec![0]);
@@ -861,7 +895,7 @@ mod tests {
             patch(0, -1000, -1000, 1000, 1000),
             patch(1, 900, 900, 901, 901),
         ];
-        let tree = RTree::from_elements(patches);
+        let tree: RTree<Patch> = RTree::from_elements(patches);
 
         let corner = window(995, 995, 999, 999);
         assert_eq!(found_by_tree(&tree, &corner), vec![0]);
@@ -884,7 +918,7 @@ mod tests {
                     patch(name, lat, lon, lat + height, lon + width)
                 })
                 .collect::<Vec<_>>();
-            let tree = RTree::from_elements(patches.clone());
+            let tree: RTree<Patch> = RTree::from_elements(patches.clone());
 
             for _ in 0..20 {
                 let lat = rng.random_range(-1200..1200);
@@ -909,7 +943,7 @@ mod tests {
                 patch(name, at, at, at + 3, at + 3)
             })
             .collect::<Vec<_>>();
-        let tree = RTree::from_elements(patches.clone());
+        let tree: RTree<Patch> = RTree::from_elements(patches.clone());
 
         let everywhere = window(-10_000, -10_000, 10_000, 10_000);
         let found = found_by_tree(&tree, &everywhere);
@@ -919,7 +953,7 @@ mod tests {
 
     #[test]
     fn an_empty_tree_has_nothing_to_walk() {
-        let tree = RTree::from_elements(Vec::<Patch>::new());
+        let tree: RTree<Patch> = RTree::from_elements(Vec::new());
         assert!(
             tree.nearest_iter(&FPCoordinate::new(0, 0)).next().is_none(),
             "a tree of nothing hands back nothing"
@@ -930,6 +964,66 @@ mod tests {
     /// a leaf and thirty leaves under the one node above them. Everything below
     /// this line is about what happens when there is more than that, which is
     /// the descent itself, and it went untested until this was written.
+    /// The measure is a choice, and the two that come with the tree disagree
+    /// about the ground: a degree of longitude is a degree wherever it is
+    /// taken in the plane, and shrinks towards the poles on the sphere.
+    #[test]
+    fn a_tree_can_be_searched_in_a_measure_of_its_own() {
+        let (patches, _) = deep_tree();
+        let planar: RTree<Patch, Planar> = RTree::from_elements(patches.clone());
+        let from = FPCoordinate::new(717, 1131);
+
+        let mut last = 0.;
+        let mut seen = 0;
+        for (_, distance) in planar.nearest_iter(&from) {
+            assert!(distance >= last, "{distance} came after {last}");
+            last = distance;
+            seen += 1;
+        }
+        assert_eq!(seen, patches.len(), "the walk has to reach every patch");
+    }
+
+    /// The bound the planar measure hands back is the nearest point of the
+    /// box and not merely near it, so the order is right for a tree of any
+    /// depth rather than right for the shallow ones. This is the whole reason
+    /// the bound travels with the measure that uses it.
+    #[test]
+    fn a_deep_walk_in_an_exact_measure_comes_out_in_order() {
+        let (patches, _) = deeper_tree();
+        let planar: RTree<Patch, Planar> = RTree::from_elements(patches);
+        let from = FPCoordinate::new(1234, 5678);
+
+        let mut last = 0.;
+        for (_, distance) in planar.nearest_iter(&from) {
+            assert!(distance >= last, "{distance} came after {last}");
+            last = distance;
+        }
+    }
+
+    /// A window is a question about ground rather than about distance, so the
+    /// two measures have to give the same answer down to the element.
+    #[test]
+    fn the_window_query_does_not_depend_on_the_measure() {
+        let (patches, haversine) = deep_tree();
+        let planar: RTree<Patch, Planar> = RTree::from_elements(patches.clone());
+
+        for bbox in [
+            window(0, 0, 100, 100),
+            window(-500, -500, 60, 60),
+            window(400, 700, 460, 780),
+            window(-10_000, -10_000, 10_000, 10_000),
+        ] {
+            assert_eq!(
+                found_by_tree(&haversine, &bbox),
+                found_by_tree(&planar, &bbox)
+            );
+            assert_eq!(
+                found_by_hand(&patches, &bbox),
+                found_by_tree(&planar, &bbox)
+            );
+        }
+    }
+
     fn deep_tree() -> (Vec<Patch>, RTree<Patch>) {
         let patches = (0..5000)
             .map(|name| {
@@ -1008,7 +1102,7 @@ mod tests {
         let mut seen = 0;
         for (patch, distance) in tree.nearest_iter(&from).take(200) {
             assert!(distance >= last, "{distance} came after {last}");
-            assert!(patch.distance_to(&from) >= 0.0);
+            assert!(RTreeElement::<Haversine>::distance_to(&patch, &from) >= 0.0);
             last = distance;
             seen += 1;
         }


### PR DESCRIPTION
A nearest-first walk needs two numbers that agree: how far away an element is, and how near the nearest thing under a box could possibly be. It keys every node on the second and opens the queue in order, which is sound only while the second never exceeds the first for anything under that node.

Those two numbers lived in different places and nothing made them agree. `BoundingBox::min_distance` was fixed on the haversine, while `RTreeElement::distance_to` let every element measure however it liked. `Patch` and `CellBox` happen to delegate to `min_distance`, so they agree by luck; an element measuring in the plane against nodes keyed on the sphere compiles cleanly and hands the answers out in the wrong order, with nothing to say so.

A metric holds both, so the pairing is a property of the implementation:

```rust
pub trait Metric {
    fn distance(first: &FPCoordinate, second: &FPCoordinate) -> f64;
    fn min_distance(bbox: &BoundingBox, coordinate: &FPCoordinate) -> f64;
}
```

`RTree<T, M = Haversine>` and `RTreeElement<M = Haversine>` take it, and the default is what was there before, so no call site changes. An element with nothing of its own to say now writes what it means:

```rust
impl<M: Metric> RTreeElement<M> for Patch {
    fn distance_to(&self, coordinate: &FPCoordinate) -> f64 {
        M::min_distance(&self.box_of(), coordinate)
    }
}
```

Two measures come with it. `Haversine` is the tree's existing pairing, moved rather than changed. `Planar` counts a degree the same wherever it is taken, which is the wrong measure for ground distance and the right one for data already projected, for an ordering that only has to be consistent, and for a test that wants an answer it can work out by hand.

`Planar` also earns its place as the honest case. Its bound is the exact nearest point of a rectangle in the plane, so `a_deep_walk_in_an_exact_measure_comes_out_in_order` holds on a three-level tree of 27,100 elements and would hold at any depth. `Haversine` cannot make that claim, because clamping each axis is a planar move and the measure is spherical — the subject of #581. This PR does not fix that. It gives the fix somewhere to live, next to the measure that needs it, and puts the requirement in writing where an implementor will read it.

The clamp itself moves to `BoundingBox::nearest_point`, so both measures share one copy and the doc can say plainly that it is the nearest point of a flat rectangle rather than of the patch of a sphere the same four numbers describe.

One cost worth naming: a blanket `impl<M: Metric> RTreeElement<M>` means `M` has to be pinned somewhere. Four test call sites that used to read `let tree = RTree::from_elements(..)` now name the type, and a test calling `bbox()` straight on a tuple names the measure it is asking. Real code building a tree it then searches never notices, since the search pins it.
