### PR TITLE
Use NodeID for the node containers in BFS, DFS, Tarjan and the path-based SCC

### DIFF
--- a/src/bfs.rs
+++ b/src/bfs.rs
@@ -8,7 +8,7 @@ pub struct BFS {
     target_set: BitVec,
     parents: Vec<NodeID>,
     target: NodeID,
-    queue: VecDeque<usize>,
+    queue: VecDeque<NodeID>,
     empty_target_set: bool,
 }
 
@@ -144,7 +144,7 @@ impl BFS {
 
 pub struct PathIter<'a> {
     bfs: &'a BFS,
-    id: usize,
+    id: NodeID,
 }
 
 impl PathIter<'_> {
@@ -179,6 +179,7 @@ impl Iterator for PathIter<'_> {
 mod tests {
     use crate::edge::InputEdge;
     use crate::graph::Graph;
+    use crate::graph::NodeID;
     use crate::{bfs::BFS, static_graph::StaticGraph};
 
     #[test]
@@ -201,7 +202,7 @@ mod tests {
         let path = bfs.fetch_node_path();
         assert_eq!(path, vec![0, 1, 5]);
 
-        let path: Vec<usize> = bfs.path_iter().collect();
+        let path: Vec<NodeID> = bfs.path_iter().collect();
         assert_eq!(path, vec![5, 1, 0]);
     }
 
@@ -245,7 +246,7 @@ mod tests {
         let path = bfs.fetch_node_path_from_node(3);
         assert_eq!(path, vec![0, 1, 2, 3]);
 
-        let path: Vec<usize> = bfs.path_iter().collect();
+        let path: Vec<NodeID> = bfs.path_iter().collect();
         assert!(path.is_empty());
     }
 
@@ -270,7 +271,7 @@ mod tests {
         let path = bfs.fetch_node_path_from_node(3);
         assert_eq!(path, vec![1, 2, 3]);
 
-        let path: Vec<usize> = bfs.path_iter().collect();
+        let path: Vec<NodeID> = bfs.path_iter().collect();
         assert!(path.is_empty());
     }
 }

--- a/src/dfs.rs
+++ b/src/dfs.rs
@@ -9,7 +9,7 @@ pub struct DFS {
     target_set: BitVec,
     parents: Vec<NodeID>,
     target: NodeID,
-    stack: Vec<usize>,
+    stack: Vec<NodeID>,
     empty_target_set: bool,
 }
 
@@ -145,7 +145,7 @@ impl DFS {
 
 pub struct PathIter<'a> {
     dfs: &'a DFS,
-    id: usize,
+    id: NodeID,
 }
 
 impl PathIter<'_> {
@@ -180,6 +180,7 @@ impl Iterator for PathIter<'_> {
 mod tests {
     use crate::edge::InputEdge;
     use crate::graph::Graph;
+    use crate::graph::NodeID;
     use crate::{dfs::DFS, static_graph::StaticGraph};
 
     #[test]
@@ -202,7 +203,7 @@ mod tests {
         let path = dfs.fetch_node_path();
         assert_eq!(path, vec![0, 4, 5]);
 
-        let path: Vec<usize> = dfs.path_iter().collect();
+        let path: Vec<NodeID> = dfs.path_iter().collect();
         assert_eq!(path, vec![5, 4, 0]);
     }
 
@@ -246,7 +247,7 @@ mod tests {
         let path = dfs.fetch_node_path_from_node(3);
         assert_eq!(path, vec![0, 4, 5, 3]);
 
-        let path: Vec<usize> = dfs.path_iter().collect();
+        let path: Vec<NodeID> = dfs.path_iter().collect();
         assert!(path.is_empty());
     }
 
@@ -271,7 +272,7 @@ mod tests {
         let path = dfs.fetch_node_path_from_node(3);
         assert_eq!(path, vec![1, 5, 3]);
 
-        let path: Vec<usize> = dfs.path_iter().collect();
+        let path: Vec<NodeID> = dfs.path_iter().collect();
         assert!(path.is_empty());
     }
 }

