### PR TITLE
Say where a border node sits, and build a grid where anyone can reach it

### DIFF
--- a/src/customization.rs
+++ b/src/customization.rs
@@ -36,13 +36,36 @@ use std::{
 pub struct CellDistances {
     pub border_nodes: Vec<NodeID>,
     matrix: Vec<usize>,
+    /// Where each border node sits in `border_nodes`.
+    ///
+    /// A query reads the matrix once per arc it takes across a cell, and the
+    /// matrix is addressed by place rather than by node. Walking the list to
+    /// find the place would make every one of those arcs cost the width of the
+    /// cell, which on the coarsest level of a continent is thousands of border
+    /// nodes. It is worked out once here, where the list is built.
+    place_of: FxHashMap<NodeID, usize>,
 }
 
 impl CellDistances {
     /// What it costs to get from one border node of the cell to another,
     /// both given as their place in `border_nodes`.
+    #[must_use]
     pub fn distance(&self, source: usize, target: usize) -> usize {
         self.matrix[source * self.border_nodes.len() + target]
+    }
+
+    /// Where a node sits in `border_nodes`, and `None` for a node that is not
+    /// on the border of this cell at all.
+    #[must_use]
+    pub fn place_of(&self, node: NodeID) -> Option<usize> {
+        self.place_of.get(&node).copied()
+    }
+
+    /// What it costs to get from one border node of the cell to another, both
+    /// given as themselves, and `None` unless the pair are both on the border.
+    #[must_use]
+    pub fn distance_between(&self, source: NodeID, target: NodeID) -> Option<usize> {
+        Some(self.distance(self.place_of(source)?, self.place_of(target)?))
     }
 }
 
@@ -379,9 +402,15 @@ impl Customization {
             );
         }
 
+        let place_of = border_nodes
+            .iter()
+            .enumerate()
+            .map(|(place, &node)| (node, place))
+            .collect();
         Some(CellDistances {
             border_nodes,
             matrix,
+            place_of,
         })
     }
 
@@ -591,50 +620,53 @@ mod tests {
         Customization::new(StaticGraph::new(edges), directory)
     }
 
-    /// A square grid of `side` by `side` nodes, cut into squares of two by two
-    /// on the finest level and of four by four above it. The arcs of a row run
-    /// one way round when `both_ways` is not asked for, which is what a road
-    /// network does and what makes the distances of a cell asymmetric.
+    /// A square grid with a partition cut over it, as
+    /// [`crate::grid_graph`] builds them.
     fn grid_with(side: usize, both_ways: bool) -> Customization {
-        let node = |row: usize, column: usize| row * side + column;
-        let mut edges = Vec::new();
-        for row in 0..side {
-            for column in 0..side {
-                if column + 1 < side {
-                    edges.push(InputEdge::new(node(row, column), node(row, column + 1), 1));
-                    if both_ways {
-                        edges.push(InputEdge::new(node(row, column + 1), node(row, column), 1));
-                    }
-                }
-                if row + 1 < side {
-                    edges.push(InputEdge::new(node(row, column), node(row + 1, column), 1));
-                    edges.push(InputEdge::new(node(row + 1, column), node(row, column), 1));
-                }
-            }
-        }
-
-        let finest = (0..side * side)
-            .map(|index| {
-                let (row, column) = (index / side, index % side);
-                ((row / 2) * (side / 2) + column / 2) as CellId
-            })
-            .collect::<Vec<_>>();
-        let coarser = (0..(side / 2) * (side / 2))
-            .map(|cell| {
-                let (row, column) = (cell / (side / 2), cell % (side / 2));
-                ((row / 2) * (side / 4) + column / 2) as CellId
-            })
-            .collect::<Vec<_>>();
-        let top = vec![0; (side / 4) * (side / 4)];
-
-        Customization::new(
-            StaticGraph::new(edges),
-            LevelDirectory::new(finest, vec![coarser, top]),
-        )
+        let (graph, directory) = crate::grid_graph::grid(side, both_ways);
+        Customization::new(graph, directory)
     }
 
     fn grid(side: usize) -> Customization {
         grid_with(side, true)
+    }
+
+    /// A query reads the matrix by node and the matrix is addressed by place,
+    /// so the two have to line up.
+    #[test]
+    fn a_border_node_knows_where_it_sits_in_the_matrix() {
+        let customization = two_cells();
+        let distances = customization.distances_of(0, 0).expect("no cell");
+
+        for (place, &node) in distances.border_nodes.iter().enumerate() {
+            assert_eq!(distances.place_of(node), Some(place));
+        }
+        // and a node that is not on this border has no place on it
+        let elsewhere = *customization
+            .distances_of(0, 1)
+            .expect("no cell")
+            .border_nodes
+            .first()
+            .expect("a cell with no border nodes");
+        assert_eq!(distances.place_of(elsewhere), None);
+        assert_eq!(distances.distance_between(elsewhere, elsewhere), None);
+    }
+
+    /// Asking by node and asking by place are the same question.
+    #[test]
+    fn the_distance_between_two_nodes_is_the_one_in_their_places() {
+        let customization = grid(8);
+        let distances = customization.distances_of(1, 0).expect("no cell");
+
+        for &source in &distances.border_nodes {
+            for &target in &distances.border_nodes {
+                let places = distances.distance(
+                    distances.place_of(source).expect("not on the border"),
+                    distances.place_of(target).expect("not on the border"),
+                );
+                assert_eq!(distances.distance_between(source, target), Some(places));
+            }
+        }
     }
 
     #[test]
