### PR TITLE
Unpack an MLD path down to the arcs of the graph

### DIFF
--- a/scripts/path_plot.R
+++ b/scripts/path_plot.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+#
+# Draws unpacked paths over the network they run on.
+#
+#   Rscript scripts/path_plot.R paths.csv network.csv paths.png 12,16,19,21,23,24
+#
+# The inputs are what a run that unpacks paths writes out:
+#
+#   paths.csv    rank,step,lat,lon   every node of each way, in order
+#   network.csv  rank,lat,lon        the nodes around that way
+#
+# The scatter is per path rather than one for the whole network. A way across a
+# town and a way across a continent are four orders of magnitude apart, and a
+# scatter thinned enough to draw the second leaves the first with nothing under
+# it at all: the panel comes out empty and looks like a path drawn on air.
+# Sampled to the window it is drawn in, every panel has a map under it.
+#
+# The last argument picks the ranks to draw, as the exponents; six of them fit
+# the two by three the page is laid out in.
+#
+# Base graphics only, and no package beyond what R ships with, as with the
+# plots beside it.
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+  stop("usage: path_plot.R <paths.csv> <network.csv> [out.png] [ranks]")
+}
+paths <- read.csv(args[1])
+network <- read.csv(args[2])
+output <- if (length(args) >= 3) args[3] else "paths.png"
+for (column in c("rank", "step", "lat", "lon")) {
+  if (!column %in% names(paths)) {
+    stop(sprintf("%s has no %s column", args[1], column))
+  }
+}
+
+drawn <- if (length(args) >= 4) {
+  as.integer(strsplit(args[4], ",")[[1]])
+} else {
+  # a spread over what there is, rather than the first six
+  ranks <- sort(unique(paths$rank))
+  ranks[unique(round(seq(1, length(ranks), length.out = 6)))]
+}
+drawn <- drawn[drawn %in% paths$rank]
+if (length(drawn) == 0) {
+  stop("none of the ranks asked for are in the file")
+}
+
+png(output, width = 1800, height = 1200, res = 130)
+par(mfrow = c(2, ceiling(length(drawn) / 2)), mar = c(2, 2.5, 2.5, 1), las = 1)
+
+for (rank in drawn) {
+  way <- paths[paths$rank == rank, ]
+  way <- way[order(way$step), ]
+  # the same window the scatter was sampled to
+  pad <- max(diff(range(way$lon)), diff(range(way$lat))) * 0.25 + 0.05
+  xlim <- c(min(way$lon) - pad, max(way$lon) + pad)
+  ylim <- c(min(way$lat) - pad, max(way$lat) + pad)
+
+  # degrees of longitude are shorter than degrees of latitude away from the
+  # equator, and a way drawn without saying so leans
+  plot(NA,
+    xlim = xlim, ylim = ylim, xlab = "", ylab = "",
+    asp = 1 / cos(mean(ylim) * pi / 180),
+    main = sprintf("rank 2^%d, %d nodes", rank, nrow(way))
+  )
+  near <- network[network$rank == rank, ]
+  if (nrow(near) > 0) {
+    # dense where the network is dense, which is what makes a town read as a
+    # town; the alpha carries it rather than the size
+    points(near$lon, near$lat, pch = 19, cex = 0.14, col = "#00000022")
+  }
+  # the straight line between the ends, to read the way against
+  lines(c(way$lon[1], way$lon[nrow(way)]), c(way$lat[1], way$lat[nrow(way)]),
+        col = "#9a9a9a", lty = 2)
+  lines(way$lon, way$lat, col = "#c05030", lwd = 1.9)
+  points(way$lon[c(1, nrow(way))], way$lat[c(1, nrow(way))],
+         pch = 19, col = c("#3060c0", "#309050"), cex = 1.2)
+}
+
+invisible(dev.off())
+cat(sprintf("wrote %s: %d paths, ranks 2^%s\n",
+            output, length(drawn), paste(drawn, collapse = ", 2^")))

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -18,10 +18,15 @@
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 1) {
-  stop("usage: rank_plot.R <timings.csv> [out.png]")
+  stop("usage: rank_plot.R <timings.csv> [out.png] [engine-to-divide-by]")
 }
 input <- args[1]
 output <- if (length(args) >= 2) args[2] else "ranks.png"
