### PR TITLE
Draw pairs on the rank axis, and time what they cost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ path = "src/sound/bin/main.rs"
 name = "solver"
 path = "src/solver/bin/main.rs"
 
+[[bin]]
+name = "ranks"
+path = "src/ranks/bin/main.rs"
+
 [dependencies]
 rkyv = "0.8.15"
 bitvec = "1.0.1"

--- a/src/ranks/bin/command_line.rs
+++ b/src/ranks/bin/command_line.rs
@@ -84,6 +84,10 @@ pub struct Time {
     /// them does not pay for what the rest of them find already warm.
     #[clap(long, default_value_t = 100, action)]
     pub warmup: usize,
+
+    /// What to seed the shuffling with, so a run can be repeated.
+    #[clap(long, default_value_t = 0x_5EED, action)]
+    pub seed: u64,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -122,7 +126,8 @@ impl Display for Arguments {
                 writeln!(f, "engine: {}", time.engine)?;
                 writeln!(f, "in: {}", time.input)?;
                 writeln!(f, "out: {}", time.out)?;
-                writeln!(f, "warmup: {} pairs", time.warmup)
+                writeln!(f, "warmup: {} pairs", time.warmup)?;
+                writeln!(f, "seed: {}", time.seed)
             }
         }
     }

--- a/src/ranks/bin/command_line.rs
+++ b/src/ranks/bin/command_line.rs
@@ -1,0 +1,129 @@
+use std::fmt::Display;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Arguments {
+    #[command(subcommand)]
+    pub mode: Mode,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Mode {
+    /// Draws pairs of nodes and says where each of them sits on the rank axis.
+    ///
+    /// A source is drawn at random and searched from over the whole graph, and
+    /// the node settled at each power of two is written down with the rank it
+    /// was settled at. One search hands back a pair for every rank, which is
+    /// what makes a sample of a million affordable: a search per pair would
+    /// cost the same as searching a source for every one of them.
+    Sample(Sample),
+
+    /// Times the pairs, and counts nothing while doing it.
+    ///
+    /// A run that is being counted is not a run worth timing, so this reads
+    /// the pairs back and searches them again with nothing collecting.
+    Time(Time),
+}
+
+#[derive(Parser, Debug)]
+pub struct Sample {
+    /// path to the input graph
+    #[clap(short, long, action)]
+    pub graph: String,
+
+    /// how many sources to draw
+    #[clap(short, long, default_value_t = 1000, action)]
+    pub sources: usize,
+
+    /// what to seed the drawing with, so a sample can be drawn again
+    #[clap(long, default_value_t = 0x_5EED, action)]
+    pub seed: u64,
+
+    /// where to write the pairs
+    #[clap(short, long, action)]
+    pub out: String,
+
+    /// how many threads to search on, and all of them when left out
+    #[clap(short, long, action)]
+    pub threads: Option<usize>,
+
+    /// Draw pairs of nodes at random instead, and search each pair on its own.
+    ///
+    /// This is what was asked for rather than what is affordable: a target
+    /// drawn at random sits at a high rank almost every time, so the low ranks
+    /// come out empty, and every pair costs a search of its own.
+    #[clap(long, action)]
+    pub pairs: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct Time {
+    /// path to the input graph
+    #[clap(short, long, action)]
+    pub graph: String,
+
+    /// path to the level directory that chipper wrote, for the mld engine
+    #[clap(short, long, default_value_t = String::new(), action)]
+    pub directory: String,
+
+    /// which search to time
+    #[clap(short, long, value_enum, default_value_t = Engine::Dijkstra)]
+    pub engine: Engine,
+
+    /// the pairs to time, as written by the sample mode
+    #[clap(short, long, action)]
+    pub input: String,
+
+    /// where to write the timings
+    #[clap(short, long, action)]
+    pub out: String,
+
+    /// How many pairs to run before the clock is started, so that the first of
+    /// them does not pay for what the rest of them find already warm.
+    #[clap(long, default_value_t = 100, action)]
+    pub warmup: usize,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Engine {
+    /// a plain unidirectional Dijkstra over the graph
+    Dijkstra,
+    /// a search over the cells of the partition
+    Mld,
+}
+
+impl Display for Engine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Engine::Dijkstra => write!(f, "dijkstra"),
+            Engine::Mld => write!(f, "mld"),
+        }
+    }
+}
+
+impl Display for Arguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "command line arguments:")?;
+        match &self.mode {
+            Mode::Sample(sample) => {
+                writeln!(f, "mode: sample")?;
+                writeln!(f, "graph: {}", sample.graph)?;
+                writeln!(f, "sources: {}", sample.sources)?;
+                writeln!(f, "seed: {}", sample.seed)?;
+                writeln!(f, "out: {}", sample.out)?;
+                writeln!(f, "pairs of nodes drawn at random: {}", sample.pairs)
+            }
+            Mode::Time(time) => {
+                writeln!(f, "mode: time")?;
+                writeln!(f, "graph: {}", time.graph)?;
+                writeln!(f, "level directory: {}", time.directory)?;
+                writeln!(f, "engine: {}", time.engine)?;
+                writeln!(f, "in: {}", time.input)?;
+                writeln!(f, "out: {}", time.out)?;
+                writeln!(f, "warmup: {} pairs", time.warmup)
+            }
+        }
+    }
+}

