### PR TITLE
Assemble the levels by boundary, and search from both ends

### DIFF
--- a/examples/cell_stats.rs
+++ b/examples/cell_stats.rs
@@ -1,0 +1,85 @@
+//! What the assembled levels actually look like, cell by cell.
+//!
+//! The query pays for border nodes: stepping over a cell walks its clique, so
+//! one entry costs as many relaxations as the cell has border nodes. Which
+//! cells get entered is not uniform — a cell is reached in rough proportion to
+//! how much boundary it has — so what an entry costs on average is the
+//! size-biased mean of the boundary, `E[B^2]/E[B]`, and not `E[B]`. The gap
+//! between those two numbers is what a skewed assembly costs.
+use std::env::args;
+
+use toolbox_rs::{edge::InputEdge, io, level_directory::LevelDirectory};
+
+fn main() {
+    let mut argv = args().skip(1);
+    let graph_path = argv.next().expect("usage: cell_stats <graph> <directory>");
+    let directory_path = argv.next().expect("usage: cell_stats <graph> <directory>");
+
+    let edges = io::read_vec_from_file::<InputEdge<usize>>(&graph_path);
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    println!(
+        "{} arcs, {} nodes, {} levels",
+        edges.len(),
+        directory.number_of_nodes(),
+        directory.levels()
+    );
+
+    let nodes = directory.number_of_nodes();
+    for level in 0..directory.levels() {
+        let cells = directory.cells_on_level(level);
+        let of_node: Vec<u32> = (0..nodes)
+            .map(|node| directory.cell_of(node, level) as u32)
+            .collect();
+
+        let mut size = vec![0_u32; cells];
+        for &cell in &of_node {
+            size[cell as usize] += 1;
+        }
+
+        // a node is on the border of its cell while an arc leaves it or
+        // reaches it, which is the definition the overlay is built on
+        let mut on_border = vec![false; nodes];
+        for edge in &edges {
+            if of_node[edge.source] != of_node[edge.target] {
+                on_border[edge.source] = true;
+                on_border[edge.target] = true;
+            }
+        }
+        let mut border = vec![0_u32; cells];
+        for (node, &is_border) in on_border.iter().enumerate() {
+            if is_border {
+                border[of_node[node] as usize] += 1;
+            }
+        }
+
+        let total: u64 = border.iter().map(|&b| u64::from(b)).sum();
+        let squared: u64 = border.iter().map(|&b| u64::from(b) * u64::from(b)).sum();
+        let mut sorted = border.clone();
+        sorted.sort_unstable();
+        let median = sorted[sorted.len() / 2];
+        let mean = total as f64 / cells as f64;
+        // what one entry into a cell of this level costs on average, given
+        // that a cell is entered in proportion to its boundary
+        let biased = squared as f64 / total as f64;
+
+        let mut node_sizes = size.clone();
+        node_sizes.sort_unstable();
+
+        println!(
+            "level {level}: {cells} cells, {} nodes each on average (median {}, max {})",
+            nodes / cells,
+            node_sizes[node_sizes.len() / 2],
+            node_sizes[node_sizes.len() - 1],
+        );
+        println!(
+            "          border: {total} in total, mean {mean:.1}, median {median}, max {}",
+            sorted[sorted.len() - 1],
+        );
+        println!(
+            "          an entry walks {biased:.1} on average, {:.2}x the mean; \
+             balancing would save {:.0}%",
+            biased / mean,
+            100.0 * (1.0 - mean / biased),
+        );
+    }
+}

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -8,8 +8,9 @@
 # to end:
 #
 #   ranks time -g graph -i pairs.csv -e dijkstra -o d.csv
+#   ranks time -g graph -i pairs.csv -e bidirectional -o b.csv
 #   ranks time -g graph -d levels -i pairs.csv -e mld -o m.csv
-#   cat d.csv <(tail -n +2 m.csv) > timings.csv
+#   cat d.csv <(tail -n +2 b.csv) <(tail -n +2 m.csv) > timings.csv
 #
 # Base graphics only, and no package beyond what R ships with. A plot that
 # wants an install first is a plot that does not get looked at, and this one is
@@ -34,12 +35,26 @@ if (nrow(timings) == 0) {
   stop("there is nothing to plot")
 }
 
-# microseconds read better than nanoseconds, and the rank axis is drawn at the
+# milliseconds read better than nanoseconds, and the rank axis is drawn at the
 # exponent so the ticks say 2^10 rather than 1024
-timings$micros <- timings$nanos / 1000
+timings$millis <- timings$nanos / 1e6
 timings$exponent <- round(log2(timings$rank))
 engines <- sort(unique(timings$engine))
 exponents <- sort(unique(timings$exponent))
+
+# the engine column says which search wrote the row; a legend wants to say
+# which search it was, and "dijkstra" does not distinguish the plain search
+# from the one that runs from both ends
+display <- c(dijkstra = "unidirectional", bidirectional = "bidirectional", mld = "mld")
+name_of <- function(engine) ifelse(engine %in% names(display), display[engine], engine)
+
+# every power of ten the numbers reach, written out rather than as 1e+03: a
+# reader who wants to know what a query costs should not have to decode it
+decades_over <- function(values) {
+  values <- values[is.finite(values) & values > 0]
+  10^(floor(log10(min(values))):ceiling(log10(max(values))))
+}
+plainly <- function(values) formatC(values, format = "fg", drop0trailing = TRUE)
 
 # a bucket holding a handful of samples is drawn like the rest and marked, so
 # that a thin tail reads as a thin tail rather than as a result