+# What the lower panel divides by. The engine over the cells by default, that
+# being the thing a plain search is usually held against here, but a file may
+# hold anything worth comparing -- two ways of unpacking a path, say -- and
+# then the one to divide by is whichever the others are being judged against.
+denominator <- if (length(args) >= 3) args[3] else "mld"
 
 timings <- read.csv(input, stringsAsFactors = FALSE)
 for (column in c("engine", "rank", "nanos")) {
@@ -113,19 +118,19 @@ medians <- sapply(engines, function(engine) {
 })
 medians <- matrix(medians, nrow = length(exponents), dimnames = list(NULL, engines))
 
-if ("mld" %in% engines && length(engines) > 1) {
-  # every plain search in the file, against the one over the cells. The plain
-  # unidirectional search is the one a rank axis is defined by, but it is not
-  # the yardstick an overlay has to beat: two searches from two ends cost
-  # nothing but a second queue, so what the cells are worth is what they beat
-  # that by.
-  against <- setdiff(engines, "mld")
-  ratios <- sapply(against, function(engine) medians[, engine] / medians[, "mld"])
+if (denominator %in% engines && length(engines) > 1) {
+  # everything else in the file against the one being judged against. Where
+  # that is the search over the cells, the plain unidirectional search is the
+  # one a rank axis is defined by but not the yardstick an overlay has to
+  # beat: two searches from two ends cost nothing but a second queue, so what
+  # the cells are worth is what they beat that by.
+  against <- setdiff(engines, denominator)
+  ratios <- sapply(against, function(engine) medians[, engine] / medians[, denominator])
   ratios <- matrix(ratios, nrow = length(exponents), dimnames = list(NULL, against))
   ylim <- range(c(ratios, 1), na.rm = TRUE)
   plot(NA,
     xlim = range(exponents), ylim = ylim, log = "y", xaxt = "n", yaxt = "n",
-    xlab = "Dijkstra rank", ylab = "plain search / mld"
+    xlab = "Dijkstra rank", ylab = sprintf("other / %s", name_of(denominator))
   )
   for (engine in against) {
     lines(exponents, ratios[, engine], type = "b", pch = 19, col = colour_of[engine])
@@ -145,15 +150,15 @@ if ("mld" %in% engines && length(engines) > 1) {
   # bottom right has the line at one running through it.
   best_of <- sapply(against, function(engine) {
     best <- which.max(ratios[, engine])
-    sprintf("%s / mld (best %.0fx at 2^%d)", name_of(engine), ratios[best, engine],
-            exponents[best])
+    sprintf("%s / %s (best %.0fx at 2^%d)", name_of(engine), name_of(denominator),
+            ratios[best, engine], exponents[best])
   })
   legend("topleft", legend = best_of, col = colour_of[against],
          lty = 1, pch = 19, bty = "n")
 
 } else {
   plot.new()
-  mtext("a speedup wants the cells and a plain search in the same file",
+  mtext(sprintf("nothing named %s in the file to divide by", denominator),
         side = 3, line = -3, cex = 0.8, col = "#808080")
 }
 

--- a/src/bidirectional_mld_query.rs
+++ b/src/bidirectional_mld_query.rs
@@ -99,6 +99,51 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
         self.meeting_node
     }
 
+    /// The nodes of the way that was found, from source to target, as the
+    /// search found them.
+    ///
+    /// Walked out of both queues, as with a plain search from both ends: back
+    /// from the meeting node through the forward parents, and on from it
+    /// through the backward ones.
+    ///
+    /// These are not all the nodes of the way. A step over a cell is one entry
+    /// here and a path through that cell in the graph, and turning the one
+    /// into the other is what
+    /// [`unpack`](crate::path_unpacking::unpack) is for.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a queue holds a node whose parent it does not.
+    #[must_use]
+    pub fn retrieve_packed_path(&self) -> Option<Vec<NodeID>> {
+        if self.upper_bound == usize::MAX || self.meeting_node == INVALID_NODE_ID {
+            return None;
+        }
+
+        let mut path = vec![self.meeting_node];
+        let mut node = self.meeting_node;
+        loop {
+            let parent = self.forward.data(node);
+            if parent == node {
+                break;
+            }
+            path.push(parent);
+            node = parent;
+        }
+        path.reverse();
+
+        let mut node = self.meeting_node;
+        loop {
+            let parent = self.backward.data(node);
+            if parent == node {
+                break;
+            }
+            path.push(parent);
+            node = parent;
+        }
+        Some(path)
+    }
+
     /// Clears the search space, keeping what was allocated for it.
     pub fn clear(&mut self) {
         self.forward.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod one_to_many_dijkstra;
 pub mod packed_partition;
 pub mod partition_id;
 pub mod path_based_scc;
+pub mod path_unpacking;
 pub mod polyline;
 pub mod prim_complete_graph;
 pub mod r_tree;

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -95,7 +95,10 @@ impl<Key: Copy + Debug + Eq + Hash, Value> LRU<Key, Value> {
     /// assert!(cache.contains(&2));
     /// assert!(cache.contains(&3));
     /// ```
-    pub fn push(&mut self, key: &Key, value: Value) {
+    /// Whatever had to be let go of to make room is handed back, so that a
+    /// caller keeping its own tally of what the cache holds -- bytes rather
+    /// than entries, say -- can take it off again.
+    pub fn push(&mut self, key: &Key, value: Value) -> Option<(Key, Value)> {
         debug_assert!(self.lru_list.len() <= self.capacity);
 
         if let Some(handle) = self.access_map.get(key) {
@@ -105,21 +108,33 @@ impl<Key: Copy + Debug + Eq + Hash, Value> LRU<Key, Value> {
             // Update the value using a mutable reference
             let front = self.lru_list.get_front_mut();
             *front = (*key, value);
-            return;
+            return None;
         }
 
         // Key doesn't exist - handle capacity and insert new entry
-        if self.access_map.len() == self.capacity {
-            // evict least recently used element
+        let evicted = if self.access_map.len() == self.capacity {
             debug_assert!(!self.access_map.is_empty());
-            if let Some((evicted_key, _)) = self.lru_list.pop_back() {
-                self.access_map.remove(&evicted_key);
-            }
-        }
+            self.pop_lru()
+        } else {
+            None
+        };
 
         // Insert new entry
         let handle = self.lru_list.push_front((*key, value));
         self.access_map.insert(*key, handle);
+        evicted
+    }
+
+    /// Lets go of whatever was used longest ago, and hands it back.
+    ///
+    /// A cache held to a number of entries lets go by itself as it is pushed
+    /// to. One held to anything else -- the room its values take, most
+    /// obviously, where the values are not all of a size -- has to be told
+    /// when, and this is how.
+    pub fn pop_lru(&mut self) -> Option<(Key, Value)> {
+        let (key, value) = self.lru_list.pop_back()?;
+        self.access_map.remove(&key);
+        Some((key, value))
     }
 
     /// Returns true if the cache contains the specified key.

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -115,6 +115,34 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         self.queue.weight(node)
     }
 
+    /// The nodes of the way to a target, as the search found them.
+    ///
+    /// These are not all the nodes of the way. A step over a cell is one entry
+    /// here and a path through that cell in the graph, and turning the one
+    /// into the other is what
+    /// [`unpack`](crate::path_unpacking::unpack) is for.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the queue holds a node whose parent it does not.
+    #[must_use]
+    pub fn retrieve_packed_path(&self, target: NodeID) -> Option<Vec<NodeID>> {
+        if !self.queue.inserted(target) {
+            return None;
+        }
+        let mut path = vec![target];
+        let mut node = target;
+        loop {
+            let parent = self.queue.data(node);
+            if parent == node {
+                path.reverse();
+                return Some(path);
+            }
+            path.push(parent);
+            node = parent;
+        }
+    }
+
     /// Clears the search space, keeping what was allocated for it.
     pub fn clear(&mut self) {
         self.queue.clear();

--- a/src/path_unpacking.rs
+++ b/src/path_unpacking.rs
@@ -1,0 +1,731 @@
+//! Turning the way a search over the cells found into the way through the
+//! graph.
+//!
+//! # What a packed path is
+//!
+//! A search over the cells steps from one side of a cell straight to the
+//! other, at the cost the customization worked out for that pair of border
+//! nodes, and never looks at what is inside. So what it hands back is not a
+//! way through the graph: between two of its nodes there may be no arc at all,
+//! only the promise that the cell can be crossed between them at that cost.
+//! Those are the steps this puts back.
+//!
+//! # Which steps have to be put back
+//!
+//! Two sets of arcs leave a node the search stepped over at a level: the ones
+//! across its cell, which the customization tabulated, and the ones out of the
+//! cell, which are arcs of the graph. The first reach border nodes of the same
+//! cell and the second only ever leave it, so which of the two a step was is
+//! read off the cells of its ends: a step whose ends share a cell at the level
+//! its tail was stepped over is a step across that cell, and every other step
+//! is an arc of the graph already.
+//!
+//! Nothing is written down during the search to say so. That is the point: the
+//! search runs the same as it did before this existed, and the question is
+//! asked of the partition afterwards, once per step of a path of a few hundred
+//! rather than once per arc of a search of thousands.
+//!
+//! # How a step across a cell is put back
+//!
+//! By searching for it: the same cell, one level down. A step across a cell of
+//! level `l` is a path within that cell over the cells of level `l - 1`, which
+//! is what the table was built out of in the first place, so a search confined
+//! to the cell and stepping over the level below finds a way of exactly the
+//! cost the table promised. The steps of *that* path across cells of level
+//! `l - 1` are put back the same way, and so on down to the finest level,
+//! where a cell is searched over the arcs of the graph and there is nothing
+//! left to unpack.
+//!
+//! This is what OSRM's `unpackPath` does, where the search it recurses into is
+//! restricted with a fixed level and a parent cell.
+
+use std::{cmp::Reverse, collections::BinaryHeap};
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    customization::Customization,
+    graph::{Graph, NodeID},
+    level_directory::CellId,
+    lru::LRU,
+};
+
+/// What a held way costs beyond its nodes: the key it is filed under, the
+/// vector heading its nodes, and what the cache and its list keep per entry.
+const PER_WAY: usize = size_of::<(NodeID, NodeID, usize)>() + size_of::<Vec<NodeID>>() + 64;
+
+/// Room for the ways of an instance, in bytes.
+///
+/// # What it scales with
+///
+/// What the cache is asked to hold is the steps across cells, and there are
+/// about as many of those as there are nodes, once per level. A cell of `s`
+/// nodes has on the order of the square root of `s` on its border, so it
+/// offers about `s` steps across it, and a level holds `n / s` such cells: the
+/// size of a cell cancels, and each level offers about as many steps as the
+/// graph has nodes. So the room wanted goes with the nodes and the levels, and
+/// not with how the levels were cut -- which is worth saying, since it is the
+/// first thing one reaches for.
+///
+/// The arcs come into it only through how wide a border is, which is to say
+/// through the constant and not through the shape of the formula.
+///
+/// # The constant
+///
+/// Five bytes for every sixteen of those, which is what gives a continent of
+/// eighteen million nodes over six levels a cache of thirty two mebibytes.
+/// There is nothing deeper in the five and the sixteen than that: it is the
+/// room a continent is thought worth giving, worked back into a rate.
+///
+/// Measured over four thousand eight hundred queries drawn from every rank of
+/// a continent, the ways held came to twenty five mebibytes and nothing was
+/// ever let go of, so this room is not what binds such a run. It is set for a
+/// stream of queries longer or more scattered than that one, and a workload
+/// known to be neither should say so with
+/// [`Unpacker::with_budget`](Unpacker::with_budget).
+#[must_use]
+pub fn budget_for(customization: &Customization) -> usize {
+    let directory = customization.directory();
+    directory
+        .number_of_nodes()
+        .saturating_mul(directory.levels())
+        / 16
+        * 5
+}
+
+/// What went wrong turning a packed path into a way through the graph.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Unpacking {
+    /// A step across a cell that the cell turned out not to offer. A table
+    /// saying a cell can be crossed where it cannot is a customization that
+    /// does not describe the graph.
+    NoWayAcross {
+        from: NodeID,
+        to: NodeID,
+        level: usize,
+    },
+    /// A step that is neither an arc of the graph nor a step across a cell.
+    NotAStep { from: NodeID, to: NodeID },
+}
+
+/// The way through the graph that a packed path stands for.
+///
+/// `packed` is what a search over the cells handed back, from source to
+/// target. What comes back is every node of the way, so that each pair of
+/// neighbours in it is an arc of the graph.
+///
+/// # Errors
+///
+/// Returns the first step that could not be put back, which means the tables
+/// and the graph disagree.
+///
+/// # Panics
+///
+/// Panics if the packed path holds a node the partition does not.
+pub fn unpack(customization: &Customization, packed: &[NodeID]) -> Result<Vec<NodeID>, Unpacking> {
+    Unpacker::default().unpack(customization, packed)
+}
+
+/// An unpacker that remembers the ways it has already put back.
+///
+/// A step across a coarse cell is one of a few hundred that cell offers, and
+/// every path crossing that part of the continent takes one of them. Putting
+/// one back is a search, so the second query to cross it pays for the same
+/// search again. Held here, it is a lookup.
+///
+/// What is kept is the finished way, all the way down to the arcs, so a hit at
+/// a coarse level saves the whole recursion under it rather than one level of
+/// it. Nothing is thrown away: a run over a continent's worth of queries keeps
+/// what it has crossed, and a caller that wants the room back asks for it with
+/// [`clear`](Self::clear).
+pub struct Unpacker {
+    ways: LRU<(NodeID, NodeID, usize), Vec<NodeID>>,
+    /// what the ways held come to, kept as they go in and out rather than
+    /// walked, since it is asked after every insert
+    bytes: usize,
+    budget: usize,
+    hits: usize,
+    misses: usize,
+    evicted: usize,
+}
+
+impl Default for Unpacker {
+    /// An unpacker with room enough for a path or two, which is what
+    /// [`unpack`](unpack) makes and throws away again.
+    ///
+    /// A caller putting back a file of them wants
+    /// [`for_instance`](Self::for_instance), which holds what the instance
+    /// warrants; one that knows better says so with
+    /// [`with_budget`](Self::with_budget).
+    fn default() -> Self {
+        Self::with_budget(1 << 20)
+    }
+}
+
+impl Unpacker {
+    /// An unpacker holding what the instance warrants, by
+    /// [`budget_for`](budget_for).
+    #[must_use]
+    pub fn for_instance(customization: &Customization) -> Self {
+        Self::with_budget(budget_for(customization))
+    }
+
+    /// An unpacker holding no more than the given number of bytes of ways.
+    ///
+    /// Held to the room rather than to a count of ways: a way put back at the
+    /// coarsest level is hundreds of nodes and one at the finest is two, so a
+    /// count says little about what is being kept.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the room asked for is more than a table can be made for. The
+    /// table is made once, to the size the room allows, so that nothing is
+    /// rehashed later; a budget of everything there is has no table.
+    #[must_use]
+    pub fn with_budget(bytes: usize) -> Self {
+        // The list is held to a count as well, as that is what it is built
+        // around. Set from the room and the smallest a way can be, so that it
+        // is the room that binds and not this.
+        let entries = (bytes / (PER_WAY + 2 * size_of::<NodeID>())).max(1);
+        Self {
+            ways: LRU::new_with_capacity(entries),
+            bytes: 0,
+            budget: bytes,
+            hits: 0,
+            misses: 0,
+            evicted: 0,
+        }
+    }
+
+    /// how many steps across a cell were answered from what was already here
+    #[must_use]
+    pub const fn hits(&self) -> usize {
+        self.hits
+    }
+
+    /// how many had to be searched for
+    #[must_use]
+    pub const fn misses(&self) -> usize {
+        self.misses
+    }
+
+    /// how many ways were let go of to make room
+    #[must_use]
+    pub const fn evicted(&self) -> usize {
+        self.evicted
+    }
+
+    /// the room the cache was given
+    #[must_use]
+    pub const fn budget(&self) -> usize {
+        self.budget
+    }
+
+    /// how many ways are being held
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ways.len()
+    }
+
+    /// What the ways held come to in bytes: their nodes, and what each costs
+    /// to keep beyond them.
+    #[must_use]
+    pub const fn held_bytes(&self) -> usize {
+        self.bytes
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ways.is_empty()
+    }
+
+    /// Drops what is held, keeping the counts.
+    pub fn clear(&mut self) {
+        self.ways.clear();
+        self.bytes = 0;
+    }
+
+    /// Files a way, letting go of whatever was used longest ago until what is
+    /// held is back inside the room it was given.
+    fn keep(&mut self, key: (NodeID, NodeID, usize), way: &[NodeID]) {
+        let cost = PER_WAY + size_of_val(way);
+        if cost > self.budget {
+            // a way that would not leave room for itself is not worth holding
+            return;
+        }
+        self.bytes += cost;
+        if let Some((_, gone)) = self.ways.push(&key, way.to_vec()) {
+            self.bytes -= PER_WAY + gone.len() * size_of::<NodeID>();
+            self.evicted += 1;
+        }
+        while self.bytes > self.budget {
+            let Some((_, gone)) = self.ways.pop_lru() else {
+                break;
+            };
+            self.bytes -= PER_WAY + gone.len() * size_of::<NodeID>();
+            self.evicted += 1;
+        }
+    }
+
+    /// The way through the graph that a packed path stands for.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first step that could not be put back.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the packed path holds a node the partition does not.
+    pub fn unpack(
+        &mut self,
+        customization: &Customization,
+        packed: &[NodeID],
+    ) -> Result<Vec<NodeID>, Unpacking> {
+        self.unpack_inner(customization, packed)
+    }
+
+    fn unpack_inner(
+        &mut self,
+        customization: &Customization,
+        packed: &[NodeID],
+    ) -> Result<Vec<NodeID>, Unpacking> {
+        let Some((&source, rest)) = packed.split_first() else {
+            return Ok(Vec::new());
+        };
+        let partition = customization.partition();
+        let source_word = partition.word(source);
+        let target_word = partition.word(*packed.last().expect("the path has a first node"));
+
+        let mut way = vec![source];
+        let mut from = source;
+        for &to in rest {
+            // the level the tail was stepped over at is the level a step across a
+            // cell would have been taken at, and the same question the search
+            // asked of it
+            match partition.query_level(source_word, target_word, from) {
+                Some(level)
+                    if partition.same_cell_at(partition.word(from), partition.word(to), level) =>
+                {
+                    let across = self.across_cell(customization, from, to, level)?;
+                    way.extend_from_slice(&across[1..]);
+                }
+                _ => way.push(to),
+            }
+            from = to;
+        }
+        Ok(way)
+    }
+
+    /// A way from one border node of a cell to another, inside the cell.
+    ///
+    /// Every node of it, so the caller may lay it end to end with what it already
+    /// has. The first node is `from` and the last is `to`.
+    fn across_cell(
+        &mut self,
+        customization: &Customization,
+        from: NodeID,
+        to: NodeID,
+        level: usize,
+    ) -> Result<Vec<NodeID>, Unpacking> {
+        if let Some(held) = self.ways.get(&(from, to, level)) {
+            self.hits += 1;
+            return Ok(held.clone());
+        }
+        self.misses += 1;
+        let partition = customization.partition();
+        let cell = partition.cell_of(from, level);
+        let found = within_cell(customization, from, to, level, cell)
+            .ok_or(Unpacking::NoWayAcross { from, to, level })?;
+
+        // The way found is over the cells of the level below, so its own steps
+        // across those cells are put back the same way. At the finest level there
+        // is no level below and every step is already an arc.
+        if level == 0 {
+            self.keep((from, to, level), &found);
+            return Ok(found);
+        }
+        let below = level - 1;
+        let mut way = vec![found[0]];
+        for pair in found.windows(2) {
+            let (step_from, step_to) = (pair[0], pair[1]);
+            if partition.same_cell_at(partition.word(step_from), partition.word(step_to), below) {
+                let across = self.across_cell(customization, step_from, step_to, below)?;
+                way.extend_from_slice(&across[1..]);
+            } else {
+                way.push(step_to);
+            }
+        }
+        self.keep((from, to, level), &way);
+        Ok(way)
+    }
+}
+
+/// A shortest way from one node of a cell to another without leaving it,
+/// stepping over the cells of the level below.
+///
+/// This is the search the table of the cell was built out of, run for one pair
+/// rather than for all of them, and asked for the way rather than the cost.
+/// The nodes it walks are the border nodes of the cells below plus whatever
+/// arcs of the graph run between them, which on a coarse cell is a small part
+/// of what it holds.
+fn within_cell(
+    customization: &Customization,
+    from: NodeID,
+    to: NodeID,
+    level: usize,
+    cell: CellId,
+) -> Option<Vec<NodeID>> {
+    if from == to {
+        return Some(vec![from]);
+    }
+    let partition = customization.partition();
+    let graph = customization.graph();
+
+    let mut parent: FxHashMap<NodeID, NodeID> = FxHashMap::default();
+    let mut best: FxHashMap<NodeID, usize> = FxHashMap::default();
+    let mut settled: Vec<NodeID> = Vec::new();
+    let mut queue = BinaryHeap::new();
+    parent.insert(from, from);
+    best.insert(from, 0);
+    queue.push(Reverse((0_usize, from)));
+
+    while let Some(Reverse((cost, node))) = queue.pop() {
+        // a lazy heap: a node is offered as often as it is reached and the
+        // stale offers are dropped here rather than lowered in place
+        if cost > best.get(&node).copied().unwrap_or(usize::MAX) {
+            continue;
+        }
+        if settled.contains(&node) {
+            continue;
+        }
+        settled.push(node);
+        if node == to {
+            let mut way = vec![to];
+            let mut at = to;
+            while parent[&at] != at {
+                at = parent[&at];
+                way.push(at);
+            }
+            way.reverse();
+            return Some(way);
+        }
+
+        // Where a node is reached more cheaply than before, both what it is
+        // held at and where it was reached from move together. Writing the one
+        // without the other is a way that is a way, and costs more than the
+        // one the search actually found.
+        let mut offer = |target: NodeID, weight: usize| {
+            if weight < best.get(&target).copied().unwrap_or(usize::MAX) {
+                best.insert(target, weight);
+                parent.insert(target, node);
+                queue.push(Reverse((weight, target)));
+            }
+        };
+
+        if level > 0 {
+            // across the cells of the level below, which is what the table of
+            // this cell was built out of
+            let below = level - 1;
+            let inner = partition.cell_of(node, below);
+            if let Some(distances) = customization.distances_of(below, inner)
+                && let Some(place) = distances.place_of(node)
+            {
+                for (&other, &across) in distances.border_nodes.iter().zip(distances.row(place)) {
+                    if across == u32::MAX || other as NodeID == node {
+                        continue;
+                    }
+                    offer(other as NodeID, cost + across as usize);
+                }
+            }
+        }
+
+        // and the arcs of the graph, which is how the search gets from one cell
+        // of the level below into the next, and all it has at the finest level
+        for edge in graph.edge_range(node) {
+            let target = graph.target(edge);
+            // never leave the cell this is confined to
+            if partition.cell_of(target, level) != cell {
+                continue;
+            }
+            if level > 0
+                && partition.same_cell_at(partition.word(node), partition.word(target), level - 1)
+            {
+                // inside a cell of the level below, which the table above
+                // answered for in one step
+                continue;
+            }
+            offer(target, cost + *graph.data(edge) as usize);
+        }
+    }
+    None
+}
+
+/// What a way through the graph costs, and `None` if it is not a way at all.
+///
+/// This is what says an unpacked path is worth having: laid against what the
+/// query said the way costs, it is the whole of the check.
+///
+/// # Panics
+///
+/// Panics if the way holds a node the graph does not.
+#[must_use]
+pub fn cost_of_way<G: Graph<u32>>(graph: &G, way: &[NodeID]) -> Option<usize> {
+    let mut total = 0_usize;
+    for pair in way.windows(2) {
+        let (from, to) = (pair[0], pair[1]);
+        let arc = graph
+            .edge_range(from)
+            .filter(|&edge| graph.target(edge) == to)
+            .map(|edge| *graph.data(edge) as usize)
+            .min()?;
+        total += arc;
+    }
+    Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        bidirectional_mld_query::BidirectionalMldQuery,
+        border_levels::BorderLevels,
+        customization::Customization,
+        edge::InputEdge,
+        grid_graph::{grid_directory, grid_edges},
+        mld_query::MldQuery,
+        static_graph::StaticGraph,
+    };
+    use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+    fn reversed(edges: &[InputEdge<u32>]) -> StaticGraph<u32> {
+        StaticGraph::new(
+            edges
+                .iter()
+                .map(|edge| InputEdge::new(edge.target, edge.source, edge.data))
+                .collect(),
+        )
+    }
+
+    /// An unpacked path has to be a way the graph really offers, and it has to
+    /// cost what the query said the way costs. Either alone is not enough: a
+    /// path of the right cost that steps where there is no arc is not a way,
+    /// and a way that costs more than the query promised is not the way it
+    /// found.
+    fn every_pair_unpacks(side: usize, seed: u64) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut edges = grid_edges(side, true);
+        for edge in &mut edges {
+            edge.data = rng.random_range(1..25_u32);
+        }
+        let plain = StaticGraph::new(edges.clone());
+        let customization = Customization::new(StaticGraph::new(edges), grid_directory(side));
+
+        let count = side * side;
+        let mut query = MldQuery::new();
+        for _ in 0..40 {
+            let source = rng.random_range(0..count as NodeID);
+            let target = rng.random_range(0..count as NodeID);
+            query.run(&customization, source, &[target]);
+            let Some(packed) = query.retrieve_packed_path(target) else {
+                continue;
+            };
+            assert_eq!(packed.first(), Some(&source));
+            assert_eq!(packed.last(), Some(&target));
+
+            let way = unpack(&customization, &packed).expect("the cells offer what they said");
+            assert_eq!(way.first(), Some(&source), "{source} to {target}");
+            assert_eq!(way.last(), Some(&target), "{source} to {target}");
+            let walked = cost_of_way(&plain, &way)
+                .unwrap_or_else(|| panic!("{source} to {target}: {way:?} is not a way"));
+            assert_eq!(
+                walked,
+                query.distance(target),
+                "{source} to {target}: the way costs {walked} against the {} reported",
+                query.distance(target)
+            );
+        }
+    }
+
+    #[test]
+    fn a_grid_of_three_levels_unpacks() {
+        every_pair_unpacks(16, 0x_11AC);
+    }
+
+    /// Six levels, so a step is put back through five levels of cell before it
+    /// reaches an arc.
+    #[test]
+    fn a_grid_of_six_levels_unpacks() {
+        every_pair_unpacks(64, 0x_51E5);
+    }
+
+    /// The search from both ends packs its path out of two queues, so its
+    /// steps want putting back just the same.
+    #[test]
+    fn a_path_from_both_ends_unpacks() {
+        let side = 32;
+        let mut rng = StdRng::seed_from_u64(0x_B07E);
+        let mut edges = grid_edges(side, true);
+        for edge in &mut edges {
+            edge.data = rng.random_range(1..25_u32);
+        }
+        let plain = StaticGraph::new(edges.clone());
+        let reverse = reversed(&edges);
+        let customization = Customization::new(StaticGraph::new(edges), grid_directory(side));
+        let backward = BorderLevels::of(&reverse, customization.partition());
+
+        let count = side * side;
+        let mut query = BidirectionalMldQuery::new();
+        for _ in 0..40 {
+            let source = rng.random_range(0..count as NodeID);
+            let target = rng.random_range(0..count as NodeID);
+            let reported = query.run(&customization, &reverse, &backward, source, target);
+            if reported == usize::MAX {
+                continue;
+            }
+            let packed = query.retrieve_packed_path().expect("a way was found");
+            assert_eq!(packed.first(), Some(&source));
+            assert_eq!(packed.last(), Some(&target));
+
+            let way = unpack(&customization, &packed).expect("the cells offer what they said");
+            let walked = cost_of_way(&plain, &way)
+                .unwrap_or_else(|| panic!("{source} to {target}: {way:?} is not a way"));
+            assert_eq!(walked, reported, "{source} to {target}");
+        }
+    }
+
+    /// What is held has to be what would have been searched for, or a second
+    /// query over the same ground gets a different answer from the first.
+    #[test]
+    fn a_held_way_is_the_way_that_would_have_been_found() {
+        let side = 32;
+        let mut rng = StdRng::seed_from_u64(0x_CAC4E);
+        let mut edges = grid_edges(side, true);
+        for edge in &mut edges {
+            edge.data = rng.random_range(1..25_u32);
+        }
+        let plain = StaticGraph::new(edges.clone());
+        let customization = Customization::new(StaticGraph::new(edges), grid_directory(side));
+
+        let count = side * side;
+        let mut query = MldQuery::new();
+        let mut held = Unpacker::for_instance(&customization);
+        for _ in 0..60 {
+            let source = rng.random_range(0..count as NodeID);
+            let target = rng.random_range(0..count as NodeID);
+            query.run(&customization, source, &[target]);
+            let Some(packed) = query.retrieve_packed_path(target) else {
+                continue;
+            };
+            let fresh = unpack(&customization, &packed).expect("the cells offer what they said");
+            let cached = held
+                .unpack(&customization, &packed)
+                .expect("the cells offer what they said");
+            assert_eq!(fresh, cached, "{source} to {target}");
+            assert_eq!(
+                cost_of_way(&plain, &cached),
+                Some(query.distance(target)),
+                "{source} to {target}"
+            );
+        }
+        // a grid of six hundred queries crosses the same cells over and over,
+        // so something has to have been answered from what was already held
+        assert!(held.hits() > 0, "nothing was ever held");
+        assert!(!held.is_empty());
+    }
+
+    /// The room is a bound, not a wish: an unpacker given very little holds
+    /// very little, lets go of the rest, and still answers correctly.
+    #[test]
+    fn a_small_budget_is_kept_to() {
+        let side = 32;
+        let mut rng = StdRng::seed_from_u64(0x_B0FF);
+        let mut edges = grid_edges(side, true);
+        for edge in &mut edges {
+            edge.data = rng.random_range(1..25_u32);
+        }
+        let plain = StaticGraph::new(edges.clone());
+        let customization = Customization::new(StaticGraph::new(edges), grid_directory(side));
+
+        let budget = 8 * 1024;
+        let mut held = Unpacker::with_budget(budget);
+        let count = side * side;
+        let mut query = MldQuery::new();
+        for _ in 0..80 {
+            let source = rng.random_range(0..count as NodeID);
+            let target = rng.random_range(0..count as NodeID);
+            query.run(&customization, source, &[target]);
+            let Some(packed) = query.retrieve_packed_path(target) else {
+                continue;
+            };
+            let way = held
+                .unpack(&customization, &packed)
+                .expect("the cells offer what they said");
+            // what it holds never says anything about what it answers
+            assert_eq!(
+                cost_of_way(&plain, &way),
+                Some(query.distance(target)),
+                "{source} to {target}"
+            );
+            assert!(
+                held.held_bytes() <= budget,
+                "held {} bytes of {budget}",
+                held.held_bytes()
+            );
+        }
+        assert!(held.evicted() > 0, "a cache this small should have let go");
+    }
+
+    /// The room an instance is given goes with its nodes and its levels, and
+    /// a continent gets thirty two mebibytes.
+    #[test]
+    fn the_budget_goes_with_nodes_and_levels() {
+        let small = Customization::new(StaticGraph::new(grid_edges(16, true)), grid_directory(16));
+        let large = Customization::new(StaticGraph::new(grid_edges(64, true)), grid_directory(64));
+        assert!(budget_for(&large) > budget_for(&small));
+
+        // eighteen million nodes over six levels, which is what a continent
+        // came to, wants thirty two mebibytes give or take a percent
+        let continent = 18_010_173_usize * 6 / 16 * 5;
+        let mebibytes = continent as f64 / (1024.0 * 1024.0);
+        assert!(
+            (mebibytes - 32.0).abs() < 1.0,
+            "a continent would be given {mebibytes:.1} MiB"
+        );
+    }
+
+    /// A packed path of one node is a query that asked about a node and
+    /// itself, and unpacks to itself.
+    #[test]
+    fn a_path_of_one_node_unpacks_to_itself() {
+        let customization =
+            Customization::new(StaticGraph::new(grid_edges(8, true)), grid_directory(8));
+        assert_eq!(unpack(&customization, &[7]), Ok(vec![7]));
+        assert_eq!(unpack(&customization, &[]), Ok(Vec::new()));
+    }
+
+    /// Unpacking puts nodes back, so an unpacked way is at least as long as
+    /// the packed one, and on a grid of several levels it is longer.
+    #[test]
+    fn a_step_over_a_cell_becomes_more_than_one_arc() {
+        let side = 32;
+        let mut rng = StdRng::seed_from_u64(0x_57E9);
+        let mut edges = grid_edges(side, true);
+        for edge in &mut edges {
+            edge.data = rng.random_range(1..25_u32);
+        }
+        let customization = Customization::new(StaticGraph::new(edges), grid_directory(side));
+
+        let mut query = MldQuery::new();
+        let (source, target) = (0, (side * side - 1) as NodeID);
+        query.run(&customization, source, &[target]);
+        let packed = query.retrieve_packed_path(target).expect("a way was found");
+        let way = unpack(&customization, &packed).expect("the cells offer what they said");
+        assert!(
+            way.len() > packed.len(),
+            "a corner to corner way over {} levels unpacked {} nodes into {}",
+            customization.directory().levels(),
+            packed.len(),
+            way.len()
+        );
+    }
+}


### PR DESCRIPTION
## What changes

### New module

`path_unpacking` turns what a search over the cells hands back into a way through the graph.

- `unpack(&Customization, packed: &[NodeID]) -> Result<Vec<NodeID>, Unpacking>` — every node of the way, so each pair of neighbours is an arc.
- `Unpacker` — the same, keeping the ways it has put back. `for_instance`, `with_budget`, `hits`, `misses`, `evicted`, `len`, `held_bytes`, `budget`, `clear`.
- `budget_for(&Customization) -> usize` — how much room the ways of an instance warrant.
- `cost_of_way(&G, &[NodeID]) -> Option<usize>` — what a way costs, and `None` if it is not a way. This is the check.
- `Unpacking` — `NoWayAcross { from, to, level }`, `NotAStep { from, to }`.

### Changed signatures

| before | after |
|---|---|
| `LRU::push(&mut self, &Key, Value)` | `-> Option<(Key, Value)>`, the entry it evicted |
| — | `LRU::pop_lru(&mut self) -> Option<(Key, Value)>` |
| — | `MldSearch::retrieve_packed_path(&self, target) -> Option<Vec<NodeID>>` |
| — | `BidirectionalMldSearch::retrieve_packed_path(&self) -> Option<Vec<NodeID>>` |

### Scripts

- `scripts/path_plot.R` — draws a way over a scatter of the network around it.
- `scripts/rank_plot.R` takes the engine to divide by as an optional third argument, defaulting to `mld`, so existing uses are unchanged.

### Behaviour

No existing behaviour changes. The searches are untouched: nothing was added to a heap entry and no branch to a relaxation.

## How a step is put back

A step across a cell of level `l` is a path within that cell over the cells of level `l - 1` — which is what the table was built out of — so a search confined to the cell and stepping over the level below finds a way of exactly the cost the table promised. Its own steps are put back the same way, down to level 0 where a cell is searched over the arcs themselves. This is OSRM's `unpackPath`, whose recursion is a search restricted to a fixed level and a parent cell.

**Which steps need putting back is read off the partition rather than recorded during the search.** The arcs across a cell reach border nodes of that same cell, and the arcs out of it only ever leave it. So a step whose ends share a cell at the level its tail was stepped over is a step across that cell, and every other step is already an arc. OSRM carries a `from_clique_arc` bool on every heap node; doing that here would mean a wider heap entry and a branch on the hot path of a search that needs neither. Asked afterwards it costs one question per step of a path of a few hundred, against one per arc of a search of thousands.

## The cache and its size

What is held is the **finished** way, down to the arcs, so a hit at a coarse level saves the whole recursion beneath it rather than one level of it. It is an LRU held to **bytes, not entries** — a way is anything from two nodes to hundreds, so a count says little about the room used.

```
budget_for = nodes × levels × 5 / 16      (Europe: 32.2 MiB)
```

Cell sizes cancel, which is the part worth knowing: a cell of `s` nodes has on the order of `√s` on its border and so offers about `s` steps across it, and a level holds `n / s` such cells. Each level therefore offers about as many steps as the graph has nodes, and how the levels were cut does not enter. Arcs enter only through how wide a border is, i.e. through the constant.

The `5 / 16` is calibration, not theory, and the doc comment says so.

## Measurements

Europe, 18,010,173 nodes, 6 levels, 4,800 paths drawn from every rank.

**Every path costs what the query said it costs** — `cost_of_way` walks it in the base graph, which fails if any pair is not an arc, and returns a cost that must equal the query's. Zero mismatches at every rank from 2^1 to 2^24.

| | uncached | cached |
|---|---|---|
| whole file | 6537 ms | 1376 ms (4.4×) |
| a path | 1362 µs | 287 µs |
| second pass over the same file | — | 15 ms (≈90×) |

Per rank bucket, unpacking runs about **twice the cost of the search that produced the path** from 2^12 up, and 3.7× at 2^24 — so getting the path out dominates answering a query on this instance. The cache is worth 1.1× at low ranks and 75× at 2^24.

| budget | held | evicted | hit | per path |
|---|---|---|---|---|
| 1 MiB | 1.0 MiB | 332,984 | 5.8% | 972 µs |
| 4 MiB | 4.0 MiB | 197,913 | 10.4% | 616 µs |
| 16 MiB | 16.0 MiB | 52,006 | 18.6% | 328 µs |
| 32 MiB | 25.1 MiB | 0 | 19.8% | 311 µs |
| 256 MiB | 25.1 MiB | 0 | 19.8% | 324 µs |

The budget is kept to exactly at every size, and every run put back the same 1,583,235 nodes — the bound never changes an answer.

**This workload does not need 32 MiB.** It fills 25.1 MiB and never evicts, and 16 MiB would buy most of it. The room is set for a longer or more scattered stream than the one measured; a caller who knows better says so with `with_budget`.

## Looked at

Paths were drawn on the network at ranks from 2^6 to 2^24. They follow road corridors, and the long ones cross the Channel where they should. The one thing worth reporting: a single arc of **51.3 km** appears on every route between Britain and the continent, at (51.094, 1.123) → (50.915, 1.799) — Folkestone to Calais. It is a genuine arc of the PTV network, not a broken unpack; `cost_of_way` had already proved it was a real arc, and the map said what it is. Median arc is 404 m.

## What it leaves for later

- **Unpacking is now the dominant cost of answering a query**, at roughly twice the search. Nothing here tries to make it cheaper beyond keeping what it finds.
- **The eviction cost function is uniform.** OSRM weighs entries by what they cost to rebuild; this treats a coarse way and a fine one alike, though the coarse one is far dearer to recompute.
- **The plots are not in the description.** `gh` cannot upload images.

---

Written with agent assistance.
