### PR TITLE
Hold the query against a plain search on a road network

### DIFF
--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -467,6 +467,14 @@ mod tests {
         agrees_with_dijkstra_on(16, false, 0x_DEEB, 10);
     }
 
+    /// Six levels, so there is a cell of a thousand nodes to step over and
+    /// five sizes of cell between that and the source. A partition of a road
+    /// network is shaped like this and a grid of eight is not.
+    #[test]
+    fn a_grid_of_six_levels_agrees_with_a_plain_search() {
+        agrees_with_dijkstra_on(64, false, 0x_51E5, 3);
+    }
+
     /// Stepping over a cell is supposed to save work, not merely give the same
     /// answer by a longer road.
     ///

--- a/src/ranks/bin/command_line.rs
+++ b/src/ranks/bin/command_line.rs
@@ -20,6 +20,15 @@ pub enum Mode {
     /// cost the same as searching a source for every one of them.
     Sample(Sample),
 
+    /// Holds the search over the cells against a search through them.
+    ///
+    /// Every pair of the file is asked of both, and a distance they disagree
+    /// on is a fault in one of them. The pairs of a source are asked of the
+    /// query together rather than one at a time, as a query with a set of
+    /// targets has to leave every cell holding one of them alone and that is
+    /// not exercised by asking for a single target.
+    Check(Check),
+
     /// Times the pairs, and counts nothing while doing it.
     ///
     /// A run that is being counted is not a run worth timing, so this reads
@@ -56,6 +65,25 @@ pub struct Sample {
     /// come out empty, and every pair costs a search of its own.
     #[clap(long, action)]
     pub pairs: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct Check {
+    /// path to the input graph
+    #[clap(short, long, action)]
+    pub graph: String,
+
+    /// path to the level directory that chipper wrote
+    #[clap(short, long, action)]
+    pub directory: String,
+
+    /// the pairs to check, as written by the sample mode
+    #[clap(short, long, action)]
+    pub input: String,
+
+    /// how many disagreements to print before saying only how many there were
+    #[clap(long, default_value_t = 10, action)]
+    pub report: usize,
 }
 
 #[derive(Parser, Debug)]
@@ -118,6 +146,12 @@ impl Display for Arguments {
                 writeln!(f, "seed: {}", sample.seed)?;
                 writeln!(f, "out: {}", sample.out)?;
                 writeln!(f, "pairs of nodes drawn at random: {}", sample.pairs)
+            }
+            Mode::Check(check) => {
+                writeln!(f, "mode: check")?;
+                writeln!(f, "graph: {}", check.graph)?;
+                writeln!(f, "level directory: {}", check.directory)?;
+                writeln!(f, "in: {}", check.input)
             }
             Mode::Time(time) => {
                 writeln!(f, "mode: time")?;

--- a/src/ranks/bin/main.rs
+++ b/src/ranks/bin/main.rs
@@ -28,11 +28,28 @@ use std::{
     time::Instant,
 };
 
-use command_line::{Arguments, Engine, Mode, Sample, Time};
+use command_line::{Arguments, Check, Engine, Mode, Sample, Time};
 use env_logger::{Builder, Env};
+use indicatif::{ProgressBar, ProgressStyle};
 use log::{info, warn};
 use rand::{RngExt, SeedableRng, prelude::StdRng, seq::SliceRandom};
 use rayon::prelude::*;
+use rustc_hash::FxHashMap;
+
+/// The bar the crate draws elsewhere, so this looks like the rest of it.
+fn bar_of(count: usize, what: &str) -> ProgressBar {
+    let bar = ProgressBar::new(count as u64);
+    bar.set_style(
+        ProgressStyle::default_spinner()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] {wide_bar:.green/yellow} {pos}/{len} {msg}",
+            )
+            .expect("the template is not a template")
+            .progress_chars("#>-"),
+    );
+    bar.set_message(what.to_string());
+    bar
+}
 
 use toolbox_rs::{
     customization::Customization,
@@ -75,6 +92,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match &args.mode {
         Mode::Sample(sample) => run_sample(sample),
+        Mode::Check(check) => run_check(check),
         Mode::Time(time) => run_time(time),
     }
 }
@@ -132,18 +150,28 @@ fn run_sample(args: &Sample) -> Result<(), Box<dyn Error>> {
     };
 
     let started = Instant::now();
+    let bar = bar_of(sources.len(), "sources");
     let pairs: Vec<Pair> = if args.pairs {
         sources
             .par_iter()
             .zip(targets.par_iter())
-            .filter_map(|(&source, &target)| one_pair(&graph, source, target))
+            .filter_map(|(&source, &target)| {
+                let pair = one_pair(&graph, source, target);
+                bar.inc(1);
+                pair
+            })
             .collect()
     } else {
         sources
             .par_iter()
-            .flat_map_iter(|&source| ranks_of(&graph, source))
+            .flat_map_iter(|&source| {
+                let of_source = ranks_of(&graph, source);
+                bar.inc(1);
+                of_source
+            })
             .collect()
     };
+    bar.finish_and_clear();
     info!(
         "{} pairs from {} sources in {:.1} s",
         pairs.len(),
@@ -206,6 +234,62 @@ fn one_pair(graph: &StaticGraph<usize>, source: NodeID, target: NodeID) -> Optio
     })
 }
 