--- a/src/ranks/bin/main.rs
+++ b/src/ranks/bin/main.rs
@@ -1,0 +1,304 @@
+//! Draws pairs of nodes, says where each of them sits on the Dijkstra rank
+//! axis, and times what a search costs for them.
+//!
+//! # Why two modes
+//!
+//! A rank plot is a picture of what a query costs against how far apart its
+//! ends are, and "how far apart" is measured in what a plain search has to do
+//! to get from one to the other: the rank of a target is the number of nodes
+//! settled before it. Working that out means counting, and counting is not
+//! free, so the pairs are drawn in one pass and timed in another. Nothing is
+//! collected while the clock is running.
+//!
+//! ```text
+//! ranks sample -g graph.toolbox -s 1000 -o pairs.csv
+//! ranks time   -g graph.toolbox -i pairs.csv -e dijkstra -o timings.csv
+//! ranks time   -g graph.toolbox -d levels.bin -i pairs.csv -e mld -o timings.csv
+//! ```
+//!
+//! The two runs of `time` can be laid end to end, as each row says which
+//! engine it came from.
+
+mod command_line;
+
+use std::{
+    error::Error,
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Write},
+    time::Instant,
+};
+
+use command_line::{Arguments, Engine, Mode, Sample, Time};
+use env_logger::{Builder, Env};
+use log::{info, warn};
+use rand::{RngExt, SeedableRng, prelude::StdRng};
+use rayon::prelude::*;
+
+use toolbox_rs::{
+    customization::Customization,
+    edge::InputEdge,
+    graph::{Graph, NodeID},
+    heap_stats::{Counters, RankTargets},
+    io,
+    level_directory::LevelDirectory,
+    mld_query::MldQuery,
+    static_graph::StaticGraph,
+    unidirectional_dijkstra::{UnidirectionalDijkstra, UnidirectionalSearch},
+};
+
+/// A pair to time, and the rank its target sits at.
+type ToTime = (NodeID, NodeID, usize);
+
+/// A pair of nodes and where the target sits on the rank axis.
+///
+/// The rank is the count of nodes a plain search settled before it reached
+/// the target, which is what a plain search cost for this pair and the axis a
+/// rank plot is drawn against. There is no separate settled count to write
+/// down: the two are the same number.
+struct Pair {
+    source: NodeID,
+    target: NodeID,
+    rank: usize,
+    distance: usize,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Builder::from_env(Env::default().default_filter_or("info")).init();
+    let args = <Arguments as clap::Parser>::parse();
+    info!("{args}");
+
+    match &args.mode {
+        Mode::Sample(sample) => run_sample(sample),
+        Mode::Time(time) => run_time(time),
+    }
+}
+
+fn load_graph(path: &str) -> StaticGraph<usize> {
+    let edges = io::read_vec_from_file::<InputEdge<usize>>(path);
+    info!("loaded {} graph edges", edges.len());
+    let graph = StaticGraph::new(edges);
+    info!(
+        "graph of {} nodes and {} edges",
+        graph.number_of_nodes(),
+        graph.number_of_edges()
+    );
+    graph
+}
+
+fn run_sample(args: &Sample) -> Result<(), Box<dyn Error>> {
+    let graph = load_graph(&args.graph);
+    let node_count = graph.number_of_nodes();
+    if node_count == 0 {
+        return Err("the graph has no nodes to draw from".into());
+    }
+
+    if let Some(threads) = args.threads {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build_global()?;
+    }
+
+    // the drawing is done up front and on one thread, so that a sample is the
+    // same sample however many threads happen to run it
+    let mut rng = StdRng::seed_from_u64(args.seed);
+    let sources = (0..args.sources)
+        .map(|_| rng.random_range(0..node_count))
+        .collect::<Vec<_>>();
+    let targets = if args.pairs {
+        (0..args.sources)
+            .map(|_| rng.random_range(0..node_count))
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    let started = Instant::now();
+    let pairs: Vec<Pair> = if args.pairs {
+        sources
+            .par_iter()
+            .zip(targets.par_iter())
+            .filter_map(|(&source, &target)| one_pair(&graph, source, target))
+            .collect()
+    } else {
+        sources
+            .par_iter()
+            .flat_map_iter(|&source| ranks_of(&graph, source))
+            .collect()
+    };
+    info!(
+        "{} pairs from {} sources in {:.1} s",
+        pairs.len(),
+        args.sources,
+        started.elapsed().as_secs_f64()
+    );
+
+    let mut out = BufWriter::new(File::create(&args.out)?);
+    writeln!(out, "source,target,rank,distance")?;
+    for pair in &pairs {
+        writeln!(
+            out,
+            "{},{},{},{}",
+            pair.source, pair.target, pair.rank, pair.distance
+        )?;
+    }
+    out.flush()?;
+    info!("wrote {} to {}", pairs.len(), args.out);
+    Ok(())
+}
+
+/// One walk of the graph from a source, and the node settled at each power of
+/// two along the way.
+///
+/// The search is given a target it will never reach, so it runs until the
+/// queue is empty and the whole of what the source can reach is walked.
+fn ranks_of(graph: &StaticGraph<usize>, source: NodeID) -> Vec<Pair> {
+    let mut search = UnidirectionalSearch::<RankTargets>::new();
+    search.run(graph, source, NodeID::MAX);
+
+    search
+        .stats()
+        .targets()
+        .iter()
+        // rank one is the source itself, which is not a pair
+        .filter(|&&(_, target)| target != source)
+        .map(|&(rank, target)| Pair {
+            source,
+            target,
+            rank,
+            distance: search.distance(target),
+        })
+        .collect()
+}
+
+/// One search per pair, which is what asking about a pair drawn at random
+/// costs.
+fn one_pair(graph: &StaticGraph<usize>, source: NodeID, target: NodeID) -> Option<Pair> {
+    let mut search = UnidirectionalSearch::<Counters>::new();
+    let distance = search.run(graph, source, target);
+    if distance == usize::MAX || source == target {
+        return None;
+    }
+    Some(Pair {
+        source,
+        target,
+        // the search stopped at the target, so what it settled is the rank
+        rank: search.stats().deleted,
+        distance,
+    })
+}
+
+fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
+    let graph = load_graph(&args.graph);
+    let pairs = read_pairs(&args.input)?;
+    info!("read {} pairs from {}", pairs.len(), args.input);
+    if pairs.is_empty() {
+        return Err("there are no pairs to time".into());
+    }
+
+    let timings = match args.engine {
+        Engine::Dijkstra => time_dijkstra(&graph, &pairs, args.warmup),
+        Engine::Mld => {
+            if args.directory.is_empty() {
+                return Err("the mld engine wants a level directory, see --directory".into());
+            }
+            let directory: LevelDirectory = io::read_from_file(&args.directory);
+            info!(
+                "loaded a directory of {} levels over {} nodes",
+                directory.levels(),
+                directory.number_of_nodes()
+            );
+            time_mld(graph, directory, &pairs, args.warmup)
+        }
+    };
+
+    let mut out = BufWriter::new(File::create(&args.out)?);
+    writeln!(out, "engine,rank,nanos,distance")?;
+    for (rank, nanos, distance) in &timings {
+        writeln!(out, "{},{rank},{nanos},{distance}", args.engine)?;
+    }
+    out.flush()?;
+    info!("wrote {} timings to {}", timings.len(), args.out);
+    Ok(())
+}
+
+/// The pairs, timed one at a time on one thread. Timing under rayon would say
+/// as much about the scheduler as about the search.
+fn time_dijkstra(
+    graph: &StaticGraph<usize>,
+    pairs: &[ToTime],
+    warmup: usize,
+) -> Vec<(usize, u128, usize)> {
+    let mut search = UnidirectionalDijkstra::new();
+    for &(source, target, _) in pairs.iter().take(warmup) {
+        search.run(graph, source, target);
+    }
+
+    pairs
+        .iter()
+        .map(|&(source, target, rank)| {
+            let started = Instant::now();
+            let distance = search.run(graph, source, target);
+            (rank, started.elapsed().as_nanos(), distance)
+        })
+        .collect()
+}
+
+/// The same pairs over the cells of the partition.
+///
+/// The overlay is worked out as it is asked for, so the warm-up matters more
+/// here than it does for the plain search: without it the first pairs would be
+/// paying for the customization of every cell they touch.
+fn time_mld(
+    graph: StaticGraph<usize>,
+    directory: LevelDirectory,
+    pairs: &[ToTime],
+    warmup: usize,
+) -> Vec<(usize, u128, usize)> {
+    let customization = Customization::new(graph, directory);
+    let mut query = MldQuery::new();
+
+    let started = Instant::now();
+    for &(source, target, _) in pairs.iter().take(warmup) {
+        query.run(&customization, source, &[target]);
+    }
+    info!(
+        "warmed {} cells in {:.1} s",
+        customization.customized_cells(),
+        started.elapsed().as_secs_f64()
+    );
+
+    pairs
+        .iter()
+        .map(|&(source, target, rank)| {
+            let started = Instant::now();
+            let reached = query.run(&customization, source, &[target]);
+            let elapsed = started.elapsed().as_nanos();
+            let distance = if reached {
+                query.distance(target)
+            } else {
+                usize::MAX
+            };
+            (rank, elapsed, distance)
+        })
+        .collect()
+}
+
+fn read_pairs(path: &str) -> Result<Vec<ToTime>, Box<dyn Error>> {
+    let mut pairs = Vec::new();
+    let mut skipped = 0;
+    for line in BufReader::new(File::open(path)?).lines().skip(1) {
+        let line = line?;
+        let mut fields = line.split(',');
+        let source = fields.next().and_then(|f| f.parse().ok());
+        let target = fields.next().and_then(|f| f.parse().ok());
+        let rank = fields.next().and_then(|f| f.parse().ok());
+        match (source, target, rank) {
+            (Some(source), Some(target), Some(rank)) => pairs.push((source, target, rank)),
+            _ => skipped += 1,
+        }
+    }
+    if skipped > 0 {
+        warn!("{skipped} lines of {path} were not a pair and were left out");
+    }
+    Ok(pairs)
+}

