### PR TITLE
Find a node in an array rather than in a map

### DIFF
--- a/src/dense_heap.rs
+++ b/src/dense_heap.rs
@@ -1,0 +1,354 @@
+//! A queue that finds a node by looking it up in an array rather than in a map.
+//!
+//! [`crate::addressable_binary_heap::AddressableHeap`] holds the place of each
+//! node in a hash map, which is what lets it take a node of any kind that
+//! counts. A search over a graph does not need that: its nodes are the numbers
+//! zero upwards, so the place of a node can sit in an array at that number and
+//! be read without hashing anything.
+//!
+//! What an array costs is room for every node of the graph whether the search
+//! reaches it or not, and the trouble of emptying it. The nodes a run put on
+//! the queue are already written down, and a search over the cells of a
+//! partition puts a few thousand of them on out of eighteen million, so
+//! emptying is a walk of those rather than of the array.
+//!
+//! The room is the price: four bytes for every node of the graph, seventy odd
+//! megabytes on a continent, held for as long as the search object is rather
+//! than per run. A search that runs once over a large graph should use the
+//! map; a search that runs a great many times, which is what this is for, pays
+//! it once and stops paying per node thereafter.
+
+use crate::{
+    graph::NodeID,
+    heap_stats::{Counters, HeapStats, Untracked},
+};
+
+/// A queue over dense node ids that counts nothing.
+pub type DenseQueue = DenseHeap<Untracked>;
+
+/// The same queue, counting what it was asked to do.
+pub type TrackedDenseQueue = DenseHeap<Counters>;
+
+#[derive(Clone, Copy)]
+struct Held {
+    node: NodeID,
+    /// where in the heap this node sits, and zero once it has come off for good
+    key: usize,
+    weight: usize,
+    data: NodeID,
+}
+
+/// The place of a node that has not been on the queue during this run.
+const NOWHERE: u32 = u32::MAX;
+
+pub struct DenseHeap<S: HeapStats<NodeID> = Untracked> {
+    /// the binary heap itself, as places into `held`, one based so that the
+    /// root has a parent slot to stop at
+    heap: Vec<(u32, usize)>,
+    held: Vec<Held>,
+    /// where each node sits in `held`, and [`NOWHERE`] for one this run has
+    /// not held
+    places: Vec<u32>,
+    stats: S,
+}
+
+impl<S: HeapStats<NodeID>> Default for DenseHeap<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S: HeapStats<NodeID>> DenseHeap<S> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            heap: vec![(0, 0)],
+            held: Vec::new(),
+            places: Vec::new(),
+            stats: S::default(),
+        }
+    }
+
+    pub fn stats(&self) -> &S {
+        &self.stats
+    }
+
+    /// Forgets the run that has just finished.
+    ///
+    /// Only what that run put on the queue is put back, which is a few
+    /// thousand nodes of a graph of millions.
+    pub fn clear(&mut self) {
+        self.heap.truncate(1);
+        for held in &self.held {
+            self.places[held.node] = NOWHERE;
+        }
+        self.held.clear();
+        self.stats = S::default();
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.heap.len() <= 1
+    }
+
+    /// How many nodes the queue held during this run.
+    #[must_use]
+    pub fn inserted_len(&self) -> usize {
+        self.held.len()
+    }
+
+    fn place_of(&self, node: NodeID) -> Option<usize> {
+        match self.places.get(node) {
+            Some(&NOWHERE) | None => None,
+            Some(&place) => Some(place as usize),
+        }
+    }
+
+    fn remember(&mut self, node: NodeID, place: usize) {
+        if node >= self.places.len() {
+            self.places.resize(node + 1, NOWHERE);
+        }
+        self.places[node] = u32::try_from(place).expect("too many nodes on one queue");
+    }
+
+    /// Whether the node has been on the queue during this run.
+    #[must_use]
+    pub fn inserted(&self, node: NodeID) -> bool {
+        self.place_of(node).is_some()
+    }
+
+    /// Whether the node is on the queue now.
+    #[must_use]
+    pub fn contains(&self, node: NodeID) -> bool {
+        self.place_of(node)
+            .is_some_and(|place| self.held[place].key != 0)
+    }
+
+    /// What the node is held at, and the largest number there is for one the
+    /// queue has never held.
+    #[must_use]
+    pub fn weight(&self, node: NodeID) -> usize {
+        self.place_of(node)
+            .map_or(usize::MAX, |place| self.held[place].weight)
+    }
+
+    /// What was written down beside the node, which a search uses for the node
+    /// it was reached from.
+    ///
+    /// # Panics
+    ///
+    /// Panics for a node the queue has not held during this run.
+    #[must_use]
+    pub fn data(&self, node: NodeID) -> NodeID {
+        let place = self.place_of(node).expect("the queue has not held that");
+        self.held[place].data
+    }
+
+    pub fn insert(&mut self, node: NodeID, weight: usize, data: NodeID) {
+        let place = self.held.len();
+        let key = self.heap.len();
+        self.held.push(Held {
+            node,
+            key,
+            weight,
+            data,
+        });
+        self.remember(node, place);
+        self.heap.push((
+            u32::try_from(place).expect("too many nodes on one queue"),
+            weight,
+        ));
+        self.stats.inserted(node);
+        self.up_heap(key);
+    }
+
+    /// Puts a node on the queue, or lowers what it is held at, in one look.
+    pub fn insert_or_decrease(&mut self, node: NodeID, weight: usize, data: NodeID) -> bool {
+        let Some(place) = self.place_of(node) else {
+            self.insert(node, weight, data);
+            return true;
+        };
+        let held = self.held[place];
+        if held.key == 0 || held.weight <= weight {
+            return false;
+        }
+        self.held[place].weight = weight;
+        self.held[place].data = data;
+        self.heap[held.key].1 = weight;
+        self.stats.decreased(node);
+        self.up_heap(held.key);
+        true
+    }
+
+    /// Takes the lightest node off the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics on an empty queue.
+    pub fn delete_min(&mut self) -> NodeID {
+        assert!(!self.is_empty(), "the queue is empty");
+        let place = self.heap[1].0 as usize;
+        let last = self.heap.len() - 1;
+        self.heap.swap(1, last);
+        self.heap.pop();
+        if self.heap.len() > 1 {
+            self.held[self.heap[1].0 as usize].key = 1;
+            self.down_heap(1);
+        }
+        self.held[place].key = 0;
+        let node = self.held[place].node;
+        self.stats.deleted(node);
+        node
+    }
+
+    fn up_heap(&mut self, mut key: usize) {
+        let rising = self.heap[key];
+        while key > 1 {
+            let parent = key >> 1;
+            if self.heap[parent].1 <= rising.1 {
+                break;
+            }
+            self.heap[key] = self.heap[parent];
+            self.held[self.heap[key].0 as usize].key = key;
+            key = parent;
+        }
+        self.heap[key] = rising;
+        self.held[rising.0 as usize].key = key;
+    }
+
+    fn down_heap(&mut self, mut key: usize) {
+        let sinking = self.heap[key];
+        loop {
+            let mut child = key << 1;
+            if child >= self.heap.len() {
+                break;
+            }
+            if child + 1 < self.heap.len() && self.heap[child + 1].1 < self.heap[child].1 {
+                child += 1;
+            }
+            if self.heap[child].1 >= sinking.1 {
+                break;
+            }
+            self.heap[key] = self.heap[child];
+            self.held[self.heap[key].0 as usize].key = key;
+            key = child;
+        }
+        self.heap[key] = sinking;
+        self.held[sinking.0 as usize].key = key;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_lightest_comes_off_first() {
+        let mut queue = DenseQueue::new();
+        for (node, weight) in [(3, 30), (1, 10), (2, 20)] {
+            queue.insert(node, weight, node);
+        }
+        assert_eq!(queue.delete_min(), 1);
+        assert_eq!(queue.delete_min(), 2);
+        assert_eq!(queue.delete_min(), 3);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn a_node_lowered_comes_off_sooner() {
+        let mut queue = DenseQueue::new();
+        queue.insert(1, 10, 1);
+        queue.insert(2, 20, 2);
+        assert!(queue.insert_or_decrease(2, 5, 9));
+        assert_eq!(queue.delete_min(), 2);
+        assert_eq!(queue.weight(2), 5);
+        assert_eq!(queue.data(2), 9);
+    }
+
+    #[test]
+    fn a_node_is_not_lowered_to_something_larger() {
+        let mut queue = DenseQueue::new();
+        queue.insert(1, 10, 1);
+        assert!(!queue.insert_or_decrease(1, 20, 7));
+        assert_eq!(queue.weight(1), 10);
+        assert_eq!(queue.data(1), 1);
+    }
+
+    /// A node that has come off for good stays off, whatever is offered for it
+    /// afterwards.
+    #[test]
+    fn a_node_that_has_come_off_does_not_go_back_on() {
+        let mut queue = DenseQueue::new();
+        queue.insert(1, 10, 1);
+        assert_eq!(queue.delete_min(), 1);
+        assert!(!queue.insert_or_decrease(1, 1, 1));
+        assert!(queue.inserted(1));
+        assert!(!queue.contains(1));
+        assert_eq!(queue.weight(1), 10);
+    }
+
+    /// What one run held is not what the next one sees, and the forgetting is
+    /// a count rather than a walk.
+    #[test]
+    fn a_run_does_not_see_what_the_one_before_it_held() {
+        let mut queue = DenseQueue::new();
+        queue.insert(5, 50, 5);
+        assert!(queue.inserted(5));
+
+        queue.clear();
+        assert!(!queue.inserted(5));
+        assert!(!queue.contains(5));
+        assert_eq!(queue.weight(5), usize::MAX);
+        assert_eq!(queue.inserted_len(), 0);
+    }
+
+    /// A run puts back what it held and nothing else, so a node of a graph
+    /// the run never reached is untouched by it.
+    #[test]
+    fn a_run_puts_back_only_what_it_held() {
+        let mut queue = DenseQueue::new();
+        queue.insert(9, 90, 9);
+        queue.insert(2, 20, 2);
+        queue.clear();
+
+        assert!(!queue.inserted(9));
+        assert!(!queue.inserted(2));
+        assert!(!queue.inserted(5), "a node it never held");
+        queue.insert(9, 1, 9);
+        assert_eq!(queue.weight(9), 1);
+    }
+
+    #[test]
+    fn a_heap_of_many_comes_out_in_order() {
+        use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_DE95);
+        for round in 0..20 {
+            let mut queue = DenseQueue::new();
+            let count = 50 + round * 7;
+            let mut weights = Vec::new();
+            for node in 0..count {
+                let weight = rng.random_range(0..1000_usize);
+                weights.push(weight);
+                queue.insert(node, weight, node);
+            }
+            // and half of them lowered afterwards
+            for (node, weight) in weights.iter_mut().enumerate() {
+                if rng.random_range(0..2) == 0 {
+                    let lower = rng.random_range(0..(*weight).max(1));
+                    if queue.insert_or_decrease(node, lower, node) {
+                        *weight = lower;
+                    }
+                }
+            }
+
+            weights.sort_unstable();
+            let mut came_out = Vec::new();
+            while !queue.is_empty() {
+                let node = queue.delete_min();
+                came_out.push(queue.weight(node));
+            }
+            assert_eq!(came_out, weights, "round {round}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod count_min_sketch;
 pub mod customization;
 pub mod cycle_check;
 pub mod ddsg;
+pub mod dense_heap;
 pub mod dfs;
 pub mod dimacs;
 pub mod dinic;

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -34,8 +34,8 @@ use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 use crate::{
-    addressable_binary_heap::AddressableHeapWithStats,
     customization::{CellDistances, Customization, Level},
+    dense_heap::DenseHeap,
     graph::{Graph, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
     level_directory::CellId,
@@ -49,7 +49,7 @@ pub type MldQuery = MldSearch<Untracked>;
 pub type TrackedMldQuery = MldSearch<Counters>;
 
 pub struct MldSearch<S: HeapStats<NodeID>> {
-    queue: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+    queue: DenseHeap<S>,
     /// The cells of every level, held for the length of a run.
     ///
     /// `of_node` is a flat array over the nodes, so the cell a node sits in on
@@ -98,7 +98,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            queue: AddressableHeapWithStats::<NodeID, usize, NodeID, S>::new(),
+            queue: DenseHeap::<S>::new(),
             levels: Vec::new(),
             matrices: Vec::new(),
             holds_target: Vec::new(),
@@ -242,7 +242,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
                     // thousand relaxations for each of a thousand nodes, in
                     // place of a thousand for each way in.
                     let cell = self.levels[level].of_node[u];
-                    let came_from = *self.queue.data(u);
+                    let came_from = self.queue.data(u);
                     if u == came_from || self.levels[level].of_node[came_from] != cell {
                         self.relax_across_cell(customization, u, distance, level);
                     }
@@ -257,6 +257,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
 
     /// The highest level whose cell around this node holds neither the source
     /// nor a target, and `None` when even the finest one does.
+    #[inline(never)]
     fn level_to_step_over(&self, node: NodeID) -> Option<usize> {
         (0..self.levels.len()).rev().find(|&level| {
             let cell = self.levels[level].of_node[node];
@@ -265,6 +266,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     }
 
     /// The arcs across the cell, which the customization worked out.
+    #[inline(never)]
     fn relax_across_cell(
         &mut self,
         customization: &Customization,
@@ -303,6 +305,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
 
     /// The arcs of the graph that leave the cell, which is how the search gets
     /// out of one.
+    #[inline(never)]
     fn relax_out_of_cell<G: Graph<usize>>(
         &mut self,
         graph: &G,
@@ -322,6 +325,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
 
     /// Every arc of the graph, which is what a plain Dijkstra does and what
     /// this does inside a cell that holds the source or a target.
+    #[inline(never)]
     fn relax_every_arc<G: Graph<usize>>(&mut self, graph: &G, node: NodeID, distance: usize) {
         for edge in graph.edge_range(node) {
             let target = graph.target(edge);
@@ -336,6 +340,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     /// already. Asking in turn whether each has been seen, whether it is still
     /// on the queue and what it is held at, is three looks apiece to find out
     /// there is nothing to do.
+    #[inline(never)]
     fn relax(&mut self, node: NodeID, distance: usize, from: NodeID) {
         self.queue.insert_or_decrease(node, distance, from);
     }


### PR DESCRIPTION
New module `src/dense_heap.rs`: `DenseHeap<S: HeapStats<NodeID>>`, with `DenseQueue` and `TrackedDenseQueue` as the plain and counting aliases. `MldSearch` uses it in place of `AddressableHeapWithStats`.

The API is the part `MldSearch` uses: `insert`, `insert_or_decrease`, `delete_min`, `weight`, `data`, `inserted`, `contains`, `is_empty`, `inserted_len`, `clear`, `stats`.

## Why

A profile of a query at rank 2^24 on a partition of europe, sampled at 1 ms with the helpers not inlined:

| | share of samples |
| --- | --- |
| `relax_across_cell`, the walk of a cell's table | 86.7% |
| of which `relax` -> `insert_or_decrease` | 67.7% |
| `relax_out_of_cell`, the arcs of the graph | 7.6% |
| `delete_min` | 2.5% |

The single hottest line is the relax inside the table walk, at 55%. That walk is 2.75M arcs for a query that settles 12,169 nodes, and each was a hash of a node followed by a probe into memory that is not in cache.

`AddressableHeap` holds the place of a node in a hash map, which is what lets it take any node type that counts. A search over a graph does not need that: the nodes are the numbers from zero, so a place can sit in an array at that number.

## Emptying it

An array over every node cannot be walked to empty it, so what a run put on the queue is walked instead. That list already exists as `held`, and a query over the cells puts a few thousand nodes on out of eighteen million.

## Cost

`places` is a `Vec<u32>`, four bytes for every node of the graph — 72 MB on europe — held for the life of the search object rather than per run, and grown lazily as nodes are touched. `u32::MAX` marks a node the run has not held, so a place needs no second field beside it. A search that runs once over a large graph wants the map. This one runs many times.

`AddressableHeap` is unchanged and still used by both Dijkstras.

## Measured

384 pairs, partition of europe.ptv of six levels. Median per rank against `UnidirectionalDijkstra`:

| rank | dijkstra | mld, hash map | mld, dense array | speedup |
| --- | --- | --- | --- | --- |
| 2^17 | 34.0 ms | 758 us | 628 us | 54 |
| 2^19 | 157.2 ms | 1.8 ms | 1.3 ms | 117 |
| 2^21 | 703.1 ms | 4.3 ms | 3.1 ms | 224 |
| 2^24 | 6587.3 ms | 28.4 ms | 17.2 ms | 383 |

All 384 distances unchanged and equal to the plain search.

## A table sized to the search instead

An open addressed table with linear probing, sized to what a query holds rather than to the graph, was tried as well: 1024 slots doubling at half full, keys spread by multiplying with the golden ratio rather than by remainder, since the ids of a road network are handed out along the ground and a remainder drops a region into one run of slots.

It is 256 KB against 72 MB and it is slower: 26.1 ms against 17.2 ms at rank 2^24, which is 252 times rather than 383.

The array is large but the part of it a query touches is not. A query settles about twelve thousand nodes and the walk of the tables reads each of them a couple of hundred times, so the working set is twelve thousand cache lines, under a megabyte, and it stays in cache after it is first touched. Both fit; the array has no hash to compute, no chain to walk and no branch to predict.

The table is kept in mind rather than kept: 72 MB is worth paying on a machine that already holds the graph, and it would not be on one that does not.

## Tests

Seven in the module: ordering, decrease-key raising a node's position, a decrease to something larger refused, a settled node not going back on, a run not seeing what the run before it held, a run putting back only what it held, and a randomised check over twenty rounds that a heap of many nodes with half of them lowered comes out in weight order.