+/// Asks both searches about every pair and says where they disagree.
+///
+/// The pairs of a source go to the query together. A query with a set of
+/// targets has to walk the arcs of every cell holding one of them rather than
+/// stepping over it, and asking for one target at a time never puts that to
+/// the test.
+fn run_check(args: &Check) -> Result<(), Box<dyn Error>> {
+    readable(&args.graph, "graph")?;
+    readable(&args.directory, "level directory")?;
+    readable(&args.input, "input")?;
+
+    let graph = load_graph(&args.graph);
+    let pairs = read_pairs(&args.input)?;
+    let directory: LevelDirectory = io::read_from_file(&args.directory);
+    info!(
+        "checking {} pairs over a directory of {} levels",
+        pairs.len(),
+        directory.levels()
+    );
+
+    let mut of_source: FxHashMap<NodeID, Vec<NodeID>> = FxHashMap::default();
+    for &(source, target, _) in &pairs {
+        of_source.entry(source).or_default().push(target);
+    }
+
+    let customization = Customization::new(graph, directory);
+    let mut query = MldQuery::new();
+    let mut plain = UnidirectionalDijkstra::new();
+    let mut checked = 0_usize;
+    let mut wrong = Vec::new();
+
+    let bar = bar_of(of_source.len(), "sources");
+    for (&source, targets) in &of_source {
+        query.run(&customization, source, targets);
+        for &target in targets {
+            let by_query = query.distance(target);
+            let by_plain = plain.run(customization.graph(), source, target);
+            checked += 1;
+            if by_query != by_plain {
+                wrong.push((source, target, by_plain, by_query));
+            }
+        }
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+
+    for &(source, target, by_plain, by_query) in wrong.iter().take(args.report) {
+        warn!("{source} to {target}: the graph says {by_plain}, the cells say {by_query}");
+    }
+    if wrong.is_empty() {
+        info!("{checked} pairs, and the two agree on every one");
+        return Ok(());
+    }
+    Err(format!("{} of {checked} pairs disagree", wrong.len()).into())
+}
+
 fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
     readable(&args.graph, "graph")?;
     readable(&args.input, "input")?;
@@ -258,18 +342,28 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
 /// as much about the scheduler as about the search.
 fn time_dijkstra(graph: &StaticGraph<usize>, pairs: &[ToTime], warmup: usize) -> Vec<Timing> {
     let mut search = UnidirectionalDijkstra::new();
+    let bar = bar_of(warmup.min(pairs.len()), "warming");
     for &(source, target, _) in pairs.iter().take(warmup) {
         search.run(graph, source, target);
+        bar.inc(1);
     }
+    bar.finish_and_clear();
 
-    pairs
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
         .iter()
         .map(|&(source, target, rank)| {
             let started = Instant::now();
             let distance = search.run(graph, source, target);
-            (source, target, rank, started.elapsed().as_nanos(), distance)
+            let elapsed = started.elapsed().as_nanos();
+            // outside the reading above, so what is drawn is not what is
+            // measured
+            bar.inc(1);
+            (source, target, rank, elapsed, distance)
         })
-        .collect()
+        .collect();
+    bar.finish_and_clear();
+    timings
 }
 
 /// The same pairs over the cells of the partition.
@@ -287,16 +381,20 @@ fn time_mld(
     let mut query = MldQuery::new();
 
     let started = Instant::now();
+    let bar = bar_of(warmup.min(pairs.len()), "warming the overlay");
     for &(source, target, _) in pairs.iter().take(warmup) {
         query.run(&customization, source, &[target]);
+        bar.inc(1);
     }
+    bar.finish_and_clear();
     info!(
         "warmed {} cells in {:.1} s",
         customization.customized_cells(),
         started.elapsed().as_secs_f64()
     );
 
-    pairs
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
         .iter()
         .map(|&(source, target, rank)| {
             let started = Instant::now();
@@ -307,9 +405,12 @@ fn time_mld(
             } else {
                 usize::MAX
             };
+            bar.inc(1);
             (source, target, rank, elapsed, distance)
         })
-        .collect()
+        .collect();
+    bar.finish_and_clear();
+    timings
 }
 
 fn read_pairs(path: &str) -> Result<Vec<ToTime>, Box<dyn Error>> {


### PR DESCRIPTION
## `ranks check`

New mode on the `ranks` binary:

```
ranks check -g graph.toolbox -d levels.bin -i pairs.csv [--report n]
```

Reads the pairs, groups them by source, asks `MldQuery` for all of a source's targets in one run, and compares each distance against `UnidirectionalDijkstra`. Prints the first `--report` disagreements and exits with an error if there are any.

Grouping by source is the point. A query given a set of targets has to walk the arcs of every cell holding one of them rather than stepping over it, and the per-level `holds_target` bookkeeping that decides this had never been exercised outside a grid: the tests use grids whose cells hold four nodes, and `ranks time` asks for one target at a time.

Result on a partition of europe.ptv, six levels, 192 pairs over ranks 2 to 4096: the two agree on every pair.

## `a_grid_of_six_levels_agrees_with_a_plain_search`

The randomised agreement tests used grids of 8 and 16 a side. Since `grid_directory` builds a full hierarchy, a grid of 64 gives six levels and a coarsest steppable cell of a thousand nodes, against sixteen at side 8.

## Progress bars

`bar_of` and the four call sites in `sample` and `time`. These were written when the tool was, but were left in a stash when that branch was parked, so they did not go up with #590.

In the timed loop `bar.inc(1)` is called after `elapsed()` is read, so nothing drawn falls inside anything measured.
