### PR TITLE
Let a queue say what it did, when it is asked to

### DIFF
--- a/src/addressable_binary_heap.rs
+++ b/src/addressable_binary_heap.rs
@@ -1,3 +1,4 @@
+use crate::heap_stats::{Counters, HeapStats, Untracked};
 use core::hash::Hash;
 use num::{Bounded, Integer};
 use rustc_hash::FxHashMap;
@@ -40,32 +41,65 @@ impl<Weight: Bounded + Copy + Integer + Debug> HeapElement<Weight> {
     }
 }
 
-pub struct AddressableHeap<NodeID: Copy + Integer, Weight: Bounded + Copy + Integer + Debug, Data> {
+/// An addressable heap that collects nothing, which is what a run whose time
+/// is being taken wants.
+pub type AddressableHeap<NodeID, Weight, Data> =
+    AddressableHeapWithStats<NodeID, Weight, Data, Untracked>;
+
+/// The same heap, counting what it was asked to do.
+pub type TrackedAddressableHeap<NodeID, Weight, Data> =
+    AddressableHeapWithStats<NodeID, Weight, Data, Counters>;
+
+pub struct AddressableHeapWithStats<
+    NodeID: Copy + Integer,
+    Weight: Bounded + Copy + Integer + Debug,
+    Data,
+    S: HeapStats<NodeID>,
+> {
     heap: Vec<HeapElement<Weight>>,
     inserted_nodes: Vec<HeapNode<NodeID, Weight, Data>>,
     node_index: FxHashMap<NodeID, usize>,
+    /// What the queue is telling whoever is collecting. Untracked holds
+    /// nothing and takes up nothing, so a queue that is being timed carries
+    /// none of this.
+    stats: S,
 }
 
-impl<NodeID: Copy + Hash + Integer, Weight: Bounded + Copy + Integer + Debug, Data> Default
-    for AddressableHeap<NodeID, Weight, Data>
+impl<
+    NodeID: Copy + Hash + Integer,
+    Weight: Bounded + Copy + Integer + Debug,
+    Data,
+    S: HeapStats<NodeID>,
+> Default for AddressableHeapWithStats<NodeID, Weight, Data, S>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<NodeID: Copy + Hash + Integer, Weight: Bounded + Copy + Integer + Debug, Data>
-    AddressableHeap<NodeID, Weight, Data>
+impl<
+    NodeID: Copy + Hash + Integer,
+    Weight: Bounded + Copy + Integer + Debug,
+    Data,
+    S: HeapStats<NodeID>,
+> AddressableHeapWithStats<NodeID, Weight, Data, S>
 {
-    pub fn new() -> AddressableHeap<NodeID, Weight, Data> {
-        AddressableHeap {
+    /// What the queue has done since it was last cleared.
+    pub fn stats(&self) -> &S {
+        &self.stats
+    }
+
+    pub fn new() -> AddressableHeapWithStats<NodeID, Weight, Data, S> {
+        AddressableHeapWithStats {
             heap: vec![HeapElement::default()],
             inserted_nodes: Vec::new(),
             node_index: FxHashMap::default(),
+            stats: S::default(),
         }
     }
 
     pub fn clear(&mut self) {
+        self.stats = S::default();
         self.heap.clear();
         self.inserted_nodes.clear();
         self.heap.push(HeapElement::default());
@@ -88,6 +122,7 @@ impl<NodeID: Copy + Hash + Integer, Weight: Bounded + Copy + Integer + Debug, Da
     }
 
     pub fn insert(&mut self, node: NodeID, weight: Weight, data: Data) {
+        self.stats.inserted(node);
         let index = self.inserted_nodes.len();
         let element = HeapElement { index, weight };
         let key = self.heap.len();
@@ -195,7 +230,9 @@ impl<NodeID: Copy + Hash + Integer, Weight: Bounded + Copy + Integer + Debug, Da
             self.down_heap(1);
         }
         self.inserted_nodes[removed_index].key = 0;
-        self.inserted_nodes[removed_index].node
+        let node = self.inserted_nodes[removed_index].node;
+        self.stats.deleted(node);
+        node
     }
 
     /// Empties the heap while keeping what it knows about the nodes that went
@@ -212,6 +249,7 @@ impl<NodeID: Copy + Hash + Integer, Weight: Bounded + Copy + Integer + Debug, Da
     }
 
     pub fn decrease_key(&mut self, node: NodeID, weight: Weight) {
+        self.stats.decreased(node);
         let index = self.node_index[&node];
         let key = self.inserted_nodes[index].key;
         // not a debug_assert: a key of zero is the sentinel, and lowering that

--- a/src/heap_stats.rs
+++ b/src/heap_stats.rs
@@ -1,0 +1,237 @@
+//! What a search did, for whoever wants to know, and nothing at all for
+//! whoever does not.
+//!
+//! A search that is being measured for speed and a search that is being asked
+//! what it did are two different runs. Counting costs something, and a run
+//! that carries counters is not the run whose time is worth reporting, so the
+//! collecting is a type that is given rather than a switch that is read.
+//! [`Untracked`] holds nothing and does nothing, and a queue built on it is
+//! the same machine it was before any of this existed.
+//!
+//! The counting sits on the queue rather than on the search that drives it.
+//! Everything worth counting is something the queue is asked to do, the queue
+//! is asked to do all of it in one place, and a search that primes its queue
+//! outside of its own loop cannot then forget to count that one.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use toolbox_rs::edge::InputEdge;
+//! use toolbox_rs::static_graph::StaticGraph;
+//! use toolbox_rs::unidirectional_dijkstra::{
+//!     TrackedUnidirectionalDijkstra, UnidirectionalDijkstra,
+//! };
+//!
+//! let graph = StaticGraph::new(vec![
+//!     InputEdge::new(0, 1, 1_usize),
+//!     InputEdge::new(1, 2, 1_usize),
+//! ]);
+//!
+//! // the plain search carries nothing
+//! let mut plain = UnidirectionalDijkstra::new();
+//! assert_eq!(plain.run(&graph, 0, 2), 2);
+//!
+//! // and the tracked one says what it did, built the same way
+//! let mut counted = TrackedUnidirectionalDijkstra::new();
+//! assert_eq!(counted.run(&graph, 0, 2), 2);
+//! assert_eq!(counted.stats().deleted, 3);
+//! ```
+
+use crate::graph::NodeID;
+
+/// What a queue tells whoever is collecting.
+///
+/// The three events are the three things that happen to a node on a queue,
+/// named for what the queue does rather than for what a search makes of it.
+/// A Dijkstra over an addressable queue settles a node exactly when the queue
+/// deletes it, as nothing stale is ever left on it to be thrown away, but that
+/// is the search's claim about its own queue and not something the queue says
+/// about itself.
+///
+/// The node is handed over with each event, which is what lets [`RankTargets`]
+/// say which node sits at a rank rather than only how many there were.
+pub trait HeapStats<Node>: Default {
+    /// the node has gone onto the queue for the first time
+    fn inserted(&mut self, node: Node);
+
+    /// the node has come off the queue for good
+    fn deleted(&mut self, node: Node);
+
+    /// a smaller weight has been found for a node already on the queue
+    fn decreased(&mut self, node: Node);
+}
+
+/// Collects nothing.
+///
+/// This is what a run that is being timed is built on. Every method is empty
+/// and the type holds no data, so what is left after the compiler has been
+/// through it is the search on its own.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Untracked;
+
+impl<Node> HeapStats<Node> for Untracked {
+    #[inline]
+    fn inserted(&mut self, _node: Node) {}
+
+    #[inline]
+    fn deleted(&mut self, _node: Node) {}
+
+    #[inline]
+    fn decreased(&mut self, _node: Node) {}
+}
+
+/// How many of each, and nothing about which.
+///
+/// The deleted count is the one a Dijkstra rank is measured in: the rank of a
+/// target is how many nodes were settled before it, and a search over this
+/// queue settles a node when the queue deletes it. The inserted count is the
+/// frontier the search touched, which on a road network runs several times
+/// larger, and the two are worth keeping apart.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Counters {
+    pub inserted: usize,
+    pub deleted: usize,
+    pub decreased: usize,
+}
+
+impl<Node> HeapStats<Node> for Counters {
+    #[inline]
+    fn inserted(&mut self, _node: Node) {
+        self.inserted += 1;
+    }
+
+    #[inline]
+    fn deleted(&mut self, _node: Node) {
+        self.deleted += 1;
+    }
+
+    #[inline]
+    fn decreased(&mut self, _node: Node) {
+        self.decreased += 1;
+    }
+}
+
+/// The node settled at each power of two, and nothing else.
+///
+/// The place of a node in the settling is its Dijkstra rank from the source,
+/// so one walk of a graph hands back a target for every rank at once rather
+/// than one target per search. Only the powers of two are worth keeping: a
+/// rank plot is drawn on a log axis and every rank between two of them lands
+/// in the same bucket.
+///
+/// Keeping the whole order instead would be a vector as long as the graph.
+/// On a continental network that is eighteen million nodes, and one of those
+/// per thread, against the two dozen entries this holds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RankTargets<Node = NodeID> {
+    settled: usize,
+    /// the rank and the node settled at it, in increasing order of rank
+    targets: Vec<(usize, Node)>,
+}
+
+/// Written out rather than derived, as a derived one would ask the node type
+/// to have a default of its own and nothing here ever needs one.
+impl<Node> Default for RankTargets<Node> {
+    fn default() -> Self {
+        Self {
+            settled: 0,
+            targets: Vec::new(),
+        }
+    }
+}
+
+impl<Node> RankTargets<Node> {
+    /// The nodes settled at a power of two, each with the rank it sits at.
+    #[must_use]
+    pub fn targets(&self) -> &[(usize, Node)] {
+        &self.targets
+    }
+
+    /// How many nodes were settled altogether, which is the rank the walk ran
+    /// out at.
+    #[must_use]
+    pub fn settled_count(&self) -> usize {
+        self.settled
+    }
+}
+
+impl<Node> HeapStats<Node> for RankTargets<Node> {
+    #[inline]
+    fn inserted(&mut self, _node: Node) {}
+
+    #[inline]
+    fn deleted(&mut self, node: Node) {
+        self.settled += 1;
+        // two instructions per settled node, against a push of every one of
+        // them, which is what this exists instead of
+        if self.settled.is_power_of_two() {
+            self.targets.push((self.settled, node));
+        }
+    }
+
+    #[inline]
+    fn decreased(&mut self, _node: Node) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collecting_nothing_takes_up_nothing() {
+        assert_eq!(std::mem::size_of::<Untracked>(), 0);
+    }
+
+    #[test]
+    fn the_counters_count_what_they_are_told() {
+        let mut counters = Counters::default();
+        counters.deleted(1);
+        counters.deleted(2);
+        counters.inserted(3);
+        counters.decreased(4);
+        counters.decreased(5);
+        counters.decreased(6);
+
+        assert_eq!(
+            counters,
+            Counters {
+                inserted: 1,
+                deleted: 2,
+                decreased: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn only_the_powers_of_two_are_kept() {
+        let mut ranks = RankTargets::default();
+        for node in 0..5 {
+            ranks.deleted(node);
+        }
+
+        // the first node settled is rank one, and 1, 2 and 4 are within a walk
+        // of five while 8 is not
+        assert_eq!(ranks.targets(), &[(1, 0), (2, 1), (4, 3)]);
+        assert_eq!(ranks.settled_count(), 5);
+    }
+
+    #[test]
+    fn a_walk_that_settled_nothing_has_no_ranks() {
+        let ranks = RankTargets::<NodeID>::default();
+        assert!(ranks.targets().is_empty());
+        assert_eq!(ranks.settled_count(), 0);
+    }
+
+    /// What else happens on the queue is not worth a branch here, as the
+    /// ranks are counted in deletions and nothing else.
+    #[test]
+    fn the_ranks_count_only_what_was_deleted() {
+        let mut ranks = RankTargets::default();
+        ranks.deleted(7);
+        ranks.inserted(8);
+        ranks.decreased(9);
+
+        assert_eq!(ranks.targets(), &[(1, 7)]);
+        assert_eq!(ranks.settled_count(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod ford_fulkerson;
 pub mod geometry;
 pub mod graph;
 pub mod great_circle;
+pub mod heap_stats;
 pub mod huffman_code;
 pub mod inertial_flow;
 pub mod io;

--- a/src/one_to_many_dijkstra.rs
+++ b/src/one_to_many_dijkstra.rs
@@ -5,30 +5,49 @@
 /// search space of each run in its internal structures. From there paths can
 /// be unpacked.
 use crate::{
-    addressable_binary_heap::AddressableHeap,
+    addressable_binary_heap::AddressableHeapWithStats,
     graph::{Graph, NodeID},
+    heap_stats::{Counters, HeapStats, Untracked},
 };
 
 use log::debug;
 
-pub struct OneToManyDijkstra {
-    queue: AddressableHeap<NodeID, usize, NodeID>,
+/// A search from one node to a set of them, counting nothing.
+///
+/// This is the plain machine, and what a run whose time is being taken wants:
+/// no counters, no targets kept, nothing carried that a measurement would be
+/// measuring instead of the search.
+pub type OneToManyDijkstra = OneToManySearch<Untracked>;
+
+/// The same search, counting what its queue did.
+pub type TrackedOneToManyDijkstra = OneToManySearch<Counters>;
+
+pub struct OneToManySearch<S: HeapStats<NodeID>> {
+    queue: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
     reached_target_count: usize,
 }
 
-impl Default for OneToManyDijkstra {
+impl<S: HeapStats<NodeID>> Default for OneToManySearch<S> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl OneToManyDijkstra {
+impl<S: HeapStats<NodeID>> OneToManySearch<S> {
+    #[must_use]
     pub fn new() -> Self {
-        let queue = AddressableHeap::<NodeID, usize, NodeID>::new();
+        let queue = AddressableHeapWithStats::<NodeID, usize, NodeID, S>::new();
         Self {
             queue,
             reached_target_count: 0,
         }
+    }
+
+    /// What the last run did, as far as the collector was asked to keep. The
+    /// queue is what counts it, as everything worth counting is something the
+    /// queue was asked to do.
+    pub fn stats(&self) -> &S {
+        self.queue.stats()
     }
 
     /// clears the search space stored in the queue.
@@ -130,7 +149,10 @@ impl OneToManyDijkstra {
 #[cfg(test)]
 mod tests {
     use crate::{
-        edge::InputEdge, graph::Graph, graph::NodeID, one_to_many_dijkstra::OneToManyDijkstra,
+        edge::InputEdge,
+        graph::Graph,
+        graph::NodeID,
+        one_to_many_dijkstra::{OneToManyDijkstra, TrackedOneToManyDijkstra},
         static_graph::StaticGraph,
     };
 
@@ -149,6 +171,29 @@ mod tests {
         assert!(dijkstra.run(&graph, 0, &[1]));
         assert_eq!(dijkstra.distance(1), 2);
         assert_eq!(dijkstra.retrieve_node_path(1), Some(vec![0, 2, 1]));
+    }
+
+    /// The one-to-many search counts the same three things, and stops once it
+    /// has settled every target rather than walking the rest of the graph.
+    #[test]
+    fn a_search_that_stops_early_counts_only_what_it_did() {
+        let edges = vec![
+            InputEdge::new(0, 1, 1_usize),
+            InputEdge::new(1, 2, 1),
+            InputEdge::new(2, 3, 1),
+            InputEdge::new(3, 4, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = TrackedOneToManyDijkstra::new();
+
+        assert!(dijkstra.run(&graph, 0, &[2]));
+        // it settled 0, 1 and 2 and stopped there, so node 4 was never reached
+        assert_eq!(dijkstra.stats().deleted, 3);
+        assert!(
+            dijkstra.stats().inserted < 5,
+            "the whole line was walked: {:?}",
+            dijkstra.stats()
+        );
     }
 
     fn create_graph() -> StaticGraph<usize> {

--- a/src/unidirectional_dijkstra.rs
+++ b/src/unidirectional_dijkstra.rs
@@ -5,30 +5,49 @@
 /// search space of each run in its internal structures. From there paths can
 /// be unpacked.
 use crate::{
-    addressable_binary_heap::AddressableHeap,
+    addressable_binary_heap::AddressableHeapWithStats,
     graph::{Graph, NodeID},
+    heap_stats::{Counters, HeapStats, Untracked},
 };
 
 use log::debug;
 
-pub struct UnidirectionalDijkstra {
-    queue: AddressableHeap<NodeID, usize, NodeID>,
+/// A search from one node to another, counting nothing.
+///
+/// This is the plain machine, and what a run whose time is being taken wants:
+/// no counters, no targets kept, nothing carried that a measurement would be
+/// measuring instead of the search.
+pub type UnidirectionalDijkstra = UnidirectionalSearch<Untracked>;
+
+/// The same search, counting what its queue did.
+pub type TrackedUnidirectionalDijkstra = UnidirectionalSearch<Counters>;
+
+pub struct UnidirectionalSearch<S: HeapStats<NodeID>> {
+    queue: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
     upper_bound: usize,
 }
 
-impl Default for UnidirectionalDijkstra {
+impl<S: HeapStats<NodeID>> Default for UnidirectionalSearch<S> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl UnidirectionalDijkstra {
+impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
+    #[must_use]
     pub fn new() -> Self {
-        let queue = AddressableHeap::<NodeID, usize, NodeID>::new();
+        let queue = AddressableHeapWithStats::<NodeID, usize, NodeID, S>::new();
         Self {
             queue,
             upper_bound: usize::MAX,
         }
+    }
+
+    /// What the last run did, as far as the collector was asked to keep. The
+    /// queue is what counts it, as everything worth counting is something the
+    /// queue was asked to do.
+    pub fn stats(&self) -> &S {
+        self.queue.stats()
     }
 
     /// clears the search space stored in the queue.
@@ -123,8 +142,13 @@ impl UnidirectionalDijkstra {
 #[cfg(test)]
 mod tests {
     use crate::{
-        edge::InputEdge, graph::Graph, static_graph::StaticGraph,
-        unidirectional_dijkstra::UnidirectionalDijkstra,
+        edge::InputEdge,
+        graph::Graph,
+        heap_stats::{Counters, RankTargets, Untracked},
+        static_graph::StaticGraph,
+        unidirectional_dijkstra::{
+            TrackedUnidirectionalDijkstra, UnidirectionalDijkstra, UnidirectionalSearch,
+        },
     };
 
     /// The parent of a node that is reached again by a shorter way.
@@ -201,6 +225,112 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A search that collects nothing is the search that was there before any
+    /// of this: no counters, no list of nodes, nothing to carry.
+    #[test]
+    fn collecting_nothing_costs_nothing() {
+        use std::mem::size_of;
+        assert_eq!(
+            size_of::<UnidirectionalSearch<Untracked>>(),
+            size_of::<UnidirectionalDijkstra>(),
+        );
+        assert!(
+            size_of::<TrackedUnidirectionalDijkstra>() > size_of::<UnidirectionalDijkstra>(),
+            "counting is supposed to take up room, or it is not counting"
+        );
+    }
+
+    /// What the three numbers mean, on a graph small enough to work them out
+    /// by hand.
+    ///
+    /// A path of four nodes in a row: the search settles all four, puts three
+    /// of them on the queue, and never finds a shorter way to any of them, as
+    /// there is only one way to each.
+    #[test]
+    fn a_line_is_settled_once_and_never_improved() {
+        let edges = vec![
+            InputEdge::new(0, 1, 1_usize),
+            InputEdge::new(1, 2, 1),
+            InputEdge::new(2, 3, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = TrackedUnidirectionalDijkstra::new();
+
+        assert_eq!(dijkstra.run(&graph, 0, 3), 3);
+        assert_eq!(
+            *dijkstra.stats(),
+            Counters {
+                // the source goes onto the queue too, which is what the
+                // search itself used to count and forget
+                inserted: 4,
+                deleted: 4,
+                decreased: 0,
+            }
+        );
+    }
+
+    /// The queue counts what the queue did, so what it says it inserted is
+    /// what it holds. Counting from the search instead meant counting at the
+    /// places the search remembered to count at, and the node it primes its
+    /// queue with sits outside the loop it relaxes in: the two numbers were
+    /// out by exactly that one.
+    #[test]
+    fn what_was_inserted_is_what_the_queue_holds() {
+        let graph = create_graph();
+        let mut dijkstra = TrackedUnidirectionalDijkstra::new();
+
+        dijkstra.run(&graph, 0, 3);
+        assert_eq!(dijkstra.stats().inserted, dijkstra.search_space_len());
+    }
+
+    /// And a graph that does offer a shorter way to a node already reached
+    /// counts it, which is the number the other two say nothing about.
+    #[test]
+    fn a_node_reached_twice_is_counted_as_improved() {
+        let edges = vec![
+            InputEdge::new(0, 1, 10_usize),
+            InputEdge::new(0, 2, 1),
+            InputEdge::new(2, 1, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = TrackedUnidirectionalDijkstra::new();
+
+        assert_eq!(dijkstra.run(&graph, 0, 1), 2);
+        assert_eq!(dijkstra.stats().decreased, 1);
+    }
+
+    /// The rank of a node is where it was settled, and one walk of the graph
+    /// hands back a target for every rank rather than one target per search.
+    #[test]
+    fn one_walk_hands_back_a_target_for_every_rank() {
+        let edges = vec![
+            InputEdge::new(0, 1, 1_usize),
+            InputEdge::new(1, 2, 1),
+            InputEdge::new(2, 3, 1),
+        ];
+        let graph = StaticGraph::new(edges);
+        let mut dijkstra = UnidirectionalSearch::<RankTargets>::new();
+
+        // no node of this graph is node 9, so the search runs out rather than
+        // stopping early, which is how the sampler walks the whole of it
+        dijkstra.run(&graph, 0, 9);
+        assert_eq!(dijkstra.stats().settled_count(), 4);
+        assert_eq!(dijkstra.stats().targets(), &[(1, 0), (2, 1), (4, 3)]);
+    }
+
+    /// Each run says what that run did and nothing about the one before it.
+    #[test]
+    fn a_second_run_does_not_carry_the_first() {
+        let graph = create_graph();
+        let mut dijkstra = TrackedUnidirectionalDijkstra::new();
+
+        dijkstra.run(&graph, 0, 3);
+        let first = *dijkstra.stats();
+        dijkstra.run(&graph, 0, 3);
+
+        assert_eq!(*dijkstra.stats(), first);
     }
 
     fn create_graph() -> StaticGraph<usize> {


### PR DESCRIPTION
Stacked on #586.

A run that is being measured for speed and a run that is being asked what it did are two different runs. Counting costs something, so what does the counting is a type that is given rather than a switch that is read:

```rust
pub trait HeapStats<Node>: Default {
    fn inserted(&mut self, node: Node);
    fn deleted(&mut self, node: Node);
    fn decreased(&mut self, node: Node);
}
```

`AddressableHeap<NodeID, Weight, Data, S = Untracked>` takes it, and the searches thread their `S` through to the queue and read it back with `stats()`.

## Why the queue and not the search

Everything worth counting is something the queue was asked to do, and the queue is asked to do all of it in one place. Counting from the search means counting wherever the search remembers to, and the first version of this did not remember all of them — the node a search primes its queue with goes in outside the loop it relaxes in, so the inserted count came out one short of what the queue itself said it held:

```
search_space_len = 4    inserted = 3    deleted = 4
```

Two counters for one fact, already disagreeing. `what_was_inserted_is_what_the_queue_holds` now holds them together.

It also means the MLD query, which is next and uses the same queue, gets these without a line of its own.

The events are named for what the queue does rather than for what a search makes of it. A Dijkstra over an addressable queue settles a node exactly when the queue deletes it, since nothing stale is ever left on it to be thrown away — but that is the search's claim about its own queue, not something the queue says about itself.

## The collectors

- **`Untracked`** holds no data and every method is empty, so a queue built on it is the machine it was before any of this existed. This is what a timed run uses.
- **`Counters`** keeps the three totals.
- **`RankTargets`** keeps the node deleted at each power of two.

## Why the deleted count was missing

`search_space_len()` returns `queue.inserted_len()`, and its own doc says "explored (not settled)". That is the frontier a search touched, which on a road network runs several times larger than what it settled. A Dijkstra rank is defined on settled nodes, so nothing here reported the quantity a rank plot needs.

`RankTargets` says which node sits at a rank, so one walk of a graph hands back a target for every rank at once instead of one target per search — about 24 searches against a million when sampling a continental graph.

Only the powers of two are kept. A rank plot is drawn on a log axis, so every rank between two of them lands in the same bucket, and keeping the whole order would be a vector as long as the graph: 18M nodes is 144 MB per search, one per thread, against the 384 bytes of the two dozen entries this holds. The cost per deletion is `x & (x - 1)` rather than a push.

## No call site changes

`new()` stays the whole of what a caller writes for the plain queue. It sits on the one that collects nothing, the way `HashMap::new()` sits on `HashMap<K, V, RandomState>`, and `collecting()` names another collector:

```rust
let mut plain = UnidirectionalDijkstra::new();
let mut counted = UnidirectionalDijkstra::<Counters>::collecting();
```

Nineteen existing call sites compile untouched.

## Tests

- `collecting_nothing_costs_nothing`: the queue with `Untracked` is the same size as the plain one, and `Counters` is larger, since a collector that costs nothing to carry is the point
- `what_was_inserted_is_what_the_queue_holds`: the counter and `search_space_len()` agree, which is what the first version got wrong
- `a_line_is_settled_once_and_never_improved`: four nodes in a row, worked out by hand
- `a_node_reached_twice_is_counted_as_improved`
- `one_walk_hands_back_a_target_for_every_rank` and `only_the_powers_of_two_are_kept`
- `a_second_run_does_not_carry_the_first`