@@ -1014,6 +1046,12 @@ mod tests {
             .insert(
                 (1, 0),
                 Arc::new(CellDistances {
+                    place_of: built
+                        .border_nodes
+                        .iter()
+                        .enumerate()
+                        .map(|(place, &node)| (node, place))
+                        .collect(),
                     border_nodes: built.border_nodes.clone(),
                     matrix,
                 }),

--- a/src/grid_graph.rs
+++ b/src/grid_graph.rs
@@ -1,0 +1,223 @@
+//! A square grid of nodes with a partition cut over it, for whatever needs a
+//! graph with cells in it and no file to read.
+//!
+//! A test wants a graph small enough to work out by hand and a benchmark wants
+//! one large enough to mean something, and neither can reach for a road network
+//! on disk: a benchmark of this crate has nothing but the crate. A grid is what
+//! is left, and it is not a bad stand-in. It has a boundary between every pair
+//! of neighbouring cells, which is what a query spends its time on, and asking
+//! for arcs that run one way makes the distances across a cell asymmetric, the
+//! way a road network does and a symmetric toy does not.
+//!
+//! What it does not have is the shape of a road network: no motorways, no
+//! ferries, no dead ends, and every cell of a size. A number measured here says
+//! how something scales, not what it costs on a continent.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use toolbox_rs::grid_graph::grid;
+//! use toolbox_rs::graph::Graph;
+//!
+//! let (graph, directory) = grid(8, true);
+//! assert_eq!(graph.number_of_nodes(), 64);
+//! // eight by eight, cut into squares of two, then of four, then the lot
+//! assert_eq!(directory.levels(), 3);
+//! assert_eq!(directory.cells_on_level(0), 16);
+//! assert_eq!(directory.cells_on_level(1), 4);
+//! assert_eq!(directory.cells_on_level(2), 1);
+//! ```
+
+use crate::{
+    edge::InputEdge,
+    graph::NodeID,
+    level_directory::{CellId, LevelDirectory},
+    static_graph::StaticGraph,
+};
+
+/// The node at a place on the grid, numbered along the rows.
+#[must_use]
+pub fn node_at(side: usize, row: usize, column: usize) -> NodeID {
+    row * side + column
+}
+
+/// The arcs of a `side` by `side` grid, each of weight one.
+///
+/// The arcs of a column always run both ways. Those of a row run one way only
+/// unless `both_ways` is asked for, which is what leaves a cell costing a
+/// different amount to cross in each direction. A query that assumed otherwise
+/// would be right on a grid of the other kind and wrong on a road.
+#[must_use]
+pub fn grid_edges(side: usize, both_ways: bool) -> Vec<InputEdge<usize>> {
+    let mut edges = Vec::new();
+    for row in 0..side {
+        for column in 0..side {
+            if column + 1 < side {
+                edges.push(InputEdge::new(
+                    node_at(side, row, column),
+                    node_at(side, row, column + 1),
+                    1,
+                ));
+                if both_ways {
+                    edges.push(InputEdge::new(
+                        node_at(side, row, column + 1),
+                        node_at(side, row, column),
+                        1,
+                    ));
+                }
+            }
+            if row + 1 < side {
+                edges.push(InputEdge::new(
+                    node_at(side, row, column),
+                    node_at(side, row + 1, column),
+                    1,
+                ));
+                edges.push(InputEdge::new(
+                    node_at(side, row + 1, column),
+                    node_at(side, row, column),
+                    1,
+                ));
+            }
+        }
+    }
+    edges
+}
+
+/// The partition of a `side` by `side` grid: squares of two by two on the
+/// finest level, and each level above it squares of twice the side of the one
+/// below, up to the one cell that holds the lot.
+///
+/// A partition of a road network has cells that grow like this, and a search
+/// over it is only worth anything where there is a cell large enough to be
+/// worth stepping over. Cutting to two levels and then a lid instead leaves
+/// the topmost cell holding every node, so it holds the ends of every query
+/// and can never be stepped over, and what is left to step over is a square of
+/// sixteen nodes whose border is nearly all of it.
+///
+/// # Panics
+///
+/// Panics unless the side is a power of two of at least four, as every level
+/// halves the number of cells across and a side that does not halve evenly
+/// would leave a cell straddling the edge of the grid.
+#[must_use]
+pub fn grid_directory(side: usize) -> LevelDirectory {
+    assert!(
+        side >= 4 && side.is_power_of_two(),
+        "a grid is cut into squares that double each level, so the side has to be a power of two"
+    );
+
+    // the finest cells are squares of two, so a node's cell is its place
+    // divided by two, counted along the rows of cells
+    let across = side / 2;
+    let base = (0..side * side)
+        .map(|index| {
+            let (row, column) = (index / side, index % side);
+            ((row / 2) * across + column / 2) as CellId
+        })
+        .collect::<Vec<_>>();
+
+    // and each level above holds four cells of the one below, so a cell's
+    // parent is its place among them divided by two, both ways
+    let mut parents = Vec::new();
+    let mut across = across;
+    while across > 1 {
+        parents.push(
+            (0..across * across)
+                .map(|cell| {
+                    let (row, column) = (cell / across, cell % across);
+                    ((row / 2) * (across / 2) + column / 2) as CellId
+                })
+                .collect::<Vec<_>>(),
+        );
+        across /= 2;
+    }
+
+    LevelDirectory::new(base, parents)
+}
+
+/// A `side` by `side` grid and the partition cut over it.
+///
+/// # Panics
+///
+/// Panics unless the side is a power of two of at least four. See
+/// [`grid_directory`].
+#[must_use]
+pub fn grid(side: usize, both_ways: bool) -> (StaticGraph<usize>, LevelDirectory) {
+    (
+        StaticGraph::new(grid_edges(side, both_ways)),
+        grid_directory(side),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Graph;
+
+    #[test]
+    fn a_grid_holds_a_node_for_every_place_on_it() {
+        let (graph, _) = grid(8, true);
+        assert_eq!(graph.number_of_nodes(), 64);
+        assert_eq!(node_at(8, 0, 0), 0);
+        assert_eq!(node_at(8, 3, 5), 29);
+    }
+
+    /// A grid of arcs both ways has one for each direction of every pair of
+    /// neighbours; one of arcs one way round has the columns both ways and the
+    /// rows only once.
+    #[test]
+    fn the_rows_run_one_way_unless_both_are_asked_for() {
+        let side = 8;
+        let pairs = side * (side - 1);
+
+        assert_eq!(grid_edges(side, true).len(), 2 * pairs + 2 * pairs);
+        assert_eq!(grid_edges(side, false).len(), pairs + 2 * pairs);
+    }
+
+    #[test]
+    fn every_node_of_a_cell_is_a_neighbour_of_another() {
+        let directory = grid_directory(8);
+        // the four nodes of the top left cell of the finest level are the
+        // corners of a square of two by two
+        for (row, column) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
+            assert_eq!(directory.cell_of(node_at(8, row, column), 0), 0);
+        }
+        // and the node next door on the right is in the cell next door
+        assert_eq!(directory.cell_of(node_at(8, 0, 2), 0), 1);
+    }
+
+    #[test]
+    fn a_cell_of_a_level_is_built_of_cells_of_the_one_below() {
+        let directory = grid_directory(8);
+        assert_eq!(directory.levels(), 3);
+        assert_eq!(directory.cells_on_level(0), 16);
+        assert_eq!(directory.cells_on_level(1), 4);
+        assert_eq!(directory.cells_on_level(2), 1);
+
+        // the four finest cells of the top left quarter share a cell above
+        for cell in [0, 1, 4, 5] {
+            assert_eq!(directory.parents_on_level(0)[cell], 0);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "power of two")]
+    fn a_side_that_does_not_halve_is_refused() {
+        let _ = grid_directory(12);
+    }
+
+    /// Every level holds squares of twice the side of the one below, so the
+    /// count of cells falls by four each time and the top holds one.
+    #[test]
+    fn the_cells_double_in_side_up_to_the_one_that_holds_the_lot() {
+        let directory = grid_directory(64);
+        assert_eq!(directory.levels(), 6);
+        for (level, cells) in [1024, 256, 64, 16, 4, 1].into_iter().enumerate() {
+            assert_eq!(
+                directory.cells_on_level(level),
+                cells,
+                "level {level} of a grid of 64"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod ford_fulkerson;
 pub mod geometry;
 pub mod graph;
 pub mod great_circle;
+pub mod grid_graph;
 pub mod heap_stats;
 pub mod huffman_code;
 pub mod inertial_flow;


### PR DESCRIPTION
Two additions needed by the MLD query. No behaviour changes.

## `CellDistances`

New private field `place_of: FxHashMap<NodeID, usize>`, filled in `tabulate()` where `border_nodes` is built.

Two new methods:

- `place_of(node) -> Option<usize>` — the index of a node in `border_nodes`, `None` if the node is not on this cell's border.
- `distance_between(source, target) -> Option<usize>` — `distance()` addressed by node instead of by index.

The matrix is addressed by index. The query holds node ids and reads the matrix once per arc it takes across a cell, so without the map each of those reads is a linear scan of `border_nodes` — thousands of entries on the coarsest level of a continental partition.

## `src/grid_graph.rs`

New module. `grid_with()` moves out of the `#[cfg(test)]` module of `customization.rs` and becomes public API, split into four functions:

- `node_at(side, row, column) -> NodeID`
- `grid_edges(side, both_ways) -> Vec<InputEdge<usize>>` — arcs of a `side` by `side` grid, all of weight 1. Column arcs always run both ways; row arcs run one way unless `both_ways` is set, which makes the distances across a cell asymmetric.
- `grid_directory(side) -> LevelDirectory` — three levels: 2x2 cells, then 4x4, then one cell over the lot. Panics unless `side >= 4` and `side % 4 == 0`.
- `grid(side, both_ways) -> (StaticGraph<usize>, LevelDirectory)`

The test helper in `customization.rs` now calls `grid_graph::grid()`, so there is one definition of the graph rather than two.

Reason for the move: benchmarks cannot reference `#[cfg(test)]` items, and both the benchmarks and the correctness harness need this graph.

## Tests

- `a_border_node_knows_where_it_sits_in_the_matrix` — every border node's `place_of` equals its index in `border_nodes`; a node from a different cell's border returns `None` from both new methods
- `the_distance_between_two_nodes_is_the_one_in_their_places` — `distance_between` equals `distance` for every pair of border nodes of a cell
- `a_grid_holds_a_node_for_every_place_on_it` — node count and `node_at` numbering
- `the_rows_run_one_way_unless_both_are_asked_for` — arc counts for both settings
- `every_node_of_a_cell_is_a_neighbour_of_another` — which cell a node falls into on the finest level
- `a_cell_of_a_level_is_built_of_cells_of_the_one_below` — cell counts per level and the parent links
- `a_side_that_does_not_divide_is_refused` — the panic