@@ -62,7 +77,7 @@ width <- 0.8 / length(engines)
 for (index in seq_along(exponents)) {
   for (which in seq_along(engines)) {
     rows <- timings$exponent == exponents[index] & timings$engine == engines[which]
-    groups[[length(groups) + 1]] <- timings$micros[rows]
+    groups[[length(groups) + 1]] <- timings$millis[rows]
     offset <- (which - (length(engines) + 1) / 2) * width
     at <- c(at, exponents[index] + offset)
     fill <- c(fill, colour_of[engines[which]])
@@ -71,13 +86,17 @@ for (index in seq_along(exponents)) {
 
 boxplot(groups,
   at = at, boxwex = width * 0.9, col = fill, log = "y",
-  xaxt = "n", xlab = "", ylab = "microseconds",
+  xaxt = "n", yaxt = "n", xlab = "", ylab = "milliseconds",
   main = sprintf("query time by Dijkstra rank (%s)", basename(input)),
   outcex = 0.3, whisklty = 1, staplewex = 0.5
 )
 axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+ticks <- decades_over(timings$millis)
+axis(2, at = ticks, labels = plainly(ticks))
 abline(v = exponents[-1] - 0.5, col = "#00000012")
-legend("topleft", legend = engines, fill = colour_of[engines], bty = "n")
+# the searches climb from left to right, so the top left corner is the one
+# nothing is drawn in
+legend("topleft", legend = name_of(engines), fill = colour_of[engines], bty = "n")
 if (length(thin) > 0) {
   mtext(sprintf("thin buckets, under %d samples: 2^%s", THIN,
                 paste(thin, collapse = ", 2^")),
@@ -89,34 +108,52 @@ par(mar = c(4.5, 4.5, 1, 1))
 medians <- sapply(engines, function(engine) {
   sapply(exponents, function(exponent) {
     rows <- timings$exponent == exponent & timings$engine == engine
-    if (any(rows)) median(timings$micros[rows]) else NA
+    if (any(rows)) median(timings$millis[rows]) else NA
   })
 })
 medians <- matrix(medians, nrow = length(exponents), dimnames = list(NULL, engines))
 
-if (all(c("dijkstra", "mld") %in% engines)) {
-  speedup <- medians[, "dijkstra"] / medians[, "mld"]
-  ylim <- range(c(speedup, 1), na.rm = TRUE)
-  plot(exponents, speedup,
-    type = "b", pch = 19, log = "y", ylim = ylim, xaxt = "n",
-    xlab = "Dijkstra rank", ylab = "dijkstra / mld", col = "#204080"
+if ("mld" %in% engines && length(engines) > 1) {
+  # every plain search in the file, against the one over the cells. The plain
+  # unidirectional search is the one a rank axis is defined by, but it is not
+  # the yardstick an overlay has to beat: two searches from two ends cost
+  # nothing but a second queue, so what the cells are worth is what they beat
+  # that by.
+  against <- setdiff(engines, "mld")
+  ratios <- sapply(against, function(engine) medians[, engine] / medians[, "mld"])
+  ratios <- matrix(ratios, nrow = length(exponents), dimnames = list(NULL, against))
+  ylim <- range(c(ratios, 1), na.rm = TRUE)
+  plot(NA,
+    xlim = range(exponents), ylim = ylim, log = "y", xaxt = "n", yaxt = "n",
+    xlab = "Dijkstra rank", ylab = "plain search / mld"
   )
+  for (engine in against) {
+    lines(exponents, ratios[, engine], type = "b", pch = 19, col = colour_of[engine])
+  }
   axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+  ticks <- decades_over(c(ratios, 1))
+  axis(2, at = ticks, labels = plainly(ticks))
   # at one the two cost the same; below it the cells are not paying for
   # themselves, and it should climb as more of them can be stepped over. A
   # curve that does not climb is the thing to look for: every level is sound to
   # step over, so a query that picks a low one gives the same answers and no
   # test of those answers would say a word.
   abline(h = 1, lty = 2, col = "#808080")
-  best <- which.max(speedup)
-  if (length(best) == 1 && is.finite(speedup[best])) {
-    mtext(sprintf("best %.1fx at 2^%d", speedup[best], exponents[best]),
-          side = 3, line = -1.2, adj = 0.98, cex = 0.75, col = "#204080")
-  }
+  # what each curve is worth at its best goes in the legend rather than beside
+  # it, so that nothing is written over the curves. They end high on the right,
+  # so the bottom right corner is the empty one.
+  best_of <- sapply(against, function(engine) {
+    best <- which.max(ratios[, engine])
+    sprintf("%s / mld (best %.0fx at 2^%d)", name_of(engine), ratios[best, engine],
+            exponents[best])
+  })
+  legend("bottomright", legend = best_of, col = colour_of[against],
+         lty = 1, pch = 19, bty = "n")
+
 } else {
   plot.new()
-  mtext("a speedup wants both engines in the file", side = 3, line = -3,
-        cex = 0.8, col = "#808080")
+  mtext("a speedup wants the cells and a plain search in the same file",
+        side = 3, line = -3, cex = 0.8, col = "#808080")
 }
 
 invisible(dev.off())

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -140,14 +140,15 @@ if ("mld" %in% engines && length(engines) > 1) {
   # test of those answers would say a word.
   abline(h = 1, lty = 2, col = "#808080")
   # what each curve is worth at its best goes in the legend rather than beside
-  # it, so that nothing is written over the curves. They end high on the right,
-  # so the bottom right corner is the empty one.
+  # it, so that nothing is written over the curves. They start low on the left
+  # and end high on the right, so the top left corner is the empty one — the
+  # bottom right has the line at one running through it.
   best_of <- sapply(against, function(engine) {
     best <- which.max(ratios[, engine])
     sprintf("%s / mld (best %.0fx at 2^%d)", name_of(engine), ratios[best, engine],
             exponents[best])
   })
-  legend("bottomright", legend = best_of, col = colour_of[against],
+  legend("topleft", legend = best_of, col = colour_of[against],
          lty = 1, pch = 19, bty = "n")
 
 } else {

--- a/src/addressable_binary_heap.rs
+++ b/src/addressable_binary_heap.rs
@@ -224,6 +224,32 @@ impl<
         self.inserted_nodes[index].node
     }
 
+    /// What the node with minimum weight is held at, without looking that node
+    /// up.
+    ///
+    /// Asking for [`min`](Self::min) and then for its weight walks the map of
+    /// places to get back to a weight the heap already has in hand. A search
+    /// that asks what its front stands at once per settled node — which is
+    /// what a search from both ends does, to know when the two fronts have met
+    /// — pays that for nothing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the heap is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use toolbox_rs::addressable_binary_heap::AddressableHeap;
+    /// let mut heap = AddressableHeap::new();
+    /// heap.insert(1, 7, 0);
+    /// heap.insert(2, 3, 0);
+    /// assert_eq!(heap.min_weight(), 3);
+    /// ```
+    pub fn min_weight(&self) -> Weight {
+        self.heap[1].weight
+    }
+
     /// Returns the node with minimum weight without removing it, or None if the heap is empty.
     ///
     /// # Examples

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -10,6 +10,10 @@
 //! crosses a cell has to be able to do it without leaving the cell, and a cell
 //! that falls into pieces cannot promise that.
 
+use std::{cmp::Reverse, collections::BinaryHeap};
+
+use rustc_hash::FxHashMap;
+
 use crate::{
     edge::TrivialEdge,
     level_directory::{CellId, LevelDirectory},
@@ -85,35 +89,88 @@ impl CellGraph {
 /// Merges neighbouring cells until none of them can take another without
 /// passing `size`, and hands back the cell each one ended up in.
 ///
-/// The pairs are taken by how many arcs run between them, the heaviest first,
-/// which is the greedy agglomeration that the coarsening of a multilevel
-/// partitioner is built on. Only cells that share an arc are ever merged, so a
-/// cell of the result is a union of cells joined along arcs and stays in one
-/// piece as long as the cells it was built from were.
+/// The smallest cell goes first, and takes in the neighbour the most arcs run
+/// to among those it still has room for. Only cells that share an arc are ever
+/// merged, so a cell of the result is a union of cells joined along arcs and
+/// stays in one piece as long as the cells it was built from were.
+///
+/// # Why the smallest first
+///
+/// Taking the heaviest pair first, once, is the coarsening a multilevel
+/// partitioner does, and it leaves a level well short of the size it was asked
+/// for: two cells that have each grown past half of it can never be put
+/// together, so the run ends with a spread of cells from very small to full
+/// rather than with cells of about the wanted size. What that costs is not the
+/// wasted room. A search steps over a cell by walking the clique between its
+/// border nodes, and it reaches a cell about as often as that cell has border
+/// nodes, so what one step costs on average is not the mean boundary but the
+/// mean weighted by boundary — and that punishes a spread twice over. Growing
+/// the smallest cell first is what keeps the spread down.
 #[must_use]
 pub fn agglomerate(graph: &CellGraph, size: usize) -> Vec<CellId> {
-    let mut arcs = graph.arcs();
-    // heaviest first, and by cell for a run that does not depend on the order
-    // the arcs happened to be collected in
-    arcs.sort_unstable_by(|a, b| b.2.cmp(&a.2).then(a.0.cmp(&b.0)).then(a.1.cmp(&b.1)));
-
-    let mut union = crate::union_find::UnionFind::new(graph.len());
+    let count = graph.len();
+    let mut union = crate::union_find::UnionFind::new(count);
     let mut merged_size = graph.sizes.clone();
-    for (left, right, _) in arcs {
-        let (left, right) = (union.find(left), union.find(right));
-        if left == right || merged_size[left] + merged_size[right] > size {
+
+    // the cells a group was built from, as a list per group rather than a
+    // vector per group: there is one group per cell to start with, and on the
+    // lowest level of a continent that is millions of them
+    let mut head: Vec<usize> = (0..count).collect();
+    let mut last: Vec<usize> = (0..count).collect();
+    let mut next: Vec<usize> = vec![usize::MAX; count];
+
+    // smallest first, and by cell so that a tie does not leave the result
+    // depending on the order the arcs happened to be collected in
+    let mut queue: BinaryHeap<Reverse<(usize, usize)>> = (0..count)
+        .map(|cell| Reverse((merged_size[cell], cell)))
+        .collect();
+
+    let mut weight_to: FxHashMap<usize, usize> = FxHashMap::default();
+    while let Some(Reverse((held, cell))) = queue.pop() {
+        // a group that has grown since, or been taken into another, comes up
+        // again as what it is now
+        if union.find(cell) != cell || merged_size[cell] != held {
             continue;
         }
-        let total = merged_size[left] + merged_size[right];
-        union.union(left, right);
-        let root = union.find(left);
+
+        // what runs to each neighbour that there is still room for. A group
+        // only ever grows, so a neighbour that does not fit now never will,
+        // and a group nothing fits is done for good.
+        weight_to.clear();
+        let mut member = head[cell];
+        while member != usize::MAX {
+            for &(neighbour, weight) in graph.neighbours_of(member) {
+                let neighbour = union.find(neighbour);
+                if neighbour == cell || merged_size[cell] + merged_size[neighbour] > size {
+                    continue;
+                }
+                *weight_to.entry(neighbour).or_insert(0) += weight;
+            }
+            member = next[member];
+        }
+
+        let Some((&best, _)) = weight_to
+            .iter()
+            .max_by_key(|&(&neighbour, &weight)| (weight, Reverse(neighbour)))
+        else {
+            continue;
+        };
+
+        let total = merged_size[cell] + merged_size[best];
+        next[last[cell]] = head[best];
+        let (joined_head, joined_last) = (head[cell], last[best]);
+        union.union(cell, best);
+        let root = union.find(cell);
         merged_size[root] = total;
+        head[root] = joined_head;
+        last[root] = joined_last;
+        queue.push(Reverse((total, root)));
     }
 
     // number the cells that are left, in the order their members appear
-    let mut cell_of_root = vec![CellId::MAX; graph.len()];
+    let mut cell_of_root = vec![CellId::MAX; count];
     let mut cells = 0;
-    (0..graph.len())
+    (0..count)
         .map(|cell| {
             let root = union.find(cell);
             if cell_of_root[root] == CellId::MAX {
@@ -123,6 +180,192 @@ pub fn agglomerate(graph: &CellGraph, size: usize) -> Vec<CellId> {
             cell_of_root[root]
         })
         .collect()
+}
+
+/// Moves single cells across a boundary while that evens the *boundaries* out
+/// and costs the cut nothing.
+///
+/// Greedy merging is done as soon as nothing fits any more, and what it leaves
+/// behind is a spread: a cell that filled up early sits next to one that never
+/// found a partner it had room for. Neither can be fixed by another merge —
+/// together they would pass the size — but a single cell handed from the
+/// larger to the smaller fixes both at once, and that is a move no merge could
+/// have made.
+///
+/// # What is evened out, and what is not
+///
+/// Not the node counts. A search steps over a cell by walking the clique
+/// between its border nodes, and it reaches a cell about as often as that cell
+/// has border nodes, so what a step costs on average is the boundary weighted
+/// by boundary — `E[B^2]/E[B]` — and bringing the *sizes* to dead level does
+/// nothing for that. Measured on a continent it does worse than nothing: the
+/// node counts came out even to within a percent, the top level's boundary
+/// grew by a tenth and its worst cell by half, and the query slowed by a
+/// third. So what is evened out here is the boundary itself, and the node
+/// count is only ever a ceiling.
+///
+/// A move is taken when all four hold:
+///
+/// - the cut does not get worse, so at least as many arcs run from the cell to
+///   the group it joins as to the one it leaves
+/// - the squares of the two boundaries come down, which is what falls when a
+///   heavy boundary and a light one are brought closer together
+/// - the group it joins still fits under `size`
+/// - the group it leaves is still in one piece without it
+///
+/// That last one is what a partitioner does not usually have to think about
+/// and this one does: a search crosses a cell without leaving it, which a cell
+/// in two pieces cannot promise. A cell whose leaving would cut its group in
+/// two therefore stays where it is however much it would even things out.
+///
+/// Returns how many cells were moved.
+#[must_use]
+pub fn refine(graph: &CellGraph, of: &mut [CellId], size: usize, rounds: usize) -> usize {
+    let groups = of
+        .iter()
+        .copied()
+        .max()
+        .map_or(0, |group| group as usize + 1);
+    let mut group_size = vec![0_usize; groups];
+    let mut members: Vec<Vec<usize>> = vec![Vec::new(); groups];
+    for (cell, &group) in of.iter().enumerate() {
+        group_size[group as usize] += graph.size_of(cell);
+        members[group as usize].push(cell);
+    }
+
+    // what each group has to walk when it is stepped over: the arcs that leave
+    // it. Only the two groups a move is between ever see this change — an arc
+    // to a third group was cut before the move and is cut after it.
+    let mut boundary = vec![0_i64; groups];
+    for (cell, &group) in of.iter().enumerate() {
+        for &(neighbour, weight) in graph.neighbours_of(cell) {
+            if of[neighbour] != group {
+                boundary[group as usize] += weight as i64;
+            }
+        }
+    }
+
+    // one stamp per walk, so that what a walk reached is not cleared between
+    // walks but simply stops counting
+    let mut seen = vec![0_u32; graph.len()];
+    let mut stamp = 0_u32;
+    let mut stack = Vec::new();
+    let mut weight_to: FxHashMap<usize, usize> = FxHashMap::default();
+
+    let mut moved = 0;
+    for _ in 0..rounds {
+        let mut this_round = 0;
+        for cell in 0..graph.len() {
+            let from = of[cell] as usize;
+            // a group is never left with nothing in it
+            if members[from].len() == 1 {
+                continue;
+            }
+
+            let mine = graph.size_of(cell);
+            weight_to.clear();
+            let mut weight_home = 0_i64;
+            for &(neighbour, weight) in graph.neighbours_of(cell) {
+                let group = of[neighbour] as usize;
+                if group == from {
+                    weight_home += weight as i64;
+                } else {
+                    *weight_to.entry(group).or_insert(0) += weight;
+                }
+            }
+            let weight_out: i64 = weight_to.values().map(|&weight| weight as i64).sum();
+
+            // the group it leaves keeps what it had, gives up what this cell
+            // held against the outside, and takes on what the two of them held
+            // against each other
+            let leaving = boundary[from] - weight_out + weight_home;
+
+            let best = weight_to
+                .iter()
+                .filter(|&(&group, _)| group_size[group] + mine <= size)
+                .filter(|&(_, &weight)| weight as i64 >= weight_home)
+                .filter_map(|(&group, &weight)| {
+                    // and the group it joins takes on everything this cell
+                    // held against anything that is not it
+                    let joining = boundary[group] + weight_home + weight_out - 2 * weight as i64;
+                    let before =
+                        boundary[from] * boundary[from] + boundary[group] * boundary[group];
+                    let after = leaving * leaving + joining * joining;
+                    (after < before).then_some((group, before - after, joining))
+                })
+                .max_by_key(|&(group, won, _)| (won, Reverse(group)));
+            let Some((to, _, joining)) = best else {
+                continue;
+            };
+
+            stamp += 1;
+            if !stays_in_one_piece(
+                graph,
+                of,
+                &members[from],
+                cell,
+                &mut seen,
+                stamp,
+                &mut stack,
+            ) {
+                continue;
+            }
+
+            let place = members[from]
+                .iter()
+                .position(|&held| held == cell)
+                .expect("a cell is a member of the group it is in");
+            members[from].swap_remove(place);
+            members[to].push(cell);
+            group_size[from] -= mine;
+            group_size[to] += mine;
+            boundary[from] = leaving;
+            boundary[to] = joining;
+            of[cell] = u32::try_from(to).expect("a cell of the result is numbered by a CellId");
+            this_round += 1;
+        }
+
+        moved += this_round;
+        if this_round == 0 {
+            break;
+        }
+    }
+    moved
+}
+
+/// Whether the group a cell sits in would still hang together without it.
+///
+/// Every other member has to be reachable from one of them along arcs that
+/// stay in the group and do not run through the cell being taken out.
+fn stays_in_one_piece(
+    graph: &CellGraph,
+    of: &[CellId],
+    members: &[usize],
+    without: usize,
+    seen: &mut [u32],
+    stamp: u32,
+    stack: &mut Vec<usize>,
+) -> bool {
+    let group = of[without];
+    let Some(&start) = members.iter().find(|&&cell| cell != without) else {
+        return true;
+    };
+
+    stack.clear();
+    stack.push(start);
+    seen[start] = stamp;
+    let mut reached = 1;
+    while let Some(cell) = stack.pop() {
+        for &(neighbour, _) in graph.neighbours_of(cell) {
+            if neighbour == without || of[neighbour] != group || seen[neighbour] == stamp {
+                continue;
+            }
+            seen[neighbour] = stamp;
+            reached += 1;
+            stack.push(neighbour);
+        }
+    }
+    reached == members.len() - 1
 }
 
 /// Draws the cells of a graph together along the given assignment.
@@ -154,6 +397,13 @@ pub fn contract(graph: &CellGraph, of: &[CellId]) -> CellGraph {
     arcs.sort_unstable();
     CellGraph::new(sizes, &arcs)
 }
+
+/// How many times the assembled levels are walked over for cells worth moving.
+///
+/// Each round is a pass over every cell, and the passes converge quickly: the
+/// sum of the squared sizes falls with every move, and the moves that are
+/// there to make are mostly found on the first pass.
+const REFINEMENT_ROUNDS: usize = 8;
 
 /// Assembles the levels by merging neighbouring cells, so that every cell of
 /// every level is a union of cells joined along arcs.
@@ -189,7 +439,9 @@ pub fn assemble_connected(
             current.len(),
             current.arcs().len()
         );
-        let merged = agglomerate(&current, size);
+        let mut merged = agglomerate(&current, size);
+        let moved = refine(&current, &mut merged, size, REFINEMENT_ROUNDS);
+        log::debug!("level {level}: {moved} cells moved to even the sizes out");
         if level == 0 {
             base = cell_of_node
                 .iter()
@@ -458,11 +710,185 @@ mod tests {
         // a path cut into cells of twelve leaves eight of them, give or take
         // the ends that cannot grow further
         let merged = agglomerate(&graph, 12);
-        let left = merged.iter().copied().max().unwrap() as usize + 1;
+        let mut held = vec![0; merged.iter().copied().max().unwrap() as usize + 1];
+        for &cell in &merged {
+            held[cell as usize] += 1;
+        }
         assert!(
-            left <= cells / 6,
-            "a path of {cells} left {left} cells of at most 12"
+            held.len() <= cells / 8,
+            "a path of {cells} left {} cells of at most 12",
+            held.len()
         );
+        // and none of them is a scrap. Taking the heaviest pair first leaves
+        // cells anywhere from one node to the full twelve, and it is the
+        // spread rather than the count that a search over them pays for.
+        assert!(
+            held.iter().all(|&size| size * 2 >= 12),
+            "a cell of {} was left where twelve was asked for: {held:?}",
+            held.iter().min().unwrap()
+        );
+    }
+
+    /// What the cut costs under an assignment: the arcs that run between two
+    /// different groups.
+    fn cut_of(graph: &CellGraph, of: &[CellId]) -> usize {
+        graph
+            .arcs()
+            .into_iter()
+            .filter(|&(left, right, _)| of[left] != of[right])
+            .map(|(_, _, weight)| weight)
+            .sum()
+    }
+
+    /// Whether every group of an assignment hangs together along the arcs of
+    /// the cell graph.
+    fn groups_hold_together(graph: &CellGraph, of: &[CellId]) -> bool {
+        let groups = of.iter().copied().max().map_or(0, |g| g as usize + 1);
+        let mut members: Vec<Vec<usize>> = vec![Vec::new(); groups];
+        for (cell, &group) in of.iter().enumerate() {
+            members[group as usize].push(cell);
+        }
+        members.iter().enumerate().all(|(group, members)| {
+            let mut seen = vec![false; graph.len()];
+            let mut stack = vec![members[0]];
+            seen[members[0]] = true;
+            let mut reached = 1;
+            while let Some(cell) = stack.pop() {
+                for &(neighbour, _) in graph.neighbours_of(cell) {
+                    if of[neighbour] as usize != group || seen[neighbour] {
+                        continue;
+                    }
+                    seen[neighbour] = true;
+                    reached += 1;
+                    stack.push(neighbour);
+                }
+            }
+            reached == members.len()
+        })
+    }
+
+    /// The move a merge cannot make: two groups that could not be put together
+    /// under the size, with the boundary between them moved to where it is
+    /// cheap.
+    #[test]
+    fn a_cell_moves_across_to_where_the_boundary_is_cheap() {
+        // a path of six, cut four and two, where merging the two is out of the
+        // question as six does not fit under three. The two groups meet along
+        // ten arcs, and one step further along the path they would meet along
+        // one, so handing that cell across leaves both of them cheaper to step
+        // over than either was.
+        let graph = CellGraph::new(
+            vec![1; 6],
+            &[(0, 1, 1), (1, 2, 1), (2, 3, 1), (3, 4, 10), (4, 5, 1)],
+        );
+        let mut of = vec![0, 0, 0, 0, 1, 1];
+
+        assert_eq!(refine(&graph, &mut of, 3, 8), 1);
+        assert_eq!(of, vec![0, 0, 0, 1, 1, 1], "the cell at the boundary moved");
+        // ten arcs out of each of them, down to one out of each
+        assert_eq!(boundary_of(&graph, &of), vec![1, 1]);
+    }
+
+    /// A cell whose leaving would cut its group in two stays where it is,
+    /// however much it would even the sizes out.
+    #[test]
+    fn a_cell_that_holds_its_group_together_does_not_move() {
+        // 0 and 2 hang off 1, and 1 is joined to 3 by ten arcs. Handing 1 to
+        // the group of 3 would even three against one into two against two and
+        // take eight arcs out of the cut, so every other test says take it —
+        // but it would leave 0 and 2 with nothing joining them to each other.
+        let graph = CellGraph::new(vec![1; 4], &[(0, 1, 1), (1, 2, 1), (1, 3, 10)]);
+        let mut of = vec![0, 0, 0, 1];
+        let before = of.clone();
+
+        assert_eq!(refine(&graph, &mut of, 4, 8), 0);
+        assert_eq!(of, before);
+    }
+
+    /// Whatever refinement does, it does not cost the cut anything, it does not
+    /// pass the size, and it leaves every group in one piece.
+    #[test]
+    fn refinement_keeps_what_merging_promised() {
+        let mut rng = StdRng::seed_from_u64(0x_5EED_1234);
+        for round in 0..40 {
+            let cells = 24 + round;
+            // a path with chords, so groups have somewhere to hand cells to
+            let mut arcs = (0..cells - 1)
+                .map(|cell| (cell, cell + 1, 1 + rng.random_range(0..9_usize)))
+                .collect::<Vec<_>>();
+            for cell in 0..cells - 3 {
+                if rng.random_range(0..4) == 0 {
+                    arcs.push((cell, cell + 3, 1 + rng.random_range(0..9)));
+                }
+            }
+            arcs.sort_unstable();
+            arcs.dedup_by_key(|&mut (left, right, _)| (left, right));
+            let sizes = (0..cells)
+                .map(|_| 1 + rng.random_range(0..3_usize))
+                .collect::<Vec<_>>();
+            let graph = CellGraph::new(sizes, &arcs);
+
+            let size = 12;
+            let mut of = agglomerate(&graph, size);
+            let cut_before = cut_of(&graph, &of);
+            let spread_before = spread_of(&graph, &of);
+
+            let _ = refine(&graph, &mut of, size, 8);
+
+            assert!(
+                cut_of(&graph, &of) <= cut_before,
+                "round {round}: the cut went from {cut_before} to {}",
+                cut_of(&graph, &of)
+            );
+            assert!(
+                spread_of(&graph, &of) <= spread_before,
+                "round {round}: the boundaries spread out rather than in"
+            );
+            assert!(
+                groups_hold_together(&graph, &of),
+                "round {round}: a group fell into pieces"
+            );
+
+            let groups = of.iter().copied().max().unwrap() as usize + 1;
+            let mut held = vec![0; groups];
+            for (cell, &group) in of.iter().enumerate() {
+                held[group as usize] += graph.size_of(cell);
+            }
+            assert!(
+                held.iter().all(|&size_of_group| size_of_group <= size),
+                "round {round}: a group of {} passed {size}",
+                held.iter().max().unwrap()
+            );
+            assert!(
+                held.iter().all(|&size_of_group| size_of_group > 0),
+                "round {round}: a group was left with nothing in it"
+            );
+        }
+    }
+
+    /// What each group has to walk when it is stepped over: the arcs that
+    /// leave it.
+    fn boundary_of(graph: &CellGraph, of: &[CellId]) -> Vec<usize> {
+        let groups = of.iter().copied().max().map_or(0, |g| g as usize + 1);
+        let mut held = vec![0; groups];
+        for (cell, &group) in of.iter().enumerate() {
+            for &(neighbour, weight) in graph.neighbours_of(cell) {
+                if of[neighbour] != group {
+                    held[group as usize] += weight;
+                }
+            }
+        }
+        held
+    }
+
+    /// How far the boundaries are from all being the same, as the sum of their
+    /// squares: that is what every move refinement takes has to bring down,
+    /// and it is what a search over the cells is billed for.
+    fn spread_of(graph: &CellGraph, of: &[CellId]) -> usize {
+        boundary_of(graph, of)
+            .into_iter()
+            .map(|held| held * held)
+            .sum()
     }
 
     #[test]

--- a/src/bidirectional_dijkstra.rs
+++ b/src/bidirectional_dijkstra.rs
@@ -1,0 +1,439 @@
+//! A search that runs from both ends and meets in the middle.
+//!
+//! # Why it is the honest yardstick
+//!
+//! A plain search from the source sweeps a disc of the network until the
+//! target falls inside it. Two searches, one from each end, sweep two discs of
+//! half the radius, and two half-radius discs hold rather less than one full
+//! one. On a road network that is worth a constant factor, and it is a factor
+//! that costs nothing but bookkeeping — no preprocessing, no overlay, no
+//! customization to keep up to date. Anything that does keep a preprocessed
+//! structure should be measured against this rather than against the plain
+//! search, or it is being credited with a speedup that a few lines of code
+//! would have given for free.
+//!
+//! # The two graphs
+//!
+//! The backward search walks arcs into a node rather than out of it, so it
+//! needs the graph with every arc turned around. On an undirected network the
+//! two are the same object and it can simply be handed over twice.
+use crate::{
+    addressable_binary_heap::AddressableHeapWithStats,
+    graph::{Graph, INVALID_NODE_ID, NodeID},
+    heap_stats::{Counters, HeapStats, Untracked},
+};
+
+/// A search from both ends, counting nothing.
+///
+/// This is what a run whose time is being taken wants: no counters, nothing
+/// carried that a measurement would be measuring instead of the search.
+pub type BidirectionalDijkstra = BidirectionalSearch<Untracked>;
+
+/// The same search, counting what its two queues did.
+pub type TrackedBidirectionalDijkstra = BidirectionalSearch<Counters>;
+
+pub struct BidirectionalSearch<S: HeapStats<NodeID>> {
+    forward: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+    backward: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+    upper_bound: usize,
+    meeting_node: NodeID,
+}
+
+impl<S: HeapStats<NodeID>> Default for BidirectionalSearch<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S: HeapStats<NodeID>> BidirectionalSearch<S> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            forward: AddressableHeapWithStats::new(),
+            backward: AddressableHeapWithStats::new(),
+            upper_bound: usize::MAX,
+            meeting_node: INVALID_NODE_ID,
+        }
+    }
+
+    /// What each side's queue did on the last run. The two are kept apart
+    /// because how the work split between them is the thing worth knowing
+    /// about a search that runs from both ends.
+    pub fn stats(&self) -> (&S, &S) {
+        (self.forward.stats(), self.backward.stats())
+    }
+
+    /// clears the search space stored in both queues.
+    pub fn clear(&mut self) {
+        self.forward.clear();
+        self.backward.clear();
+        self.upper_bound = usize::MAX;
+        self.meeting_node = INVALID_NODE_ID;
+    }
+
+    /// The node the two sides met at, or `INVALID_NODE_ID` if they never did.
+    #[must_use]
+    pub fn meeting_node(&self) -> NodeID {
+        self.meeting_node
+    }
+
+    /// how many nodes were explored (not settled), counting both sides.
+    pub fn search_space_len(&self) -> usize {
+        self.forward.inserted_len() + self.backward.inserted_len()
+    }
+
+    /// Settles the next node of one side and relaxes what leaves it.
+    ///
+    /// The node it settles is done for this side, so whatever the other side
+    /// holds for that node is a path from one end to the other through it, and
+    /// the shortest such path seen so far is what the search is bounded by.
+    fn advance<G: Graph<usize>>(
+        queue: &mut AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+        other: &AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+        graph: &G,
+        bound: &mut usize,
+        meeting: &mut NodeID,
+    ) {
+        let u = queue.delete_min();
+        let distance = queue.weight(u);
+
+        // one look, not two: a node the other side has never seen is held at
+        // no distance at all, which is the same answer as asking first whether
+        // it has seen it
+        let from_there = other.weight(u);
+        if from_there != usize::MAX {
+            let through = distance + from_there;
+            if through < *bound {
+                *bound = through;
+                *meeting = u;
+            }
+        }
+
+        for edge in graph.edge_range(u) {
+            let v = graph.target(edge);
+            queue.insert_or_decrease(v, distance + *graph.data(edge), u);
+        }
+    }
+
+    /// Runs a search from `s` and a search from `t` until they meet, and hands
+    /// back what the way between them costs, or `usize::MAX` if there is none.
+    ///
+    /// `reverse` is `graph` with every arc turned around; on an undirected
+    /// network the same graph is handed over twice.
+    ///
+    /// The object is reusable and clears itself on every run.
+    pub fn run<G: Graph<usize>>(&mut self, graph: &G, reverse: &G, s: NodeID, t: NodeID) -> usize {
+        self.clear();
+
+        self.forward.insert(s, 0, s);
+        self.backward.insert(t, 0, t);
+
+        while !self.forward.is_empty() && !self.backward.is_empty() {
+            let front = self.forward.min_weight();
+            let back = self.backward.min_weight();
+
+            // neither side can reach past its own front, so once the two
+            // fronts together are no shorter than the best way already found,
+            // there is nothing left that could beat it
+            if front + back >= self.upper_bound {
+                break;
+            }
+
+            // work on whichever side has come the shorter way, which keeps the
+            // two fronts growing together rather than one running ahead
+            if front <= back {
+                Self::advance(
+                    &mut self.forward,
+                    &self.backward,
+                    graph,
+                    &mut self.upper_bound,
+                    &mut self.meeting_node,
+                );
+            } else {
+                Self::advance(
+                    &mut self.backward,
+                    &self.forward,
+                    reverse,
+                    &mut self.upper_bound,
+                    &mut self.meeting_node,
+                );
+            }
+        }
+
+        self.upper_bound
+    }
+
+    /// The nodes of the way that was found, from source to target.
+    ///
+    /// It is walked out of both queues: back from the meeting node to the
+    /// source through the forward parents, and on from it to the target
+    /// through the backward ones.
+    pub fn retrieve_node_path(&self) -> Option<Vec<NodeID>> {
+        if self.upper_bound == usize::MAX {
+            return None;
+        }
+
+        let mut path = vec![self.meeting_node];
+        let mut node = self.meeting_node;
+        loop {
+            let parent = *self.forward.data(node);
+            if parent == node {
+                break;
+            }
+            path.push(parent);
+            node = parent;
+        }
+        path.reverse();
+
+        let mut node = self.meeting_node;
+        loop {
+            let parent = *self.backward.data(node);
+            if parent == node {
+                break;
+            }
+            path.push(parent);
+            node = parent;
+        }
+
+        Some(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        bidirectional_dijkstra::{
+            BidirectionalDijkstra, BidirectionalSearch, TrackedBidirectionalDijkstra,
+        },
+        edge::InputEdge,
+        graph::Graph,
+        grid_graph::{grid_edges, node_at},
+        heap_stats::Untracked,
+        static_graph::StaticGraph,
+        unidirectional_dijkstra::UnidirectionalDijkstra,
+    };
+
+    /// The same arcs, turned around, which is what the backward side walks.
+    fn reversed(edges: &[InputEdge<usize>]) -> StaticGraph<usize> {
+        StaticGraph::new(
+            edges
+                .iter()
+                .map(|e| InputEdge::new(e.target, e.source, e.data))
+                .collect(),
+        )
+    }
+
+    fn create_graph() -> Vec<InputEdge<usize>> {
+        vec![
+            InputEdge::new(0, 1, 3),
+            InputEdge::new(1, 2, 3),
+            InputEdge::new(4, 2, 1),
+            InputEdge::new(2, 3, 6),
+            InputEdge::new(0, 4, 2),
+            InputEdge::new(4, 5, 2),
+            InputEdge::new(5, 3, 7),
+            InputEdge::new(1, 5, 2),
+        ]
+    }
+
+    /// The table the plain search is held against, so the two searches are
+    /// held against the same numbers rather than against each other alone.
+    #[test]
+    fn apsp() {
+        let edges = create_graph();
+        let graph = StaticGraph::new(edges.clone());
+        let reverse = reversed(&edges);
+
+        let no = usize::MAX;
+        let results_table = [
+            [0, 3, 3, 9, 2, 4],
+            [no, 0, 3, 9, no, 2],
+            [no, no, 0, 6, no, no],
+            [no, no, no, 0, no, no],
+            [no, no, 1, 7, 0, 2],
+            [no, no, no, 7, no, 0],
+        ];
+
+        let mut search = BidirectionalDijkstra::new();
+        for (i, table) in results_table.iter().enumerate() {
+            for (j, expected) in table.iter().enumerate() {
+                assert_eq!(*expected, search.run(&graph, &reverse, i, j), "{i} to {j}");
+            }
+        }
+    }
+
+    /// What the two sides agree on has to be what one side on its own would
+    /// have said, on graphs nobody worked out by hand. This is the check that
+    /// the stopping rule does not stop early.
+    #[test]
+    fn both_ends_agree_with_one_end() {
+        use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_B1_D1);
+        for round in 0..20 {
+            let count = 8 + round;
+            let mut edges = Vec::new();
+            for source in 0..count {
+                for target in 0..count {
+                    if source != target && rng.random_range(0..3) == 0 {
+                        edges.push(InputEdge::new(
+                            source,
+                            target,
+                            rng.random_range(1..20_usize),
+                        ));
+                    }
+                }
+            }
+            if edges.is_empty() {
+                continue;
+            }
+            let graph = StaticGraph::new(edges.clone());
+            let reverse = reversed(&edges);
+            let mut both = BidirectionalDijkstra::new();
+            let mut one = UnidirectionalDijkstra::new();
+
+            for source in 0..count {
+                for target in 0..count {
+                    assert_eq!(
+                        one.run(&graph, source, target),
+                        both.run(&graph, &reverse, source, target),
+                        "round {round}: {source} to {target}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// The way that comes back has to be a way of the graph, and it has to
+    /// cost what was reported. The join at the meeting node is what this
+    /// catches: a path that is walked out of two queues can be handed back
+    /// with the middle node in it twice, or with a step that is not an arc.
+    #[test]
+    fn a_retrieved_path_walks_the_graph_and_costs_what_was_reported() {
+        use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_B1_D2);
+        for round in 0..20 {
+            let count = 8 + round;
+            let mut edges = Vec::new();
+            for source in 0..count {
+                for target in 0..count {
+                    if source != target && rng.random_range(0..3) == 0 {
+                        edges.push(InputEdge::new(
+                            source,
+                            target,
+                            rng.random_range(1..20_usize),
+                        ));
+                    }
+                }
+            }
+            if edges.is_empty() {
+                continue;
+            }
+            let graph = StaticGraph::new(edges.clone());
+            let reverse = reversed(&edges);
+            let mut search = BidirectionalDijkstra::new();
+
+            for source in 0..count {
+                for target in 0..count {
+                    let distance = search.run(&graph, &reverse, source, target);
+                    if distance == usize::MAX {
+                        continue;
+                    }
+                    let path = search
+                        .retrieve_node_path()
+                        .expect("a way was found but not handed back");
+                    assert_eq!(path.first(), Some(&source), "round {round}: {path:?}");
+                    assert_eq!(path.last(), Some(&target), "round {round}: {path:?}");
+
+                    let mut walked = 0;
+                    for step in path.windows(2) {
+                        let edge = graph
+                            .find_edge(step[0], step[1])
+                            .expect("the way takes an arc the graph does not have");
+                        walked += *graph.data(edge);
+                    }
+                    assert_eq!(walked, distance, "round {round}: {path:?}");
+                }
+            }
+        }
+    }
+
+    /// Two searches from two ends look at less than one search from one end.
+    ///
+    /// This is the whole reason to have it, so it is worth asserting rather
+    /// than assuming. A grid is the shape that shows it: a search from one end
+    /// sweeps a disc until the target falls into it, and two searches sweep
+    /// two discs of half the radius, which together cover about half the
+    /// ground. On a line there is nothing to halve and the two ends lose;
+    /// corner to corner of a grid there is nothing to halve either, as the
+    /// disc has to swallow the whole of it either way.
+    #[test]
+    fn two_ends_look_at_less_than_one_end() {
+        // the two ends sit well inside the grid, so neither disc runs into an
+        // edge of it and gets clipped into looking smaller than it is
+        let side = 256;
+        let edges = grid_edges(side, true);
+        let graph = StaticGraph::new(edges);
+        let source = node_at(side, 128, 96);
+        let target = node_at(side, 128, 160);
+
+        let mut one = UnidirectionalDijkstra::new();
+        let mut both = BidirectionalDijkstra::new();
+        assert_eq!(
+            one.run(&graph, source, target),
+            both.run(&graph, &graph, source, target)
+        );
+
+        assert!(
+            both.search_space_len() * 4 < one.search_space_len() * 3,
+            "two ends explored {}, one end explored {}",
+            both.search_space_len(),
+            one.search_space_len(),
+        );
+    }
+
+    /// A search that collects nothing carries nothing to collect it in.
+    #[test]
+    fn collecting_nothing_costs_nothing() {
+        use std::mem::size_of;
+        assert_eq!(
+            size_of::<BidirectionalSearch<Untracked>>(),
+            size_of::<BidirectionalDijkstra>(),
+        );
+        assert!(
+            size_of::<TrackedBidirectionalDijkstra>() > size_of::<BidirectionalDijkstra>(),
+            "counting is supposed to take up room, or it is not counting"
+        );
+    }
+
+    /// Each run says what that run did and nothing about the one before it.
+    #[test]
+    fn a_second_run_does_not_carry_the_first() {
+        let edges = create_graph();
+        let graph = StaticGraph::new(edges.clone());
+        let reverse = reversed(&edges);
+        let mut search = TrackedBidirectionalDijkstra::new();
+
+        search.run(&graph, &reverse, 0, 3);
+        let (forward, backward) = search.stats();
+        let first = (*forward, *backward);
+        search.run(&graph, &reverse, 0, 3);
+        let (forward, backward) = search.stats();
+
+        assert_eq!((*forward, *backward), first);
+    }
+
+    /// An end that cannot be reached is reported as unreachable rather than as
+    /// some distance the two sides happened to agree on.
+    #[test]
+    fn an_unreachable_end_stays_unreachable() {
+        let edges = vec![InputEdge::new(0, 1, 1_usize), InputEdge::new(2, 3, 1_usize)];
+        let graph = StaticGraph::new(edges.clone());
+        let reverse = reversed(&edges);
+        let mut search = BidirectionalDijkstra::new();
+
+        assert_eq!(search.run(&graph, &reverse, 0, 3), usize::MAX);
+        assert_eq!(search.retrieve_node_path(), None);
+    }
+}

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -74,6 +74,23 @@ impl CellDistances {
         }
     }
 
+    /// What it costs to get from one border node to each of the others, as a
+    /// row of the table.
+    ///
+    /// A search walks the whole row against `border_nodes`, and asking for the
+    /// entries one at a time makes it work out where each sits: the width of
+    /// the cell is read, multiplied, added and then checked against the length
+    /// of the table, for every one of a couple of million arcs. The row is one
+    /// piece of memory and the two are walked in step, so it is handed over
+    /// whole and walked as it lies.
+    ///
+    /// An entry of `u32::MAX` is a pair with no way between them.
+    #[must_use]
+    pub fn row(&self, source: usize) -> &[u32] {
+        let width = self.border_nodes.len();
+        &self.matrix[source * width..(source + 1) * width]
+    }
+
     /// Where a node sits in `border_nodes`, and `None` for a node that is not
     /// on the border of this cell at all.
     #[must_use]

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -34,8 +34,23 @@ use std::{
 /// The distances between the border nodes of one cell, in the order the border
 /// nodes are listed in.
 pub struct CellDistances {
-    pub border_nodes: Vec<NodeID>,
-    matrix: Vec<usize>,
+    /// The nodes on the edge of the cell, as four byte numbers.
+    ///
+    /// Read side by side with a row of the table above, once per arc a query
+    /// takes across the cell, so the two are streamed together and both are
+    /// worth keeping narrow. A graph of four thousand million nodes is not one
+    /// this crate can hold anyway, as the tables address it with four bytes.
+    pub border_nodes: Vec<u32>,
+    /// What it costs to cross the cell, as four byte numbers.
+    ///
+    /// A query reads one of these for every arc it takes across a cell, and
+    /// that walk is where such a query spends most of its time. Eight byte
+    /// numbers would be twice the memory to stream for the same answers: on a
+    /// partition of a continent the tables come to some sixty million entries,
+    /// and the row of a coarse cell is a few hundred of them read one after
+    /// another. Four bytes reach four thousand million, and the longest way
+    /// across europe by the clock is under a million.
+    matrix: Vec<u32>,
     /// Where each border node sits in `border_nodes`.
     ///
     /// A query reads the matrix once per arc it takes across a cell, and the
@@ -51,7 +66,12 @@ impl CellDistances {
     /// both given as their place in `border_nodes`.
     #[must_use]
     pub fn distance(&self, source: usize, target: usize) -> usize {
-        self.matrix[source * self.border_nodes.len() + target]
+        let across = self.matrix[source * self.border_nodes.len() + target];
+        if across == u32::MAX {
+            usize::MAX
+        } else {
+            across as usize
+        }
     }
 
     /// Where a node sits in `border_nodes`, and `None` for a node that is not
@@ -364,12 +384,17 @@ impl Customization {
 
         // whichever graph it is, the border nodes lead its numbering
         let border = (0..border_nodes.len()).collect::<Vec<_>>();
-        let mut matrix = vec![usize::MAX; border_nodes.len() * border_nodes.len()];
+        let mut matrix = vec![u32::MAX; border_nodes.len() * border_nodes.len()];
         let mut dijkstra = OneToManyDijkstra::new();
         for &source in &border {
             dijkstra.run(&cell_graph, source, &border);
             for &target in &border {
-                matrix[source * border_nodes.len() + target] = dijkstra.distance(target);
+                let across = dijkstra.distance(target);
+                // what cannot be reached keeps the largest four byte number,
+                // and a cell that really did cost that much would be a graph
+                // nobody has
+                matrix[source * border_nodes.len() + target] =
+                    u32::try_from(across).unwrap_or(u32::MAX);
             }
         }
         drop(of_node);
@@ -408,7 +433,10 @@ impl Customization {
             .map(|(place, &node)| (node, place))
             .collect();
         Some(CellDistances {
-            border_nodes,
+            border_nodes: border_nodes
+                .into_iter()
+                .map(|node| u32::try_from(node).expect("the graph is too large to hold"))
+                .collect(),
             matrix,
             place_of,
         })
@@ -491,9 +519,9 @@ impl Customization {
                         continue;
                     }
                     let next = of_node.len();
-                    let from = *of_node.entry(from).or_insert(next);
+                    let from = *of_node.entry(from as usize).or_insert(next);
                     let next = of_node.len();
-                    let to = *of_node.entry(to).or_insert(next);
+                    let to = *of_node.entry(to as usize).or_insert(next);
                     edges.push(InputEdge::new(from, to, weight));
                 }
             }
@@ -576,15 +604,15 @@ impl Customization {
             ..Default::default()
         };
         for (source, &from) in built.border_nodes.iter().enumerate() {
-            let reached = distances_within_cell(&self.graph, &cells.of_node, cell, from);
+            let reached = distances_within_cell(&self.graph, &cells.of_node, cell, from as usize);
             for (target, &to) in built.border_nodes.iter().enumerate() {
-                let expected = reached.get(&to).copied().unwrap_or(usize::MAX);
+                let expected = reached.get(&(to as usize)).copied().unwrap_or(usize::MAX);
                 let built = built.distance(source, target);
                 if built != expected {
                     check.mismatches.push(Mismatch {
                         cell,
-                        from,
-                        to,
+                        from: from as usize,
+                        to: to as usize,
                         built,
                         expected,
                     });
@@ -639,7 +667,7 @@ mod tests {
         let distances = customization.distances_of(0, 0).expect("no cell");
 
         for (place, &node) in distances.border_nodes.iter().enumerate() {
-            assert_eq!(distances.place_of(node), Some(place));
+            assert_eq!(distances.place_of(node as usize), Some(place));
         }
         // and a node that is not on this border has no place on it
         let elsewhere = *customization
@@ -648,8 +676,11 @@ mod tests {
             .border_nodes
             .first()
             .expect("a cell with no border nodes");
-        assert_eq!(distances.place_of(elsewhere), None);
-        assert_eq!(distances.distance_between(elsewhere, elsewhere), None);
+        assert_eq!(distances.place_of(elsewhere as usize), None);
+        assert_eq!(
+            distances.distance_between(elsewhere as usize, elsewhere as usize),
+            None
+        );
     }
 
     /// Asking by node and asking by place are the same question.
@@ -660,6 +691,7 @@ mod tests {
 
         for &source in &distances.border_nodes {
             for &target in &distances.border_nodes {
+                let (source, target) = (source as usize, target as usize);
                 let places = distances.distance(
                     distances.place_of(source).expect("not on the border"),
                     distances.place_of(target).expect("not on the border"),
@@ -856,7 +888,11 @@ mod tests {
             let indices = (0..border.len()).collect::<Vec<_>>();
             let mut dijkstra = OneToManyDijkstra::new();
 
-            assert_eq!(built_up.border_nodes, border, "cell {cell}");
+            assert_eq!(
+                built_up.border_nodes,
+                border.iter().map(|&n| n as u32).collect::<Vec<_>>(),
+                "cell {cell}"
+            );
             for (source, _) in border.iter().enumerate() {
                 dijkstra.run(&graph, source, &indices);
                 for (target, _) in border.iter().enumerate() {
@@ -1050,7 +1086,7 @@ mod tests {
                         .border_nodes
                         .iter()
                         .enumerate()
-                        .map(|(place, &node)| (node, place))
+                        .map(|(place, &node)| (node as usize, place))
                         .collect(),
                     border_nodes: built.border_nodes.clone(),
                     matrix,
@@ -1065,7 +1101,7 @@ mod tests {
         );
         let wrong = check.mismatches[0];
         assert_eq!(wrong.built, wrong.expected + 100);
-        assert_eq!(wrong.from, built.border_nodes[0]);
-        assert_eq!(wrong.to, built.border_nodes[1]);
+        assert_eq!(wrong.from, built.border_nodes[0] as usize);
+        assert_eq!(wrong.to, built.border_nodes[1] as usize);
     }
 }

--- a/src/dense_heap.rs
+++ b/src/dense_heap.rs
@@ -41,6 +41,9 @@ struct Held {
 /// The place of a node that has not been on the queue during this run.
 const NOWHERE: u32 = u32::MAX;
 
+/// What a node has not been reached at.
+const NOTHING: u32 = u32::MAX;
+
 pub struct DenseHeap<S: HeapStats<NodeID> = Untracked> {
     /// the binary heap itself, as places into `held`, one based so that the
     /// root has a parent slot to stop at
@@ -49,6 +52,21 @@ pub struct DenseHeap<S: HeapStats<NodeID> = Untracked> {
     /// where each node sits in `held`, and [`NOWHERE`] for one this run has
     /// not held
     places: Vec<u32>,
+    /// What each node is held at now, or was settled at, and [`NOTHING`] for
+    /// one this run has not reached.
+    ///
+    /// A search turns an offer away far more often than it takes one, and both
+    /// reasons for turning it away -- the node is settled, or it is already
+    /// held at no more than this -- are answered by the same comparison. Kept
+    /// beside the node rather than behind its place, that is one look into
+    /// memory instead of a look to find the place and a second to read what is
+    /// there.
+    ///
+    /// A node that has come off the queue keeps what it came off at, which
+    /// nothing offered later can beat: a search settles in the order of what
+    /// it costs to reach. A caller that offers something smaller than that is
+    /// not such a search, and is turned away where the place is read.
+    best: Vec<u32>,
     stats: S,
 }
 
@@ -65,6 +83,7 @@ impl<S: HeapStats<NodeID>> DenseHeap<S> {
             heap: vec![(0, 0)],
             held: Vec::new(),
             places: Vec::new(),
+            best: Vec::new(),
             stats: S::default(),
         }
     }
@@ -81,6 +100,7 @@ impl<S: HeapStats<NodeID>> DenseHeap<S> {
         self.heap.truncate(1);
         for held in &self.held {
             self.places[held.node] = NOWHERE;
+            self.best[held.node] = NOTHING;
         }
         self.held.clear();
         self.stats = S::default();
@@ -107,6 +127,7 @@ impl<S: HeapStats<NodeID>> DenseHeap<S> {
     fn remember(&mut self, node: NodeID, place: usize) {
         if node >= self.places.len() {
             self.places.resize(node + 1, NOWHERE);
+            self.best.resize(node + 1, NOTHING);
         }
         self.places[node] = u32::try_from(place).expect("too many nodes on one queue");
     }
@@ -154,6 +175,7 @@ impl<S: HeapStats<NodeID>> DenseHeap<S> {
             data,
         });
         self.remember(node, place);
+        self.best[node] = u32::try_from(weight).unwrap_or(u32::MAX);
         self.heap.push((
             u32::try_from(place).expect("too many nodes on one queue"),
             weight,
@@ -164,16 +186,26 @@ impl<S: HeapStats<NodeID>> DenseHeap<S> {
 
     /// Puts a node on the queue, or lowers what it is held at, in one look.
     pub fn insert_or_decrease(&mut self, node: NodeID, weight: usize, data: NodeID) -> bool {
+        let offered = u32::try_from(weight).unwrap_or(u32::MAX);
+        // one look answers both ways of turning an offer away
+        if self.best.get(node).is_some_and(|&held| offered >= held) {
+            return false;
+        }
         let Some(place) = self.place_of(node) else {
             self.insert(node, weight, data);
             return true;
         };
         let held = self.held[place];
-        if held.key == 0 || held.weight <= weight {
+        // A node that has come off the queue is turned away by the comparison
+        // above, as it came off at no more than anything offered afterwards.
+        // Except by an offer smaller than what it came off at, which a search
+        // that settles in order never makes and which this refuses anyway.
+        if held.key == 0 {
             return false;
         }
         self.held[place].weight = weight;
         self.held[place].data = data;
+        self.best[node] = offered;
         self.heap[held.key].1 = weight;
         self.stats.decreased(node);
         self.up_heap(held.key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod alpha_shape;
 pub mod as_bytes;
 pub mod assembly;
 pub mod bfs;
+pub mod bidirectional_dijkstra;
 pub mod bin_pack;
 pub mod bit_weight_iterator;
 pub mod bitset_subset_iterator;

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -294,13 +294,14 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
             // where a search that started here begins
             return;
         };
-        for (to, &target) in distances.border_nodes.iter().enumerate() {
-            let across = distances.distance(from, to);
-            let target = target as NodeID;
-            if across == usize::MAX || target == node {
+        // the row and the nodes it is about, walked in step as two pieces of
+        // memory rather than asked for an entry at a time
+        let here = u32::try_from(node).unwrap_or(u32::MAX);
+        for (&target, &across) in distances.border_nodes.iter().zip(distances.row(from)) {
+            if across == u32::MAX || target == here {
                 continue;
             }
-            self.relax(target, distance + across, node);
+            self.relax(target as NodeID, distance + across as usize, node);
         }
     }
 

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -296,6 +296,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         };
         for (to, &target) in distances.border_nodes.iter().enumerate() {
             let across = distances.distance(from, to);
+            let target = target as NodeID;
             if across == usize::MAX || target == node {
                 continue;
             }

--- a/src/ranks/bin/command_line.rs
+++ b/src/ranks/bin/command_line.rs
@@ -122,6 +122,8 @@ pub struct Time {
 pub enum Engine {
     /// a plain unidirectional Dijkstra over the graph
     Dijkstra,
+    /// a plain Dijkstra run from both ends at once
+    Bidirectional,
     /// a search over the cells of the partition
     Mld,
 }
@@ -130,6 +132,7 @@ impl Display for Engine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Engine::Dijkstra => write!(f, "dijkstra"),
+            Engine::Bidirectional => write!(f, "bidirectional"),
             Engine::Mld => write!(f, "mld"),
         }
     }

--- a/src/ranks/bin/main.rs
+++ b/src/ranks/bin/main.rs
@@ -52,6 +52,7 @@ fn bar_of(count: usize, what: &str) -> ProgressBar {
 }
 
 use toolbox_rs::{
+    bidirectional_dijkstra::BidirectionalDijkstra,
     customization::Customization,
     edge::InputEdge,
     graph::{Graph, NodeID},
@@ -313,6 +314,18 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
 
     let timings = match args.engine {
         Engine::Dijkstra => time_dijkstra(&graph, &pairs, args.warmup),
+        Engine::Bidirectional => {
+            // the backward side walks arcs into a node, which on a network
+            // read in both directions is the same graph read the same way
+            if is_symmetric(&graph) {
+                info!("the graph is its own reverse, so the backward side shares it");
+                time_bidirectional(&graph, &graph, &pairs, args.warmup)
+            } else {
+                warn!("the graph is directed, so a reversed copy is being built");
+                let reverse = reverse_of(&graph);
+                time_bidirectional(&graph, &reverse, &pairs, args.warmup)
+            }
+        }
         Engine::Mld => {
             let directory: LevelDirectory = io::read_from_file(&args.directory);
             info!(
@@ -338,6 +351,16 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Clearing what the last query left behind belongs to that query, not to the
+/// next one.
+///
+/// A search clears itself as the first thing it does, and what that costs goes
+/// with the size of the run before it, not of the run being timed. Over pairs
+/// drawn from every rank and then shuffled, that puts the cost of clearing a
+/// search of sixteen million nodes onto whichever query happens to follow it:
+/// a small query measured after a large one came out thirty times what the
+/// same query costs after another small one. Clearing before the clock starts
+/// puts it back where it belongs.
 /// The pairs, timed one at a time on one thread. Timing under rayon would say
 /// as much about the scheduler as about the search.
 fn time_dijkstra(graph: &StaticGraph<usize>, pairs: &[ToTime], warmup: usize) -> Vec<Timing> {
@@ -353,11 +376,76 @@ fn time_dijkstra(graph: &StaticGraph<usize>, pairs: &[ToTime], warmup: usize) ->
     let timings = pairs
         .iter()
         .map(|&(source, target, rank)| {
+            search.clear();
             let started = Instant::now();
             let distance = search.run(graph, source, target);
             let elapsed = started.elapsed().as_nanos();
             // outside the reading above, so what is drawn is not what is
             // measured
+            bar.inc(1);
+            (source, target, rank, elapsed, distance)
+        })
+        .collect();
+    bar.finish_and_clear();
+    timings
+}
+
+/// Whether every arc of the graph has its opposite, at the same cost.
+///
+/// A network read in both directions is its own reverse, and then the backward
+/// side of a search from both ends can walk the forward graph and no second
+/// copy of it is needed. That is worth one pass to establish rather than
+/// assuming: assuming it of a graph that is directed somewhere would quietly
+/// hand back distances that are wrong only for the pairs that go that way.
+fn is_symmetric(graph: &StaticGraph<usize>) -> bool {
+    graph.node_range().all(|u| {
+        graph.edge_range(u).all(|edge| {
+            let v = graph.target(edge);
+            graph
+                .find_edge(v, u)
+                .is_some_and(|back| graph.data(back) == graph.data(edge))
+        })
+    })
+}
+
+/// The graph with every arc turned around.
+fn reverse_of(graph: &StaticGraph<usize>) -> StaticGraph<usize> {
+    let mut edges = Vec::with_capacity(graph.number_of_edges());
+    for u in graph.node_range() {
+        for edge in graph.edge_range(u) {
+            edges.push(InputEdge::new(graph.target(edge), u, *graph.data(edge)));
+        }
+    }
+    StaticGraph::new(edges)
+}
+
+/// The same pairs, run from both ends at once.
+///
+/// This is the yardstick that costs nothing to have: no preprocessing, no
+/// overlay, just a second queue. What the overlay is worth is what it beats
+/// this by, not what it beats the one-ended search by.
+fn time_bidirectional(
+    graph: &StaticGraph<usize>,
+    reverse: &StaticGraph<usize>,
+    pairs: &[ToTime],
+    warmup: usize,
+) -> Vec<Timing> {
+    let mut search = BidirectionalDijkstra::new();
+    let bar = bar_of(warmup.min(pairs.len()), "warming");
+    for &(source, target, _) in pairs.iter().take(warmup) {
+        search.run(graph, reverse, source, target);
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
+        .iter()
+        .map(|&(source, target, rank)| {
+            search.clear();
+            let started = Instant::now();
+            let distance = search.run(graph, reverse, source, target);
+            let elapsed = started.elapsed().as_nanos();
             bar.inc(1);
             (source, target, rank, elapsed, distance)
         })
@@ -397,6 +485,7 @@ fn time_mld(
     let timings = pairs
         .iter()
         .map(|&(source, target, rank)| {
+            query.clear();
             let started = Instant::now();
             let reached = query.run(&customization, source, &[target]);
             let elapsed = started.elapsed().as_nanos();


### PR DESCRIPTION
## Changes

**`src/assembly.rs`**
- `agglomerate` grows the smallest cell first, taking in the neighbour the most arcs run to among those it still has room for. It previously sorted the arcs once by weight and made a single pass, so two cells that had each grown past half the size could never be put together.
- `refine(graph, of, size, rounds)` moves single cells across a boundary. A move is taken when the cut does not get worse, the squares of the two boundaries come down, the receiving group still fits under `size`, and the group left is still in one piece without the cell.
- What is evened out is the boundary, not the node count. A search reaches a cell about as often as that cell has border nodes, so a step over it costs `E[B^2]/E[B]`. Balancing node counts instead was measured: level 5's boundary grew from 7560 to 8347, its worst cell from 751 to 1201, and the query slowed by 39.5%.

**`src/bidirectional_dijkstra.rs`** (new)
- `BidirectionalSearch<S: HeapStats<NodeID>>`, with `BidirectionalDijkstra` and `TrackedBidirectionalDijkstra`.
- `run(graph, reverse, s, t)` settles from whichever side stands at the shorter distance and stops once the two fronts together reach the best way found. `reverse` is the graph with every arc turned around.
- `retrieve_node_path()`, `meeting_node()`, `search_space_len()`, `stats() -> (&S, &S)`.

**`src/addressable_binary_heap.rs`**
- `min_weight()` reads the weight of the minimum without looking the node up.

**`src/customization.rs`, `src/mld_query.rs`**
- `CellDistances` holds `u32` rather than `usize`.
- `CellDistances::row(source)` returns one border node's distances as a slice; `relax_across_cell` zips it against `border_nodes` instead of indexing the matrix per target.

**`src/dense_heap.rs`**
- `best`, the weight each node is held at, so an offer that is no better is refused by one load and compare.

**`src/ranks/bin/`**
- `-e bidirectional`. The tool checks whether the graph is its own reverse and shares it when so, and builds a reversed copy when not.
- Clearing now happens before the clock starts. A search clears itself as its first act, and over shuffled pairs that put the cost of clearing a sixteen-million-node search onto whichever query followed. A query of rank 2^1 measured 926.7 us that way and measures 1.0 us with the clock started after the clear.

**`scripts/rank_plot.R`**
- Takes any number of engines. Milliseconds without scientific notation, speedup ticks at 1, 10, 100, 1000.

**`examples/cell_stats.rs`** (new)
- Prints the sizes and boundaries of every level of a directory.

## Partition

europe.ptv, 18,010,173 nodes, levels `[50, 250, 1000, 10000, 100000, 1000000]`.

| level 5 | before | after |
| --- | --- | --- |
| cells | 31 | 25 |
| mean nodes per cell | 580,973 | 720,406 |
| border nodes | 9,618 | 6,521 |
| largest cell's border | 1,054 | 541 |
| what one step walks | 640.8 | 366.9 |

Customization of the whole overlay: 140.9 s to 58.1 s.

## Query

3,072 pairs, 128 per rank bucket, median per bucket, one thread.

| rank | unidirectional | bidirectional | mld | uni/mld | bi/mld |
| --- | --- | --- | --- | --- | --- |
| 2^1 | 1.0 us | 1.8 us | 2.4 us | 0.4x | 0.7x |
| 2^8 | 61.1 us | 41.5 us | 23.9 us | 2.6x | 1.7x |
| 2^12 | 852.4 us | 389.5 us | 86.4 us | 9.9x | 4.5x |
| 2^16 | 15.19 ms | 6.03 ms | 340.3 us | 44.6x | 17.7x |
| 2^20 | 318.07 ms | 182.84 ms | 1.37 ms | 232.9x | 133.9x |
| 2^24 | 6360.40 ms | 4763.55 ms | 5.87 ms | 1083.5x | 811.5x |

Totals: unidirectional 1576.0 s, bidirectional 1317.2 s, mld 2.6 s.

The overlay costs more than a plain search below rank 2^5. All three engines return the same distance on every one of the 3,072 pairs.

![rank_plot.png](https://github.com/user-attachments/assets/3dd85595-c8f1-4d3b-a29f-5df3e4180013)

585 library tests pass; `cargo clippy --all-targets` and `cargo fmt --check` are clean.