--- a/src/ranks/bin/main.rs
+++ b/src/ranks/bin/main.rs
@@ -31,7 +31,7 @@ use std::{
 use command_line::{Arguments, Engine, Mode, Sample, Time};
 use env_logger::{Builder, Env};
 use log::{info, warn};
-use rand::{RngExt, SeedableRng, prelude::StdRng};
+use rand::{RngExt, SeedableRng, prelude::StdRng, seq::SliceRandom};
 use rayon::prelude::*;
 
 use toolbox_rs::{
@@ -48,6 +48,12 @@ use toolbox_rs::{
 
 /// A pair to time, and the rank its target sits at.
 type ToTime = (NodeID, NodeID, usize);
+
+/// What one pair cost: the pair itself, its rank, the nanoseconds, and what
+/// the search said the distance was. The pair is carried through so the two
+/// engines can be held against each other rather than trusted to come out in
+/// the same order.
+type Timing = (NodeID, NodeID, usize, u128, usize);
 
 /// A pair of nodes and where the target sits on the rank axis.
 ///
@@ -73,6 +79,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
+/// Whether a path is there to be read, said plainly rather than left to the
+/// unwrap inside the reader.
+fn readable(path: &str, what: &str) -> Result<(), Box<dyn Error>> {
+    if path.is_empty() {
+        return Err(format!("no {what} was given").into());
+    }
+    if !std::path::Path::new(path).is_file() {
+        return Err(format!("the {what} {path:?} is not a file that can be read").into());
+    }
+    Ok(())
+}
+
 fn load_graph(path: &str) -> StaticGraph<usize> {
     let edges = io::read_vec_from_file::<InputEdge<usize>>(path);
     info!("loaded {} graph edges", edges.len());
@@ -86,6 +104,7 @@ fn load_graph(path: &str) -> StaticGraph<usize> {
 }
 
 fn run_sample(args: &Sample) -> Result<(), Box<dyn Error>> {
+    readable(&args.graph, "graph")?;
     let graph = load_graph(&args.graph);
     let node_count = graph.number_of_nodes();
     if node_count == 0 {
@@ -188,19 +207,29 @@ fn one_pair(graph: &StaticGraph<usize>, source: NodeID, target: NodeID) -> Optio
 }
 
 fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
+    readable(&args.graph, "graph")?;
+    readable(&args.input, "input")?;
+    if args.engine == Engine::Mld {
+        readable(&args.directory, "level directory")?;
+    }
     let graph = load_graph(&args.graph);
-    let pairs = read_pairs(&args.input)?;
+    let mut pairs = read_pairs(&args.input)?;
     info!("read {} pairs from {}", pairs.len(), args.input);
     if pairs.is_empty() {
         return Err("there are no pairs to time".into());
     }
 
+    // The pairs arrive in the order they were sampled, which is every rank of
+    // one source and then every rank of the next. Timed in that order, each
+    // query but the first of a source finds that source's cells already warm
+    // and its part of the graph already in cache, and the ranks within a
+    // source run from low to high, so the bias lines up with the very axis
+    // being plotted. Shuffling spreads it out.
+    pairs.shuffle(&mut StdRng::seed_from_u64(args.seed));
+
     let timings = match args.engine {
         Engine::Dijkstra => time_dijkstra(&graph, &pairs, args.warmup),
         Engine::Mld => {
-            if args.directory.is_empty() {
-                return Err("the mld engine wants a level directory, see --directory".into());
-            }
             let directory: LevelDirectory = io::read_from_file(&args.directory);
             info!(
                 "loaded a directory of {} levels over {} nodes",
@@ -212,9 +241,13 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
     };
 
     let mut out = BufWriter::new(File::create(&args.out)?);
-    writeln!(out, "engine,rank,nanos,distance")?;
-    for (rank, nanos, distance) in &timings {
-        writeln!(out, "{},{rank},{nanos},{distance}", args.engine)?;
+    writeln!(out, "engine,source,target,rank,nanos,distance")?;
+    for (source, target, rank, nanos, distance) in &timings {
+        writeln!(
+            out,
+            "{},{source},{target},{rank},{nanos},{distance}",
+            args.engine
+        )?;
     }
     out.flush()?;
     info!("wrote {} timings to {}", timings.len(), args.out);
@@ -223,11 +256,7 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
 
 /// The pairs, timed one at a time on one thread. Timing under rayon would say
 /// as much about the scheduler as about the search.
-fn time_dijkstra(
-    graph: &StaticGraph<usize>,
-    pairs: &[ToTime],
-    warmup: usize,
-) -> Vec<(usize, u128, usize)> {
+fn time_dijkstra(graph: &StaticGraph<usize>, pairs: &[ToTime], warmup: usize) -> Vec<Timing> {
     let mut search = UnidirectionalDijkstra::new();
     for &(source, target, _) in pairs.iter().take(warmup) {
         search.run(graph, source, target);
@@ -238,7 +267,7 @@ fn time_dijkstra(
         .map(|&(source, target, rank)| {
             let started = Instant::now();
             let distance = search.run(graph, source, target);
-            (rank, started.elapsed().as_nanos(), distance)
+            (source, target, rank, started.elapsed().as_nanos(), distance)
         })
         .collect()
 }
@@ -253,7 +282,7 @@ fn time_mld(
     directory: LevelDirectory,
     pairs: &[ToTime],
     warmup: usize,
-) -> Vec<(usize, u128, usize)> {
+) -> Vec<Timing> {
     let customization = Customization::new(graph, directory);
     let mut query = MldQuery::new();
 
@@ -278,7 +307,7 @@ fn time_mld(
             } else {
                 usize::MAX
             };
-            (rank, elapsed, distance)
+            (source, target, rank, elapsed, distance)
         })
         .collect()
 }

--- a/src/unidirectional_dijkstra.rs
+++ b/src/unidirectional_dijkstra.rs
@@ -56,6 +56,17 @@ impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
         self.upper_bound = usize::MAX;
     }
 
+    /// What it cost to reach a node, and `usize::MAX` for one the last run
+    /// never reached.
+    ///
+    /// A run that stopped at its target has this for every node it settled on
+    /// the way, and one that ran until the queue was empty has it for
+    /// everything the source can reach.
+    #[must_use]
+    pub fn distance(&self, node: NodeID) -> usize {
+        self.queue.weight(node)
+    }
+
     /// retrieves the number of nodes that were explored (not settled) during
     /// a search.
     pub fn search_space_len(&self) -> usize {


### PR DESCRIPTION
Stacked on #589.

New binary `ranks` (`src/ranks/bin/`), and one method on `UnidirectionalSearch`.

## `ranks sample`

```
ranks sample -g graph.toolbox -s 1000 --seed 5EED -o pairs.csv [--pairs] [-t threads]
```

Draws sources at random, walks the whole graph from each with `UnidirectionalSearch<RankTargets>`, and writes the node settled at each power of two with the rank it was settled at. Output columns: `source,target,rank,distance`.

One walk yields a pair for every rank, so a sample costs a search per source rather than a search per pair. On europe.ptv a full search is about 25 s, so 1000 sources is about 24,000 pairs in roughly 50 minutes on eight threads.

There is no separate settled count in the output because the rank is the settled count — the target was the rank-th node settled.

`--pairs` draws pairs of nodes and searches each on its own. It covers the rank axis badly: a target drawn at random sits near the top of it almost every time.

Sources are drawn on one thread before the searches fan out over rayon, so a seed gives the same sample whatever the thread count.

## `ranks time`

```
ranks time -g graph.toolbox [-d levels.bin] -i pairs.csv -e dijkstra|mld -o timings.csv [--warmup n]
```

Reads the pairs back and runs them again with `Untracked`, on one thread. Output columns: `engine,rank,nanos,distance`. The engine is a column rather than part of the filename, so runs of both engines concatenate into one file for the plot.

`--warmup` runs that many pairs before the clock starts. It matters most for `mld`, where the overlay is worked out as it is asked for.

## `UnidirectionalSearch::distance(node)`

Returns what a node cost once a run has settled it, `usize::MAX` otherwise. The search could previously only report what its own target cost; a walk of the whole graph settles a target for every rank and each needs its distance.

## Measured on europe.ptv

256 pairs, ranks 2 to 65536, six-level partition. Both engines agree on the distance for every pair.

| rank | dijkstra | mld, warm | speedup |
| --- | --- | --- | --- |
| 2 | 2.9 us | 3.1 us | 0.92 |
| 64 | 8.0 us | 8.1 us | 0.99 |
| 512 | 51.5 us | 28.3 us | 1.82 |
| 4096 | 507 us | 96 us | 5.25 |
| 32768 | 4.75 ms | 425 us | 11.17 |
| 65536 | 10.0 ms | 864 us | 11.61 |

Parity where there is nothing to skip, climbing to 11.6x at the top of this range, which is still only the low quarter of the rank axis.

The same run with `--warmup 10` instead of 256 reports mld at 9.7 ms for rank 8192 against 196 us warm — a factor of fifty. That difference is cells being tabulated for the first time inside the timed call. Warm the overlay or the numbers are about customization.
