### PR TITLE
Measure the query against a plain search, and the overlay against both

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -11,4 +11,5 @@ criterion_main!(
     benchmarks::loser_tree::loser_tree,
     benchmarks::polyline::polyline,
     benchmarks::mercator::mercator_benches,
+    benchmarks::mld_query::mld_query,
 );

--- a/benches/benchmarks/mld_query.rs
+++ b/benches/benchmarks/mld_query.rs
@@ -1,0 +1,128 @@
+//! What a search over the cells costs against a search through them.
+//!
+//! Every pair of every rank goes into one measurement, so what comes out is a
+//! mixture over the whole rank axis and a guard against the cost moving, not a
+//! reading of the speedup. The speedup depends on how far apart the ends of a
+//! query are, and where that is read is the rank plot the `ranks` tool feeds.
+//!
+//! A grid is also not a road network. Its cells are uniform and its finest
+//! ones hold four nodes, of which all four sit on the border, so there is
+//! little to step over down there. It says how the cost scales with the size
+//! of the graph, and that the query does not get slower.
+
+use criterion::{Criterion, criterion_group};
+use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
+use std::hint::black_box;
+
+use toolbox_rs::{
+    customization::Customization,
+    graph::{Graph, NodeID},
+    grid_graph::grid,
+    heap_stats::RankTargets,
+    mld_query::MldQuery,
+    unidirectional_dijkstra::{UnidirectionalDijkstra, UnidirectionalSearch},
+};
+
+/// The sides to measure on. A grid of 256 is 65,536 nodes, which is enough for
+/// the rank axis to have somewhere to go and small enough for the overlay to
+/// be worked out in the setup of a benchmark.
+const SIDES: [usize; 3] = [64, 128, 256];
+
+/// Pairs drawn the way the `ranks` tool draws them: one walk of the graph per
+/// source, and the node settled at each power of two.
+///
+/// Working this out here rather than in the loop is what keeps the counting
+/// out of the measurement. Nothing timed below collects anything.
+fn pairs_of(
+    graph: &toolbox_rs::static_graph::StaticGraph<usize>,
+    sources: usize,
+) -> Vec<(NodeID, NodeID)> {
+    let mut rng = StdRng::seed_from_u64(0x_5EED);
+    let mut search = UnidirectionalSearch::<RankTargets>::new();
+    let mut pairs = Vec::new();
+
+    for _ in 0..sources {
+        let source = rand::RngExt::random_range(&mut rng, 0..graph.number_of_nodes());
+        search.run(graph, source, NodeID::MAX);
+        pairs.extend(
+            search
+                .stats()
+                .targets()
+                .iter()
+                .filter(|&&(_, target)| target != source)
+                .map(|&(_, target)| (source, target)),
+        );
+    }
+
+    // The pairs come out as every rank of one source and then the next, so a
+    // run in that order finds each source's cells warm from the query before
+    // it. Shuffling spreads that out.
+    pairs.shuffle(&mut rng);
+    pairs
+}
+
+pub fn query_benchmark(c: &mut Criterion) {
+    for side in SIDES {
+        let (graph, directory) = grid(side, true);
+        let pairs = pairs_of(&graph, 8);
+        let customization = Customization::new(graph, directory);
+
+        // every cell any of these pairs opens, worked out before the clock
+        // starts, or the first iteration pays for the whole overlay
+        let mut warm = MldQuery::new();
+        for &(source, target) in &pairs {
+            warm.run(&customization, source, &[target]);
+        }
+
+        let mut dijkstra = UnidirectionalDijkstra::new();
+        c.bench_function(&format!("mld/dijkstra/{side}"), |b| {
+            b.iter(|| {
+                for &(source, target) in black_box(&pairs) {
+                    black_box(dijkstra.run(customization.graph(), source, target));
+                }
+            });
+        });
+
+        let mut query = MldQuery::new();
+        c.bench_function(&format!("mld/query/{side}"), |b| {
+            b.iter(|| {
+                for &(source, target) in black_box(&pairs) {
+                    black_box(query.run(black_box(&customization), source, &[target]));
+                }
+            });
+        });
+    }
+}
+
+/// What the overlay costs to work out, which is what is being traded for the
+/// query time above.
+///
+/// A fresh customization per iteration, as a warm one has nothing left to do.
+pub fn customization_benchmark(c: &mut Criterion) {
+    for side in [64_usize, 128] {
+        let levels = grid(side, true).1.levels();
+
+        c.bench_function(&format!("mld/customize/{side}"), |b| {
+            b.iter_batched(
+                || {
+                    // built afresh each time, as a graph cannot be cloned and a
+                    // customization that has already been asked has nothing
+                    // left to work out
+                    let (graph, directory) = grid(side, true);
+                    Customization::new(graph, directory)
+                },
+                |customization| {
+                    for level in 0..levels {
+                        let cells = customization.level(level).nodes_of_cell.len();
+                        for cell in 0..cells {
+                            black_box(customization.distances_of(level, cell as u32));
+                        }
+                    }
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+}
+
+criterion_group!(mld_query, query_benchmark, customization_benchmark);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -4,5 +4,6 @@ pub mod k_way_merge_iterator;
 pub mod loser_tree;
 pub mod medium_size_hash_table;
 pub mod mercator;
+pub mod mld_query;
 pub mod polyline;
 pub mod radix_sort;

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -1,0 +1,125 @@
+#!/usr/bin/env Rscript
+#
+# Draws what the searches cost against how far apart the ends of a query are.
+#
+#   Rscript scripts/rank_plot.R timings.csv ranks.png
+#
+# The input is what `ranks time` writes, with the runs of both engines laid end
+# to end:
+#
+#   ranks time -g graph -i pairs.csv -e dijkstra -o d.csv
+#   ranks time -g graph -d levels -i pairs.csv -e mld -o m.csv
+#   cat d.csv <(tail -n +2 m.csv) > timings.csv
+#
+# Base graphics only, and no package beyond what R ships with. A plot that
+# wants an install first is a plot that does not get looked at, and this one is
+# meant to run wherever the numbers were made.
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1) {
+  stop("usage: rank_plot.R <timings.csv> [out.png]")
+}
+input <- args[1]
+output <- if (length(args) >= 2) args[2] else "ranks.png"
+
+timings <- read.csv(input, stringsAsFactors = FALSE)
+for (column in c("engine", "rank", "nanos")) {
+  if (!column %in% names(timings)) {
+    stop(sprintf("%s has no %s column", input, column))
+  }
+}
+
+timings <- timings[timings$rank > 0 & timings$nanos > 0, ]
+if (nrow(timings) == 0) {
+  stop("there is nothing to plot")
+}
+
+# microseconds read better than nanoseconds, and the rank axis is drawn at the
+# exponent so the ticks say 2^10 rather than 1024
+timings$micros <- timings$nanos / 1000
+timings$exponent <- round(log2(timings$rank))
+engines <- sort(unique(timings$engine))
+exponents <- sort(unique(timings$exponent))
+
+# a bucket holding a handful of samples is drawn like the rest and marked, so
+# that a thin tail reads as a thin tail rather than as a result
+THIN <- 5
+counts <- table(timings$exponent)
+thin <- as.integer(names(counts)[counts < THIN * length(engines)])
+
+palette <- c("#3060c0", "#c05030", "#309050", "#9050b0")
+colour_of <- setNames(palette[seq_along(engines)], engines)
+
+png(output, width = 1400, height = 1000, res = 130)
+layout(matrix(c(1, 2), nrow = 2), heights = c(2, 1))
+par(mar = c(1.5, 4.5, 2.5, 1), las = 1)
+
+# what each engine costs, as a box per bucket
+groups <- list()
+at <- c()
+fill <- c()
+width <- 0.8 / length(engines)
+for (index in seq_along(exponents)) {
+  for (which in seq_along(engines)) {
+    rows <- timings$exponent == exponents[index] & timings$engine == engines[which]
+    groups[[length(groups) + 1]] <- timings$micros[rows]
+    offset <- (which - (length(engines) + 1) / 2) * width
+    at <- c(at, exponents[index] + offset)
+    fill <- c(fill, colour_of[engines[which]])
+  }
+}
+
+boxplot(groups,
+  at = at, boxwex = width * 0.9, col = fill, log = "y",
+  xaxt = "n", xlab = "", ylab = "microseconds",
+  main = sprintf("query time by Dijkstra rank (%s)", basename(input)),
+  outcex = 0.3, whisklty = 1, staplewex = 0.5
+)
+axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+abline(v = exponents[-1] - 0.5, col = "#00000012")
+legend("topleft", legend = engines, fill = colour_of[engines], bty = "n")
+if (length(thin) > 0) {
+  mtext(sprintf("thin buckets, under %d samples: 2^%s", THIN,
+                paste(thin, collapse = ", 2^")),
+        side = 3, line = 0, cex = 0.7, col = "#a04000")
+}
+
+# and what one is worth against another, which is the curve to read
+par(mar = c(4.5, 4.5, 1, 1))
+medians <- sapply(engines, function(engine) {
+  sapply(exponents, function(exponent) {
+    rows <- timings$exponent == exponent & timings$engine == engine
+    if (any(rows)) median(timings$micros[rows]) else NA
+  })
+})
+medians <- matrix(medians, nrow = length(exponents), dimnames = list(NULL, engines))
+
+if (all(c("dijkstra", "mld") %in% engines)) {
+  speedup <- medians[, "dijkstra"] / medians[, "mld"]
+  ylim <- range(c(speedup, 1), na.rm = TRUE)
+  plot(exponents, speedup,
+    type = "b", pch = 19, log = "y", ylim = ylim, xaxt = "n",
+    xlab = "Dijkstra rank", ylab = "dijkstra / mld", col = "#204080"
+  )
+  axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+  # at one the two cost the same; below it the cells are not paying for
+  # themselves, and it should climb as more of them can be stepped over. A
+  # curve that does not climb is the thing to look for: every level is sound to
+  # step over, so a query that picks a low one gives the same answers and no
+  # test of those answers would say a word.
+  abline(h = 1, lty = 2, col = "#808080")
+  best <- which.max(speedup)
+  if (length(best) == 1 && is.finite(speedup[best])) {
+    mtext(sprintf("best %.1fx at 2^%d", speedup[best], exponents[best]),
+          side = 3, line = -1.2, adj = 0.98, cex = 0.75, col = "#204080")
+  }
+} else {
+  plot.new()
+  mtext("a speedup wants both engines in the file", side = 3, line = -3,
+        cex = 0.8, col = "#808080")
+}
+
+invisible(dev.off())
+cat(sprintf("wrote %s: %d timings, %d engines, ranks 2^%d to 2^%d\n",
+            output, nrow(timings), length(engines),
+            min(exponents), max(exponents)))


### PR DESCRIPTION
Stacked on #590.

New file `benches/benchmarks/mld_query.rs`, registered in `benches/benchmarks/mod.rs` and `benches/bench_main.rs`.

## Benchmarks

- `mld/dijkstra/{side}` and `mld/query/{side}` for sides 64, 128, 256 — the same pairs through `UnidirectionalDijkstra` and `MldQuery`
- `mld/customize/{side}` for sides 64, 128 — the cost of working out every cell of every level, with a fresh `Customization` per iteration via `iter_batched`

## How the pairs are drawn

`UnidirectionalSearch<RankTargets>` per source, taking the node settled at each power of two, which is the method the `ranks` tool uses. Eight sources per side.

The pairs are then shuffled. They come off the sampler as every rank of one source and then the next, so run in that order each query but the first of a source finds that source's cells warm and its part of the graph in cache.

Both happen in the setup. Nothing inside a timed loop collects anything: the searches are the `Untracked` aliases.

## Warming

Every pair is run once before `bench_function`. Without it the first criterion iteration pays for the customization of every cell the pairs touch. Measured on a partition of europe, the same query reads 196 us warm and 9.7 ms cold.

## Numbers

| side | nodes | `mld/dijkstra` | `mld/query` | ratio |
| --- | --- | --- | --- | --- |
| 64 | 4,096 | 5.28 ms | 6.14 ms | 0.86 |
| 128 | 16,384 | 25.0 ms | 24.1 ms | 1.03 |
| 256 | 65,536 | 128.5 ms | 89.7 ms | 1.43 |

| side | `mld/customize` |
| --- | --- |
| 64 | 63.0 ms |
| 128 | 493 ms |

## What these numbers are not

Every rank goes into one measurement, so the ratio is a mixture over the whole rank axis rather than a reading of the speedup, which depends on how far apart the ends of a query are. That is what the rank plot is for.

A grid is also not a road network: its cells are uniform and the finest hold four nodes with all four on the border, so there is little to step over down there. This says how the cost scales with the size of the graph, and that the query has not got slower.