--- a/src/dimacs.rs
+++ b/src/dimacs.rs
@@ -123,7 +123,7 @@ mod tests {
         writeln!(file, "a 4 1 1").unwrap();
         writeln!(file, "a 1 3 1").unwrap();
 
-        let edges = read_graph::<NodeID>(file_path.to_str().unwrap(), WeightType::Unit);
+        let edges = read_graph::<usize>(file_path.to_str().unwrap(), WeightType::Unit);
         assert_eq!(edges.len(), 5);
         assert_eq!(edges[0].source, 0);
         assert_eq!(edges[0].target, 1);
@@ -147,7 +147,7 @@ mod tests {
         writeln!(file, "a 1 3 1").unwrap();
         writeln!(file, "a 1 1 1").unwrap();
 
-        let edges = read_graph::<NodeID>(file_path.to_str().unwrap(), WeightType::Unit);
+        let edges = read_graph::<usize>(file_path.to_str().unwrap(), WeightType::Unit);
         assert_eq!(edges.len(), 5);
         assert_eq!(edges[0].source, 0);
         assert_eq!(edges[0].target, 1);
@@ -173,7 +173,7 @@ mod tests {
         writeln!(file, "h 4 1 1").unwrap();
         writeln!(file, "a 1 3 1").unwrap();
 
-        let edges = read_graph::<NodeID>(file_path.to_str().unwrap(), WeightType::Unit);
+        let edges = read_graph::<usize>(file_path.to_str().unwrap(), WeightType::Unit);
         assert_eq!(edges.len(), 5);
         assert_eq!(edges[0].source, 0);
         assert_eq!(edges[0].target, 1);
@@ -196,7 +196,7 @@ mod tests {
         writeln!(file, "a 4 1 40").unwrap();
         writeln!(file, "a 1 3 50").unwrap();
 
-        let edges = read_graph::<NodeID>(file_path.to_str().unwrap(), WeightType::Original);
+        let edges = read_graph::<usize>(file_path.to_str().unwrap(), WeightType::Original);
         assert_eq!(edges.len(), 5);
         assert_eq!(edges[0].source, 0);
         assert_eq!(edges[0].target, 1);
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_read_graph_invalid_file() {
         let result = std::panic::catch_unwind(|| {
-            read_graph::<NodeID>("invalid_file.txt", WeightType::Unit);
+            read_graph::<usize>("invalid_file.txt", WeightType::Unit);
         });
         assert!(result.is_err());
     }

--- a/src/path_based_scc.rs
+++ b/src/path_based_scc.rs
@@ -17,6 +17,8 @@
  * - Last SCC gets number 2
  */
 
+use crate::graph::NodeID;
+
 use crate::graph::Graph;
 
 #[derive(Clone, Copy)]
@@ -28,7 +30,7 @@ enum DfsState {
 
 pub struct PathBasedScc {
     scc: Vec<usize>,
-    stack: Vec<usize>,  // Stack S
+    stack: Vec<NodeID>, // Stack S
     bounds: Vec<usize>, // Stack B
     component: usize,
 }

--- a/src/tarjan.rs
+++ b/src/tarjan.rs
@@ -7,7 +7,7 @@ use core::cmp::min;
 struct DFSNode {
     caller: NodeID,
     index: usize,
-    lowlink: NodeID,
+    lowlink: usize,
     neighbor: usize,
     on_stack: bool,
 }
@@ -17,7 +17,7 @@ impl DFSNode {
         DFSNode {
             caller: NodeID::MAX,
             index: usize::MAX,
-            lowlink: NodeID::MAX,
+            lowlink: usize::MAX,
             neighbor: usize::MAX,
             on_stack: false,
         }
@@ -55,7 +55,7 @@ impl Tarjan {
             }
             // TODO: consider moving the following to a function to save indentation
 
-            self.stack_push(n, usize::MAX, index);
+            self.stack_push(n, NodeID::MAX, index);
             index += 1;
             let mut last = n;
 
@@ -93,7 +93,7 @@ impl Tarjan {
                     }
 
                     let new_last = self.dfs_state[last].caller;
-                    if new_last != usize::MAX {
+                    if new_last != NodeID::MAX {
                         self.dfs_state[new_last].lowlink = min(
                             self.dfs_state[new_last].lowlink,
                             self.dfs_state[last].lowlink,
@@ -109,7 +109,7 @@ impl Tarjan {
         assignment
     }
 
-    fn stack_push(&mut self, w: usize, caller: usize, index: usize) {
+    fn stack_push(&mut self, w: NodeID, caller: NodeID, index: usize) {
         self.dfs_state[w].caller = caller;
         self.dfs_state[w].neighbor = 0;
         self.dfs_state[w].index = index;


### PR DESCRIPTION
## What changes

| file | before | after |
|---|---|---|
| `bfs.rs` | `queue: VecDeque<usize>` | `VecDeque<NodeID>` |
| `bfs.rs` | `PathIter { id: usize }` | `{ id: NodeID }` |
| `dfs.rs` | `stack: Vec<usize>` | `Vec<NodeID>` |
| `dfs.rs` | `PathIter { id: usize }` | `{ id: NodeID }` |
| `path_based_scc.rs` | `stack: Vec<usize>` | `Vec<NodeID>` |
| `tarjan.rs` | `stack_push(w: usize, caller: usize, index: usize)` | `stack_push(w: NodeID, caller: NodeID, index: usize)` |
| `tarjan.rs` | `DFSNode { lowlink: NodeID }` | `{ lowlink: usize }` |
| `dimacs.rs` (tests) | `read_graph::<NodeID>(..)` | `read_graph::<usize>(..)` |

No behaviour change, no public API change. 584 tests pass, clippy and `cargo fmt` clean.

## Why these are wrong today

The containers held node ids but were typed by what a node id currently *is* rather than by what it *means*. Nothing but a node id is ever put in any of them.

`tarjan.rs` had the other half backwards as well: `lowlink` is a depth-first numbering, not a node — it is assigned from `index` and compared against `index` — and it was typed `NodeID`. So the file used both aliases, each for the thing the other names.

The `dimacs` tests asked `read_graph` for a weight of type `NodeID`. A weight is not a node id. That the two are the same type today is precisely why it went unnoticed.

## Why it is its own change

It fell out of a routing change that narrows `NodeID`, where these files produced errors having nothing to do with the work. They are worth fixing on their own terms and are not worth reviewing inside a routing diff.

The routing work is stacked on this branch.

---

Written with agent assistance.
