### PR TITLE
Hand a node the way it was reached by, not itself

### DIFF
--- a/src/one_to_many_dijkstra.rs
+++ b/src/one_to_many_dijkstra.rs
@@ -92,7 +92,7 @@ impl OneToManyDijkstra {
                 if self.queue.contains(v) && self.queue.weight(v) > new_distance {
                     debug!("[decrease] node: {v}, new weight: {new_distance}, new parent: {u}");
                     // if lower distance found, update distance and its parent
-                    self.queue.decrease_key_and_update_data(v, new_distance, v);
+                    self.queue.decrease_key_and_update_data(v, new_distance, u);
                 }
             }
         }
@@ -133,6 +133,23 @@ mod tests {
         edge::InputEdge, graph::Graph, graph::NodeID, one_to_many_dijkstra::OneToManyDijkstra,
         static_graph::StaticGraph,
     };
+
+    /// A node reached again by a shorter way keeps the node that way came
+    /// from, or the walk back stops in the middle of the path.
+    #[test]
+    fn a_node_reached_again_keeps_the_way_it_was_reached_by() {
+        let edges = vec![
+            InputEdge::new(0, 1, 10_usize),
+            InputEdge::new(0, 2, 1),
+            InputEdge::new(2, 1, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = OneToManyDijkstra::new();
+
+        assert!(dijkstra.run(&graph, 0, &[1]));
+        assert_eq!(dijkstra.distance(1), 2);
+        assert_eq!(dijkstra.retrieve_node_path(1), Some(vec![0, 2, 1]));
+    }
 
     fn create_graph() -> StaticGraph<usize> {
         let edges = vec![

--- a/src/unidirectional_dijkstra.rs
+++ b/src/unidirectional_dijkstra.rs
@@ -85,7 +85,7 @@ impl UnidirectionalDijkstra {
                 if self.queue.contains(v) && self.queue.weight(v) > new_distance {
                     debug!("[decrease] node: {v}, new weight: {new_distance}, new parent: {u}");
                     // if lower distance found, update distance and its parent
-                    self.queue.decrease_key_and_update_data(v, new_distance, v);
+                    self.queue.decrease_key_and_update_data(v, new_distance, u);
                 }
             }
         }
@@ -126,6 +126,82 @@ mod tests {
         edge::InputEdge, graph::Graph, static_graph::StaticGraph,
         unidirectional_dijkstra::UnidirectionalDijkstra,
     };
+
+    /// The parent of a node that is reached again by a shorter way.
+    ///
+    /// A node is inserted with the node it was reached from as its parent, and
+    /// a later, shorter way to it has to hand it the node that shorter way came
+    /// from. Handing it itself instead leaves it looking like the node the
+    /// search started at, which is where the walk back stops: the path then
+    /// begins in the middle of itself and says nothing about how it got there.
+    #[test]
+    fn a_node_reached_again_keeps_the_way_it_was_reached_by() {
+        // 0 to 1 costs ten the direct way and two through node 2, so node 1 is
+        // reached once and then reached again by something better
+        let edges = vec![
+            InputEdge::new(0, 1, 10_usize),
+            InputEdge::new(0, 2, 1),
+            InputEdge::new(2, 1, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = UnidirectionalDijkstra::new();
+
+        assert_eq!(dijkstra.run(&graph, 0, 1), 2);
+        assert_eq!(dijkstra.retrieve_node_path(1), Some(vec![0, 2, 1]));
+    }
+
+    /// Whatever path comes back has to be a path of the graph, and it has to
+    /// cost what the search said it costs. That holds the two together on
+    /// graphs nobody worked out by hand.
+    #[test]
+    fn a_retrieved_path_walks_the_graph_and_costs_what_was_reported() {
+        use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_D1_5A);
+        for round in 0..20 {
+            let count = 8 + round;
+            let mut edges = Vec::new();
+            for source in 0..count {
+                for target in 0..count {
+                    if source != target && rng.random_range(0..3) == 0 {
+                        edges.push(InputEdge::new(
+                            source,
+                            target,
+                            rng.random_range(1..20_usize),
+                        ));
+                    }
+                }
+            }
+            if edges.is_empty() {
+                continue;
+            }
+            let graph = StaticGraph::new(edges);
+            let mut dijkstra = UnidirectionalDijkstra::new();
+
+            for source in 0..count {
+                for target in 0..count {
+                    let distance = dijkstra.run(&graph, source, target);
+                    if distance == usize::MAX {
+                        continue;
+                    }
+                    let path = dijkstra
+                        .retrieve_node_path(target)
+                        .expect("a path was found but not handed back");
+                    assert_eq!(path.first(), Some(&source), "round {round}: {path:?}");
+                    assert_eq!(path.last(), Some(&target), "round {round}: {path:?}");
+
+                    let mut walked = 0;
+                    for step in path.windows(2) {
+                        let edge = graph
+                            .find_edge(step[0], step[1])
+                            .expect("the path takes an arc the graph does not have");
+                        walked += *graph.data(edge);
+                    }
+                    assert_eq!(walked, distance, "round {round}: {path:?}");
+                }
+            }
+        }
+    }
 
     fn create_graph() -> StaticGraph<usize> {
         let edges = vec![


### PR DESCRIPTION
Both Dijkstras set a node's parent to the node itself when a shorter way to it turns up:

```rust
self.queue.insert(v, new_distance, u);                          // parent u, correct
self.queue.decrease_key_and_update_data(v, new_distance, v);    // parent v, wrong
```

The third argument is the parent. On insertion it gets `u`, the node the arc came from. On a decrease it got `v`, the node being updated.

Distances were never affected, which is why this stood: the weight is updated correctly and only the parent goes astray. It shows up in `retrieve_node_path`, which walks parents back from the target and stops when a node is its own parent, since that is what the node the search started at looks like. A node that was reached again therefore looks like the start of the search, and the path comes back beginning in the middle of itself.

Three arcs are enough. With `0 -> 1` at 10, `0 -> 2` at 1 and `2 -> 1` at 1:

| | before | after |
| --- | --- | --- |
| `run(0, 1)` | 2 | 2 |
| `retrieve_node_path(1)` | `[1]` | `[0, 2, 1]` |

Any node reached again by something shorter is affected, which on a road network is most of them.

`one_to_many_dijkstra.rs` had the identical line and is fixed the same way. The overlay in `customization.rs` is not affected: it uses `OneToManyDijkstra` for the cell matrices but reads distances only, never paths.

## Tests

- `a_node_reached_again_keeps_the_way_it_was_reached_by`, in both modules, on the three arcs above
- `a_retrieved_path_walks_the_graph_and_costs_what_was_reported`: twenty rounds of random graphs, every reachable pair, checking that the path starts at the source, ends at the target, takes only arcs the graph has, and that those arcs add up to the distance the search reported

All three fail on the old behaviour and pass on the new one.
