### PR TITLE
Keep the cell tables in four byte numbers

### DIFF
--- a/src/customization.rs
+++ b/src/customization.rs
@@ -34,8 +34,23 @@ use std::{
 /// The distances between the border nodes of one cell, in the order the border
 /// nodes are listed in.
 pub struct CellDistances {
-    pub border_nodes: Vec<NodeID>,
-    matrix: Vec<usize>,
+    /// The nodes on the edge of the cell, as four byte numbers.
+    ///
+    /// Read side by side with a row of the table above, once per arc a query
+    /// takes across the cell, so the two are streamed together and both are
+    /// worth keeping narrow. A graph of four thousand million nodes is not one
+    /// this crate can hold anyway, as the tables address it with four bytes.
+    pub border_nodes: Vec<u32>,
+    /// What it costs to cross the cell, as four byte numbers.
+    ///
+    /// A query reads one of these for every arc it takes across a cell, and
+    /// that walk is where such a query spends most of its time. Eight byte
+    /// numbers would be twice the memory to stream for the same answers: on a
+    /// partition of a continent the tables come to some sixty million entries,
+    /// and the row of a coarse cell is a few hundred of them read one after
+    /// another. Four bytes reach four thousand million, and the longest way
+    /// across europe by the clock is under a million.
+    matrix: Vec<u32>,
     /// Where each border node sits in `border_nodes`.
     ///
     /// A query reads the matrix once per arc it takes across a cell, and the
@@ -51,7 +66,12 @@ impl CellDistances {
     /// both given as their place in `border_nodes`.
     #[must_use]
     pub fn distance(&self, source: usize, target: usize) -> usize {
-        self.matrix[source * self.border_nodes.len() + target]
+        let across = self.matrix[source * self.border_nodes.len() + target];
+        if across == u32::MAX {
+            usize::MAX
+        } else {
+            across as usize
+        }
     }
 
     /// Where a node sits in `border_nodes`, and `None` for a node that is not
@@ -364,12 +384,17 @@ impl Customization {
 
         // whichever graph it is, the border nodes lead its numbering
         let border = (0..border_nodes.len()).collect::<Vec<_>>();
-        let mut matrix = vec![usize::MAX; border_nodes.len() * border_nodes.len()];
+        let mut matrix = vec![u32::MAX; border_nodes.len() * border_nodes.len()];
         let mut dijkstra = OneToManyDijkstra::new();
         for &source in &border {
             dijkstra.run(&cell_graph, source, &border);
             for &target in &border {
-                matrix[source * border_nodes.len() + target] = dijkstra.distance(target);
+                let across = dijkstra.distance(target);
+                // what cannot be reached keeps the largest four byte number,
+                // and a cell that really did cost that much would be a graph
+                // nobody has
+                matrix[source * border_nodes.len() + target] =
+                    u32::try_from(across).unwrap_or(u32::MAX);
             }
         }
         drop(of_node);
@@ -408,7 +433,10 @@ impl Customization {
             .map(|(place, &node)| (node, place))
             .collect();
         Some(CellDistances {
-            border_nodes,
+            border_nodes: border_nodes
+                .into_iter()
+                .map(|node| u32::try_from(node).expect("the graph is too large to hold"))
+                .collect(),
             matrix,
             place_of,
         })
@@ -491,9 +519,9 @@ impl Customization {
                         continue;
                     }
                     let next = of_node.len();
-                    let from = *of_node.entry(from).or_insert(next);
+                    let from = *of_node.entry(from as usize).or_insert(next);
                     let next = of_node.len();
-                    let to = *of_node.entry(to).or_insert(next);
+                    let to = *of_node.entry(to as usize).or_insert(next);
                     edges.push(InputEdge::new(from, to, weight));
                 }
             }
@@ -576,15 +604,15 @@ impl Customization {
             ..Default::default()
         };
         for (source, &from) in built.border_nodes.iter().enumerate() {
-            let reached = distances_within_cell(&self.graph, &cells.of_node, cell, from);
+            let reached = distances_within_cell(&self.graph, &cells.of_node, cell, from as usize);
             for (target, &to) in built.border_nodes.iter().enumerate() {
-                let expected = reached.get(&to).copied().unwrap_or(usize::MAX);
+                let expected = reached.get(&(to as usize)).copied().unwrap_or(usize::MAX);
                 let built = built.distance(source, target);
                 if built != expected {
                     check.mismatches.push(Mismatch {
                         cell,
-                        from,
-                        to,
+                        from: from as usize,
+                        to: to as usize,
                         built,
                         expected,
                     });
@@ -639,7 +667,7 @@ mod tests {
         let distances = customization.distances_of(0, 0).expect("no cell");
 
         for (place, &node) in distances.border_nodes.iter().enumerate() {
-            assert_eq!(distances.place_of(node), Some(place));
+            assert_eq!(distances.place_of(node as usize), Some(place));
         }
         // and a node that is not on this border has no place on it
         let elsewhere = *customization
@@ -648,8 +676,11 @@ mod tests {
             .border_nodes
             .first()
             .expect("a cell with no border nodes");
-        assert_eq!(distances.place_of(elsewhere), None);
-        assert_eq!(distances.distance_between(elsewhere, elsewhere), None);
+        assert_eq!(distances.place_of(elsewhere as usize), None);
+        assert_eq!(
+            distances.distance_between(elsewhere as usize, elsewhere as usize),
+            None
+        );
     }
 
     /// Asking by node and asking by place are the same question.
@@ -660,6 +691,7 @@ mod tests {
 
         for &source in &distances.border_nodes {
             for &target in &distances.border_nodes {
+                let (source, target) = (source as usize, target as usize);
                 let places = distances.distance(
                     distances.place_of(source).expect("not on the border"),
                     distances.place_of(target).expect("not on the border"),
@@ -856,7 +888,11 @@ mod tests {
             let indices = (0..border.len()).collect::<Vec<_>>();
             let mut dijkstra = OneToManyDijkstra::new();
 
-            assert_eq!(built_up.border_nodes, border, "cell {cell}");
+            assert_eq!(
+                built_up.border_nodes,
+                border.iter().map(|&n| n as u32).collect::<Vec<_>>(),
+                "cell {cell}"
+            );
             for (source, _) in border.iter().enumerate() {
                 dijkstra.run(&graph, source, &indices);
                 for (target, _) in border.iter().enumerate() {
@@ -1050,7 +1086,7 @@ mod tests {
                         .border_nodes
                         .iter()
                         .enumerate()
-                        .map(|(place, &node)| (node, place))
+                        .map(|(place, &node)| (node as usize, place))
                         .collect(),
                     border_nodes: built.border_nodes.clone(),
                     matrix,
@@ -1065,7 +1101,7 @@ mod tests {
         );
         let wrong = check.mismatches[0];
         assert_eq!(wrong.built, wrong.expected + 100);
-        assert_eq!(wrong.from, built.border_nodes[0]);
-        assert_eq!(wrong.to, built.border_nodes[1]);
+        assert_eq!(wrong.from, built.border_nodes[0] as usize);
+        assert_eq!(wrong.to, built.border_nodes[1] as usize);
     }
 }

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -296,6 +296,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         };
         for (to, &target) in distances.border_nodes.iter().enumerate() {
             let across = distances.distance(from, to);
+            let target = target as NodeID;
             if across == usize::MAX || target == node {
                 continue;
             }


### PR DESCRIPTION
Stacked on #595.

`CellDistances` keeps its two arrays in `u32` instead of `usize`:

- `matrix: Vec<u32>` — what it costs to cross the cell between each pair of border nodes
- `border_nodes: Vec<u32>` — the nodes on the cell's edge

`distance()` still takes and returns `usize`, and still hands back `usize::MAX` for a pair that cannot be reached, so callers are unchanged.

## Why it fits

The longest way across europe by the clock is under a million and the graph holds eighteen million nodes. Four bytes reach four thousand million. The tables already address the graph with four byte places.

A distance too large for `u32` is written as unreachable rather than wrapped: `u32::try_from(across).unwrap_or(u32::MAX)`. Wrapping would produce a short distance and a wrong path; unreachable is the safe way round. It does not arise on any graph this crate can hold.

## Measured

Partition of europe.ptv, six levels of [50, 250, 1000, 10000, 100000, 1000000] nodes, every cell of every level worked out, peak resident memory over the run:

| | peak resident |
| --- | --- |
| eight byte tables | 4.11 GB |
| four byte tables | 3.72 GB |

390 MB, about a tenth of the process.

## On speed

It is 2% quicker — 17.2 ms against 16.9 ms at rank 2^24 — and that is not the reason for the change.

A query of that size offers 2.59M arcs out of the tables, so halving the entries halves some forty megabytes of streaming. It buys almost nothing because the query touches twelve thousand distinct nodes and reads each a couple of hundred times: the working set is a few hundred kilobytes and sits in cache whatever width the numbers are written in.

That is consistent with the rest of the profiling. A table sized to the search rather than to the graph (256 KB against 72 MB) came out 52% slower, and moving the settled mark onto the place to save a second read gained 1%. The query is instruction bound at about 6.5 ns per offered arc, not memory bound.
