### PR TITLE
Find a node of a cell in an array, and work out every pair of a middling one

### DIFF
--- a/examples/customize.rs
+++ b/examples/customize.rs
@@ -101,10 +101,20 @@ fn main() {
         let add =
             |a: (usize, usize, usize), b: (usize, usize, usize)| (a.0 + b.0, a.1 + b.1, a.2 + b.2);
         let (tabulated, border, entries) = if parallel {
-            (0..cells)
-                .into_par_iter()
-                .map(of_cell)
-                .reduce(|| (0, 0, 0), add)
+            // Widest cell first.
+            //
+            // A level is handed out a cell to a thread, and the coarsest level
+            // of a continent has twenty-six of them of very different sizes.
+            // Taken in the order they are numbered a big one can come up last
+            // and every thread waits on it; taken widest first it starts at
+            // once and the small ones fill in around it. Longest job first,
+            // which is the oldest trick there is for this and costs a sort of
+            // as many numbers as the level has cells.
+            let holding = customization.level(level);
+            let mut order: Vec<usize> = (0..cells).collect();
+            order
+                .sort_unstable_by_key(|&cell| std::cmp::Reverse(holding.nodes_of_cell[cell].len()));
+            order.into_par_iter().map(of_cell).reduce(|| (0, 0, 0), add)
         } else {
             (0..cells).map(of_cell).fold((0, 0, 0), add)
         };

--- a/examples/customize.rs
+++ b/examples/customize.rs
@@ -1,0 +1,140 @@
+//! Customizes every cell of every level and says what it cost.
+//!
+//! ```text
+//! customize <graph> <directory> [level]
+//! ```
+//!
+//! The overlay is worked out as it is asked for, so nothing in the crate ever
+//! customizes the whole of it in one go and there is no number saying what
+//! that costs. This asks for every cell of every level in turn, which is the
+//! same work a customization would do, and reports it per level.
+//!
+//! Bottom up, because a cell is built out of the cells below it. Asking for a
+//! coarse cell first would pull the fine ones in behind it and charge their
+//! time to the coarse level, which is the one measurement here that has to be
+//! right.
+//!
+//! What is reported per level is what the cost is made of. A level is a number
+//! of cells, each with a number of border nodes, and the table of a cell is
+//! that number squared, filled by that number of searches. So the totals of
+//! the border nodes and of their squares say which levels can be expected to
+//! be dear before anything is measured, and the wall time says which ones
+//! turned out to be.
+
+use std::{
+    env::args,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use rayon::prelude::*;
+use toolbox_rs::{
+    customization::Customization, graph::Graph, io, level_directory::LevelDirectory,
+    static_graph::StaticGraph,
+};
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!("usage: customize <graph> <directory> [level]: missing {what}")
+        })
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let rest: Vec<String> = argv.collect();
+    // cells of one level are independent of one another, so a level is
+    // parallel; the levels are not, a cell being built out of the cells below
+    let parallel = rest.iter().any(|word| word == "parallel");
+    let only: Option<usize> = rest
+        .iter()
+        .find(|word| word.parse::<usize>().is_ok())
+        .map(|word| word.parse().expect("a level"));
+
+    let loading = Instant::now();
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    let levels = directory.levels();
+    println!(
+        "{} nodes, {} arcs, {levels} levels, loaded in {:.1?}",
+        directory.number_of_nodes(),
+        graph.number_of_edges(),
+        loading.elapsed()
+    );
+
+    // What the cells of a level cost, split into what was spent building the
+    // graph to search and what was spent searching it. Six levels of counters
+    // rather than a lock around a table: this is read once per cell, and a
+    // measurement that contends is a measurement that changes what it measures.
+    const LEVELS: usize = 16;
+    static BUILDING: [AtomicU64; LEVELS] = [const { AtomicU64::new(0) }; LEVELS];
+    static SEARCHING: [AtomicU64; LEVELS] = [const { AtomicU64::new(0) }; LEVELS];
+    static NODES: [AtomicU64; LEVELS] = [const { AtomicU64::new(0) }; LEVELS];
+    static ARCS: [AtomicU64; LEVELS] = [const { AtomicU64::new(0) }; LEVELS];
+
+    let customization = Customization::new(graph, directory).watched_by(|report| {
+        let level = report.level.min(LEVELS - 1);
+        BUILDING[level].fetch_add(report.building.as_nanos() as u64, Ordering::Relaxed);
+        SEARCHING[level].fetch_add(report.searching.as_nanos() as u64, Ordering::Relaxed);
+        NODES[level].fetch_add(report.searched as u64, Ordering::Relaxed);
+        ARCS[level].fetch_add(report.arcs as u64, Ordering::Relaxed);
+    });
+    println!(
+        "{:>5} {:>8} {:>9} {:>12} {:>8} {:>9} {:>9} {:>8} {:>8} {:>6}",
+        "level", "cells", "entries", "arcs", "V", "wall", "search", "build", "b/V", "build%"
+    );
+
+    let mut whole = std::time::Duration::ZERO;
+    let mut all_entries = 0usize;
+    for level in 0..levels {
+        let cells = customization.cells_on_level(level);
+        let started = Instant::now();
+        let of_cell = |cell: usize| {
+            customization
+                .distances_of(level, cell as u32)
+                .map_or((0, 0, 0), |distances| {
+                    let wide = distances.border_nodes.len();
+                    (1, wide, wide * wide)
+                })
+        };
+        let add =
+            |a: (usize, usize, usize), b: (usize, usize, usize)| (a.0 + b.0, a.1 + b.1, a.2 + b.2);
+        let (tabulated, border, entries) = if parallel {
+            (0..cells)
+                .into_par_iter()
+                .map(of_cell)
+                .reduce(|| (0, 0, 0), add)
+        } else {
+            (0..cells).map(of_cell).fold((0, 0, 0), add)
+        };
+        let elapsed = started.elapsed();
+        whole += elapsed;
+        all_entries += entries;
+        let building = BUILDING[level].load(Ordering::Relaxed) as f64 / 1e9;
+        let searching = SEARCHING[level].load(Ordering::Relaxed) as f64 / 1e9;
+        let searched = NODES[level].load(Ordering::Relaxed);
+        let arcs = ARCS[level].load(Ordering::Relaxed);
+        println!(
+            "{level:>5} {cells:>8} {entries:>9} {arcs:>12} {:>8} {:>9} {:>9} {:>8} {:>8} {:>5.0}%",
+            searched / tabulated.max(1) as u64,
+            format!("{:.2}s", elapsed.as_secs_f64()),
+            format!("{searching:.2}s"),
+            format!("{building:.2}s"),
+            format!("{:.2}", border as f64 / searched.max(1) as f64),
+            100.0 * building / (building + searching).max(1e-9),
+        );
+        // a level is built out of the one below, so the ones below a level
+        // asked for are worked out and reported on the way up to it
+        if only.is_some_and(|wanted| wanted == level) {
+            break;
+        }
+    }
+
+    println!(
+        "customized {} cells in {:.2?}, {all_entries} entries, {:.0} entries a second",
+        customization.customized_cells(),
+        whole,
+        all_entries as f64 / whole.as_secs_f64()
+    );
+}

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -256,8 +256,139 @@ pub struct CellReport<'a> {
     pub total: Duration,
 }
 
+/// How wide a cell may be and still be worth a Floyd-Warshall.
+///
+/// Two things decide whether a cell is better tabulated by working out every
+/// pair at once than by a search from each of its border nodes, and the
+/// measurements on a continent say both matter.
+///
+/// The finest level is searched over the arcs of the road network, where a
+/// node has two or three of them. A search there touches almost nothing, and
+/// working out every pair does the same work whatever the arcs are, so it
+/// loses however narrow the cell is. Every level above is searched over the
+/// cliques of the cells below, where the arcs go as the square of the nodes
+/// and a search touches all of them. That is the case this is for.
+///
+/// And it is cubic in the nodes of the cell, so it wants a narrow one. Level
+/// by level on Europe, one thread, against the searches it replaces:
+///
+/// ```text
+///   level 0     36 nodes    4.15s against  3.74s
+///   level 1     30 nodes    0.77s against  2.07s
+///   level 2     45 nodes    0.49s against  1.69s
+///   level 3    197 nodes    2.20s against  2.65s
+///   level 4    505 nodes    3.88s against  3.07s
+///   level 5   1169 nodes   11.69s against  3.40s
+/// ```
+///
+/// The turn is between two hundred nodes and five hundred. The gains on either
+/// side of it are slight and the losses past it are not, so the line is drawn
+/// nearer the near side.
+const WIDEST_FOR_FLOYD_WARSHALL: usize = 300;
+
+/// The levels to work out every pair on, when `TOOLBOX_FLOYD_WARSHALL` says.
+///
+/// For measuring one way against the other, and nothing else: with nothing
+/// asked for, each cell is judged on its own by the rule above.
+fn floyd_warshall_levels() -> Option<&'static [bool]> {
+    static LEVELS: OnceLock<Option<Vec<bool>>> = OnceLock::new();
+    LEVELS
+        .get_or_init(|| {
+            let asked = std::env::var("TOOLBOX_FLOYD_WARSHALL").ok()?;
+            let mut wanted = vec![false; 32];
+            for level in asked
+                .split(',')
+                .filter_map(|word| word.trim().parse::<usize>().ok())
+            {
+                if let Some(slot) = wanted.get_mut(level) {
+                    *slot = true;
+                }
+            }
+            Some(wanted)
+        })
+        .as_deref()
+}
+
+/// Every distance within a cell, by Floyd-Warshall, of which the leading
+/// `wide` rows and columns are the answer.
+///
+/// The table is the whole cell rather than its border, which is the trade: it
+/// works out distances between nodes nobody asked about, and in exchange the
+/// inner loop is a row read against a row written with nothing in it but a
+/// compare and a move. No queue, no addressing, nothing to settle, and a
+/// compiler is free to do several at once.
+///
+/// Row `k` is copied out before the sweep that uses it so that the two rows in
+/// hand are not the same one, which lets the inner loop be a plain walk of two
+/// slices rather than an indexed one the bounds checks stay in.
+fn floyd_warshall(graph: &StaticGraph<u32>, nodes: usize, wide: usize) -> Vec<u32> {
+    let mut table = vec![u32::MAX; nodes * nodes];
+    for node in 0..nodes {
+        table[node * nodes + node] = 0;
+    }
+    for source in 0..nodes {
+        for edge in graph.edge_range(source) {
+            let target = graph.target(edge);
+            let weight = *graph.data(edge);
+            let held = &mut table[source * nodes + target];
+            *held = (*held).min(weight);
+        }
+    }
+
+    let mut through = vec![u32::MAX; nodes];
+    for step in 0..nodes {
+        through.copy_from_slice(&table[step * nodes..(step + 1) * nodes]);
+        for source in 0..nodes {
+            let reach = table[source * nodes + step];
+            // nothing goes through a node this one does not reach
+            if reach == u32::MAX {
+                continue;
+            }
+            let row = &mut table[source * nodes..(source + 1) * nodes];
+            for (held, &onward) in row.iter_mut().zip(through.iter()) {
+                // the unreachable is the largest there is, and saturating
+                // keeps it there rather than wrapping it round to nothing
+                let offered = reach.saturating_add(onward);
+                *held = (*held).min(offered);
+            }
+        }
+    }
+
+    // the border nodes lead the numbering, so the answer is the corner of it
+    let mut matrix = vec![u32::MAX; wide * wide];
+    for source in 0..wide {
+        matrix[source * wide..(source + 1) * wide]
+            .copy_from_slice(&table[source * nodes..source * nodes + wide]);
+    }
+    matrix
+}
+
+/// What building and searching one cell needs, kept to be used for the next.
+///
+/// A cell is a small thing and there are six hundred thousand of them, so what
+/// it costs to ask for the room is a real part of what a cell costs. Every one
+/// of them was making a map, a list of arcs, an adjacency array and a search,
+/// using them for a few microseconds and giving them all back. Under one
+/// thread that is the allocator's fast path several million times; under eight
+/// it is the allocator's slow path, and the customization of a continent spent
+/// thirteen seconds of system time on it.
+///
+/// Held rather than pooled by size: what a cell wants grows to what the widest
+/// cell of a level wanted and stays there, which for the finest level is a few
+/// hundred arcs and for the coarsest a few hundred thousand.
+#[derive(Default)]
+struct Scratch {
+    dijkstra: OneToManyDijkstra,
+    /// where a node of the graph sits in the numbering of the cell
+    of_node: FxHashMap<NodeID, usize>,
+    /// the arcs of the cell, sorted in place and read into the graph
+    edges: Vec<InputEdge<u32>>,
+    /// the nodes of the cell that sit on its border, in order
+    border_nodes: Vec<NodeID>,
+}
+
 thread_local! {
-    /// Searches kept for the next cell rather than made for each one.
+    /// Room kept for the next cell rather than asked for by each one.
     ///
     /// A cell is a small graph and a search over it a small object, so what it
     /// costs to make one is a real part of what a cell costs: on a continent
@@ -267,9 +398,9 @@ thread_local! {
     /// to a thread and the threads sharing nothing else.
     ///
     /// A pool rather than one, so that a cell asking for the cells below it
-    /// while it holds a search cannot find the place empty and the borrow
-    /// already taken.
-    static SEARCHES: RefCell<Vec<OneToManyDijkstra>> = const { RefCell::new(Vec::new()) };
+    /// while it holds this cannot find the place empty and the borrow already
+    /// taken. Bottom up nothing nests and the pool is one deep.
+    static SCRATCH: RefCell<Vec<Scratch>> = const { RefCell::new(Vec::new()) };
 }
 
 /// The cells of a partition, worked out level by level as they are asked for.
@@ -524,25 +655,27 @@ impl Customization {
     fn tabulate(&self, level: usize, cell: CellId) -> Option<CellDistances> {
         let started = Instant::now();
         let cells = self.level(level);
+        // taken before the cell is built rather than before it is searched,
+        // the building being the part that asks for the room
+        let mut scratch = SCRATCH.with_borrow_mut(Vec::pop).unwrap_or_default();
         let building = Instant::now();
         let nodes = cells.nodes_of_cell.get(cell as usize)?;
 
         // the border nodes lead the numbering, so that they are the leading
         // rows and columns of the matrix
-        let border_nodes = nodes
-            .iter()
-            .copied()
-            .filter(|&node| cells.on_border[node])
-            .collect::<Vec<_>>();
-        if border_nodes.is_empty() {
+        scratch.border_nodes.clear();
+        scratch
+            .border_nodes
+            .extend(nodes.iter().copied().filter(|&node| cells.on_border[node]));
+        if scratch.border_nodes.is_empty() {
             debug!("cell {cell} of level {level} has no border nodes");
+            SCRATCH.with_borrow_mut(|pool| pool.push(scratch));
             return None;
         }
 
-        let (cell_graph, of_node, searched) = if level == 0 {
+        let (cell_graph, searched) = if level == 0 {
             (
-                self.subgraph_of(&cells, cell, nodes, &border_nodes),
-                None,
+                self.subgraph_of(&cells, cell, nodes, &mut scratch),
                 nodes.len(),
             )
         } else {
@@ -550,8 +683,7 @@ impl Customization {
             // inside one of them is already tabulated, and what it does between
             // them is an arc of the graph. Searching that instead of the nodes
             // of the cell is what keeps a coarse level affordable.
-            let (graph, of_node, searched) = self.overlay_of(level, cell, &cells);
-            (graph, Some(of_node), searched)
+            self.overlay_of(level, cell, &cells, &mut scratch)
         };
 
         let building = building.elapsed();
@@ -559,25 +691,26 @@ impl Customization {
 
         // whichever graph it is, the border nodes lead its numbering
         let searching = Instant::now();
-        let wide = border_nodes.len();
-        let mut matrix = vec![u32::MAX; wide * wide];
-        // the cells below are all tabulated by now, so nothing this search
-        // does can ask for another one, and the pool is only ever one deep
-        let mut dijkstra = SEARCHES
-            .with_borrow_mut(Vec::pop)
-            .unwrap_or_default();
-        for source in 0..wide {
-            dijkstra.run_to_leading(&cell_graph, source, wide);
-            let row = &mut matrix[source * wide..(source + 1) * wide];
-            for (target, across) in row.iter_mut().enumerate() {
-                // what cannot be reached keeps the largest four byte number,
-                // and a cell that really did cost that much would be a graph
-                // nobody has
-                *across = u32::try_from(dijkstra.distance(target)).unwrap_or(u32::MAX);
+        let wide = scratch.border_nodes.len();
+        // a cell of the finest level is searched over road arcs, which is the
+        // one case where working out every pair is not worth it
+        let every_pair = level > 0 && searched <= WIDEST_FOR_FLOYD_WARSHALL;
+        let matrix = if floyd_warshall_levels().map_or(every_pair, |asked| asked[level.min(31)]) {
+            floyd_warshall(&cell_graph, searched.max(wide), wide)
+        } else {
+            let mut matrix = vec![u32::MAX; wide * wide];
+            for source in 0..wide {
+                scratch.dijkstra.run_to_leading(&cell_graph, source, wide);
+                let row = &mut matrix[source * wide..(source + 1) * wide];
+                for (target, across) in row.iter_mut().enumerate() {
+                    // what cannot be reached keeps the largest four byte
+                    // number, and a cell that really did cost that much would
+                    // be a graph nobody has
+                    *across = u32::try_from(scratch.dijkstra.distance(target)).unwrap_or(u32::MAX);
+                }
             }
-        }
-        SEARCHES.with_borrow_mut(|pool| pool.push(dijkstra));
-        drop(of_node);
+            matrix
+        };
         let searching = searching.elapsed();
 
         // the searches are what the customization of a cell costs, so the
@@ -594,7 +727,7 @@ impl Customization {
                 level,
                 cell,
                 nodes,
-                border_nodes: border_nodes.len(),
+                border_nodes: wide,
                 searched,
                 arcs,
                 elapsed,
@@ -607,23 +740,23 @@ impl Customization {
             debug!(
                 "cell {cell} of level {level}: {} nodes, {} of them on the border, searched over {searched}",
                 nodes.len(),
-                border_nodes.len()
+                wide
             );
         }
 
-        let place_of = border_nodes
+        let place_of = scratch
+            .border_nodes
             .iter()
             .enumerate()
             .map(|(place, &node)| (node, place))
             .collect();
-        Some(CellDistances::holding(
-            border_nodes
-                .into_iter()
-                .map(|node| u32::try_from(node).expect("the graph is too large to hold"))
-                .collect(),
-            matrix,
-            place_of,
-        ))
+        let border_nodes = scratch
+            .border_nodes
+            .iter()
+            .map(|&node| u32::try_from(node).expect("the graph is too large to hold"))
+            .collect();
+        SCRATCH.with_borrow_mut(|pool| pool.push(scratch));
+        Some(CellDistances::holding(border_nodes, matrix, place_of))
     }
 
     /// The arcs of the graph that stay inside a cell, with its border nodes
@@ -634,14 +767,20 @@ impl Customization {
         cells: &Level,
         cell: CellId,
         nodes: &[NodeID],
-        border_nodes: &[NodeID],
+        scratch: &mut Scratch,
     ) -> StaticGraph<u32> {
         // TODO: faster hashmap implementation using tabhash or fibonacci hash
-        let mut of_node = FxHashMap::default();
-        for &node in border_nodes {
+        let Scratch {
+            of_node,
+            edges,
+            border_nodes,
+            ..
+        } = scratch;
+        of_node.clear();
+        edges.clear();
+        for &node in border_nodes.iter() {
             of_node.insert(node, of_node.len());
         }
-        let mut edges = Vec::new();
         for &node in nodes {
             for edge in self.graph.edge_range(node) {
                 let target = self.graph.target(edge);
@@ -659,8 +798,9 @@ impl Customization {
         // appears in no arc here. The graph is asked for the nodes the cell
         // has all the same, or a search started from that node would read past
         // the end of it.
-        // TODO: find a way to avoid relocations
-        StaticGraph::new_with_nodes(of_node.len().max(border_nodes.len()), edges)
+        let nodes = of_node.len().max(border_nodes.len());
+        edges.sort_unstable();
+        StaticGraph::from_sorted_slice(nodes, edges)
     }
 
     /// The graph a cell of a level above the finest is searched over: one arc
@@ -676,12 +816,15 @@ impl Customization {
         level: usize,
         cell: CellId,
         cells: &Level,
-    ) -> (StaticGraph<u32>, FxHashMap<NodeID, usize>, usize) {
+        scratch: &mut Scratch,
+    ) -> (StaticGraph<u32>, usize) {
         let below = self.level(level - 1);
+        let Scratch { of_node, edges, .. } = scratch;
+        of_node.clear();
+        edges.clear();
 
         // the border nodes of this cell lead the numbering, the border nodes of
         // the cells below follow
-        let mut of_node = FxHashMap::default();
         for &node in cells.nodes_of_cell[cell as usize]
             .iter()
             .filter(|&&node| cells.on_border[node])
@@ -689,7 +832,6 @@ impl Customization {
             of_node.insert(node, of_node.len());
         }
 
-        let mut edges = Vec::new();
         for &child in &cells.built_from[cell as usize] {
             let Some(distances) = self.distances_of(level - 1, child) else {
                 // a cell below with no border cannot be entered or left, so no
@@ -743,8 +885,8 @@ impl Customization {
         // that no arc of it touches would otherwise be missing from it and a
         // search started there would read past its end.
         let searched = of_node.len();
-        let graph = StaticGraph::new_with_nodes(searched, edges);
-        (graph, of_node, searched)
+        edges.sort_unstable();
+        (StaticGraph::from_sorted_slice(searched, edges), searched)
     }
 }
 
@@ -1103,7 +1245,11 @@ mod tests {
                 .copied()
                 .filter(|&node| cells.on_border[node])
                 .collect::<Vec<_>>();
-            let graph = customization.subgraph_of(&cells, cell, nodes, &border);
+            let mut scratch = Scratch {
+                border_nodes: border.clone(),
+                ..Scratch::default()
+            };
+            let graph = customization.subgraph_of(&cells, cell, nodes, &mut scratch);
             let indices = (0..border.len() as NodeID).collect::<Vec<_>>();
             let mut dijkstra = OneToManyDijkstra::new();
 
@@ -1141,7 +1287,11 @@ mod tests {
                 .copied()
                 .filter(|&node| cells.on_border[node])
                 .collect::<Vec<_>>();
-            let graph = customization.subgraph_of(&cells, cell, nodes, &border);
+            let mut scratch = Scratch {
+                border_nodes: border.clone(),
+                ..Scratch::default()
+            };
+            let graph = customization.subgraph_of(&cells, cell, nodes, &mut scratch);
             let indices = (0..border.len() as NodeID).collect::<Vec<_>>();
             let mut dijkstra = OneToManyDijkstra::new();
 

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -26,6 +26,7 @@ use crate::{
 use log::debug;
 use rustc_hash::FxHashMap;
 use std::{
+    cell::RefCell,
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -236,11 +237,39 @@ pub struct CellReport<'a> {
     /// how many nodes the search ran over, which on a level above the finest
     /// is the border nodes of the cells below rather than all of their nodes
     pub searched: usize,
+    /// how many arcs it ran over, a clique of the cells below among them
+    pub arcs: usize,
     pub elapsed: Duration,
+    /// What went on building the graph the searches then ran over.
+    ///
+    /// Split from the searches because the two answer to different things. The
+    /// searches are the work the algorithm asks for and shrink only by asking
+    /// for less of it; the building is a cost of how this happens to be
+    /// arranged, and a level that spends its time there is a level with
+    /// something to take away rather than something to make cleverer.
+    pub building: Duration,
+    /// and what went on the searches themselves
+    pub searching: Duration,
     /// how many cells have been worked out so far, this one included
     pub customized_cells: usize,
     /// what all of them together have cost
     pub total: Duration,
+}
+
+thread_local! {
+    /// Searches kept for the next cell rather than made for each one.
+    ///
+    /// A cell is a small graph and a search over it a small object, so what it
+    /// costs to make one is a real part of what a cell costs: on a continent
+    /// there are six hundred thousand cells and six hundred thousand searches
+    /// made and thrown away, and the queue inside one holds several vectors of
+    /// its own. Kept per thread, the customization of a level running a cell
+    /// to a thread and the threads sharing nothing else.
+    ///
+    /// A pool rather than one, so that a cell asking for the cells below it
+    /// while it holds a search cannot find the place empty and the borrow
+    /// already taken.
+    static SEARCHES: RefCell<Vec<OneToManyDijkstra>> = const { RefCell::new(Vec::new()) };
 }
 
 /// The cells of a partition, worked out level by level as they are asked for.
@@ -495,6 +524,7 @@ impl Customization {
     fn tabulate(&self, level: usize, cell: CellId) -> Option<CellDistances> {
         let started = Instant::now();
         let cells = self.level(level);
+        let building = Instant::now();
         let nodes = cells.nodes_of_cell.get(cell as usize)?;
 
         // the border nodes lead the numbering, so that they are the leading
@@ -524,22 +554,31 @@ impl Customization {
             (graph, Some(of_node), searched)
         };
 
+        let building = building.elapsed();
+        let arcs = cell_graph.number_of_edges();
+
         // whichever graph it is, the border nodes lead its numbering
-        let border = (0..border_nodes.len() as NodeID).collect::<Vec<_>>();
-        let mut matrix = vec![u32::MAX; border_nodes.len() * border_nodes.len()];
-        let mut dijkstra = OneToManyDijkstra::new();
-        for &source in &border {
-            dijkstra.run(&cell_graph, source, &border);
-            for &target in &border {
-                let across = dijkstra.distance(target);
+        let searching = Instant::now();
+        let wide = border_nodes.len();
+        let mut matrix = vec![u32::MAX; wide * wide];
+        // the cells below are all tabulated by now, so nothing this search
+        // does can ask for another one, and the pool is only ever one deep
+        let mut dijkstra = SEARCHES
+            .with_borrow_mut(Vec::pop)
+            .unwrap_or_default();
+        for source in 0..wide {
+            dijkstra.run_to_leading(&cell_graph, source, wide);
+            let row = &mut matrix[source * wide..(source + 1) * wide];
+            for (target, across) in row.iter_mut().enumerate() {
                 // what cannot be reached keeps the largest four byte number,
                 // and a cell that really did cost that much would be a graph
                 // nobody has
-                matrix[source * border_nodes.len() + target] =
-                    u32::try_from(across).unwrap_or(u32::MAX);
+                *across = u32::try_from(dijkstra.distance(target)).unwrap_or(u32::MAX);
             }
         }
+        SEARCHES.with_borrow_mut(|pool| pool.push(dijkstra));
         drop(of_node);
+        let searching = searching.elapsed();
 
         // the searches are what the customization of a cell costs, so the
         // clock is read once they are done
@@ -557,7 +596,10 @@ impl Customization {
                 nodes,
                 border_nodes: border_nodes.len(),
                 searched,
+                arcs,
                 elapsed,
+                building,
+                searching,
                 customized_cells,
                 total,
             });

--- a/src/one_to_many_dijkstra.rs
+++ b/src/one_to_many_dijkstra.rs
@@ -5,7 +5,7 @@
 /// search space of each run in its internal structures. From there paths can
 /// be unpacked.
 use crate::{
-    addressable_binary_heap::AddressableHeapWithStats,
+    dense_heap::DenseHeap,
     graph::{Graph, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
 };
@@ -23,7 +23,16 @@ pub type OneToManyDijkstra = OneToManySearch<Untracked>;
 pub type TrackedOneToManyDijkstra = OneToManySearch<Counters>;
 
 pub struct OneToManySearch<S: HeapStats<NodeID>> {
-    queue: AddressableHeapWithStats<NodeID, usize, NodeID, S>,
+    /// A queue that finds a node in an array rather than in a map.
+    ///
+    /// The graph this search runs over is a cell, whose nodes are numbered
+    /// from nothing with no gaps, so the array is as long as the cell is wide
+    /// and the search never asks a hash anything. It was a map before, and a
+    /// relaxation asked it three or four separate questions -- is this node
+    /// on the queue, is it still on it, what is it held at, now lower it --
+    /// where the array answers all of them in one look. On the coarse levels
+    /// of a continent that inner loop runs some thousand million times.
+    queue: DenseHeap<S>,
     reached_target_count: usize,
 }
 
@@ -36,9 +45,8 @@ impl<S: HeapStats<NodeID>> Default for OneToManySearch<S> {
 impl<S: HeapStats<NodeID>> OneToManySearch<S> {
     #[must_use]
     pub fn new() -> Self {
-        let queue = AddressableHeapWithStats::<NodeID, usize, NodeID, S>::new();
         Self {
-            queue,
+            queue: DenseHeap::new(),
             reached_target_count: 0,
         }
     }
@@ -71,20 +79,50 @@ impl<S: HeapStats<NodeID>> OneToManySearch<S> {
     /// to run consecutive searches, even on different graphs. It is cleared on
     /// every run, which saves on allocations.
     pub fn run<G: Graph<u32>>(&mut self, graph: &G, source: NodeID, targets: &[NodeID]) -> bool {
-        let targets =
+        let wanted =
             rustc_hash::FxHashMap::<NodeID, ()>::from_iter(targets.iter().map(|&x| (x, ())));
+        self.walk(graph, source, wanted.len(), |node| {
+            wanted.contains_key(&node)
+        })
+    }
 
+    /// The same search, to the first `count` nodes of the graph.
+    ///
+    /// A search whose targets are a prefix of the numbering does not need to
+    /// be told which nodes they are. [`run`](Self::run) builds a set of them
+    /// and asks it once per settled node, which for a customization is a set
+    /// the size of the answer being computed: one built and thrown away per
+    /// search, and one lookup per settle, to ask a question that is
+    /// `node < count`. The border nodes of a cell are numbered first exactly
+    /// so that it is.
+    pub fn run_to_leading<G: Graph<u32>>(
+        &mut self,
+        graph: &G,
+        source: NodeID,
+        count: usize,
+    ) -> bool {
+        self.walk(graph, source, count, |node| node < count)
+    }
+
+    /// What both of them do, differing only in how a target is recognised.
+    fn walk<G: Graph<u32>>(
+        &mut self,
+        graph: &G,
+        source: NodeID,
+        wanted: usize,
+        is_target: impl Fn(NodeID) -> bool,
+    ) -> bool {
         // clear the search space
         self.clear();
 
-        debug!("[start] sources: {source:?}, targets: {targets:?}");
+        debug!("[start] source: {source:?}, {wanted} targets");
 
         // prime queue
         self.queue.insert(source, 0, source);
         debug!("[push] {source} at distance {}", self.queue.weight(source));
 
         // iteratively search the graph
-        while !self.queue.is_empty() && self.reached_target_count < targets.len() {
+        while !self.queue.is_empty() && self.reached_target_count < wanted {
             // settle next node from queue
             let u = self.queue.delete_min();
             let distance = self.queue.weight(u);
@@ -92,31 +130,22 @@ impl<S: HeapStats<NodeID>> OneToManySearch<S> {
             debug!("[pop] {u} at distance {distance}");
 
             // check if target is reached
-            if targets.contains_key(&u) {
+            if is_target(u) {
                 self.reached_target_count += 1;
                 debug!("[done] reached {u} at {distance}");
             }
 
-            // relax outgoing edges
+            // relax outgoing edges, each in one look at the queue: whether
+            // the node is on it, what it is held at and whether this is an
+            // improvement are the same question asked of the same slot
             for edge in graph.edge_range(u) {
-                debug!("[relax] edge {edge}");
                 let v = graph.target(edge);
                 let new_distance = distance + *graph.data(edge) as usize;
-
-                if !self.queue.inserted(v) {
-                    debug!("[push] node: {v}, weight: {new_distance}, parent: {u}");
-                    // if target not enqued before, do now
-                    self.queue.insert(v, new_distance, u);
-                }
-                if self.queue.contains(v) && self.queue.weight(v) > new_distance {
-                    debug!("[decrease] node: {v}, new weight: {new_distance}, new parent: {u}");
-                    // if lower distance found, update distance and its parent
-                    self.queue.decrease_key_and_update_data(v, new_distance, u);
-                }
+                self.queue.insert_or_decrease(v, new_distance, u);
             }
         }
 
-        self.reached_target_count == targets.len()
+        self.reached_target_count == wanted
     }
 
     /// retrieve path from the node to the queue according to the search space
@@ -134,7 +163,7 @@ impl<S: HeapStats<NodeID>> OneToManySearch<S> {
             // since the target was inserted (as checked above) and the sources
             // parent is the source node of the search itself, this loop will
             // terminate.
-            let parent = *self.queue.data(node);
+            let parent = self.queue.data(node);
             if parent == node {
                 // reverse order to go from source to target
                 path.reverse();

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -99,7 +99,7 @@ impl<T: Ord + Copy> StaticGraph<T> {
         mut input: Vec<impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord>,
     ) -> Self {
         input.sort();
-        Self::assemble(nodes, input)
+        Self::assemble(nodes, &input)
     }
 
     /// Assembles a graph from a prebuilt adjacency array. The caller has to
@@ -123,19 +123,29 @@ impl<T: Ord + Copy> StaticGraph<T> {
     pub fn new_from_sorted_list(
         input: Vec<impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord>,
     ) -> Self {
-        Self::assemble(0, input)
+        Self::assemble(0, &input)
     }
 
     /// Builds the adjacency array out of a sorted arc list, over as many nodes
     /// as the arcs reach or as many as were asked for, whichever is more.
-    fn assemble(
+    /// Builds the arrays from a sorted list the caller keeps.
+    ///
+    /// A customization builds one graph per cell and a continent has six
+    /// hundred thousand cells, so the list the graph is made of is worth
+    /// refilling rather than making anew each time. Nothing here needs to own
+    /// it: the arrays are built by reading it once.
+    pub fn from_sorted_slice(
         nodes: usize,
-        input: Vec<impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord>,
+        input: &[impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord],
     ) -> Self {
+        Self::assemble(nodes, input)
+    }
+
+    fn assemble(nodes: usize, input: &[impl Edge<ID = NodeID> + EdgeData<DATA = T> + Ord]) -> Self {
         // TODO: renumber IDs if necessary
         let number_of_edges = input.len();
         let mut number_of_nodes = nodes.saturating_sub(1);
-        for edge in &input {
+        for edge in input {
             number_of_nodes = max(edge.source(), number_of_nodes);
             number_of_nodes = max(edge.target(), number_of_nodes);
         }
@@ -160,13 +170,14 @@ impl<T: Ord + Copy> StaticGraph<T> {
             .node_array
             .push(NodeArrayEntry::new((input.len()) as EdgeID));
 
-        graph.edge_array = input
-            .iter()
-            .map(move |edge| EdgeArrayEntry {
+        // extended rather than collected into: collecting throws away the
+        // room reserved for it just above and asks for the same room again
+        graph
+            .edge_array
+            .extend(input.iter().map(|edge| EdgeArrayEntry {
                 target: u32::try_from(edge.target()).expect("the graph is too large to hold"),
                 data: *edge.data(),
-            })
-            .collect();
+            }));
         debug_assert!(graph.check_integrity());
         graph
     }


### PR DESCRIPTION
## What changes

### Changed signatures

| before | after |
|---|---|
| `OneToManySearch::run(&G, source, targets: &[NodeID])` | unchanged, now over a dense queue |
| — | `OneToManySearch::run_to_leading(&G, source, count: usize) -> bool` |
| — | `StaticGraph::from_sorted_slice(nodes, &[E]) -> Self` |
| `OneToManySearch { queue: AddressableHeapWithStats<..> }` | `queue: DenseHeap<S>` |

`CellReport` gains three fields: `arcs: usize`, `building: Duration`,
`searching: Duration`. `elapsed` is unchanged and is still the whole of it.

### New

`examples/customize.rs` — customizes every cell of every level bottom up and
reports per level: cells, entries, arcs, mean overlay width, wall, and the
split between building the cell graph and searching it. Takes an optional
level to stop at and the word `parallel`.

### Behaviour

No cell distance changes. Levels 0 to 3 of europe.ptv check against plain
Dijkstra on the base graph, 58.6 million pairs, none differing. `sound` is
what checks it, and it deliberately walks a heap this crate has no hand in.

## The four changes

**A node of a cell is found in an array rather than in a map.** The queue the
customization searched on addressed its nodes through an `FxHashMap`, and a
relaxation asked it three or four separate questions: is this node on the
queue, is it still on it, what is it held at, now lower it. The graph it runs
over is a cell, whose nodes are numbered from nothing with no gaps, so an
array answers all four in one look. `DenseHeap` is the queue the queries
already run on; only this had been left behind.

**Floyd-Warshall where the cell is narrow and dense.** Cubic in the nodes of
the cell whatever the border is, so it wants a narrow one; the same work
whatever the arcs are, so it wants a dense one. The finest level is searched
over road arcs, where a node has two or three, and it loses there however
narrow the cell. Chosen per cell, on `level > 0 && searched <= 300`.

**The room a cell needs is kept for the next one.** Every cell was making a
map, an arc list, an adjacency array and a search for a few microseconds and
handing them all back, six hundred thousand times over. `Scratch` is pooled
per thread; `StaticGraph::from_sorted_slice` assembles from a list the caller
keeps; `assemble` extends the room it reserved rather than collecting into
new room.

**The widest cell of a level is handed out first.** A level is customized a
cell to a thread. The coarsest level of a continent has twenty-six of very
different sizes, and in numbering order a large one comes up late while seven
threads wait on it.

## Measurements

europe.ptv, 18,010,173 nodes, 42,188,664 arcs, 6 levels, boundary directory.
623,435 cells, 66,267,046 entries. Four physical cores.

| | wall | processor | peak memory |
|---|---|---|---|
| before | 60.08s | 65.5s | 3.0 GB |
| after, one thread | 22.30s | 26.6s | 3.3 GB |
| after, eight threads | **7.11s** | 40.8s | 3.3 GB |

The searches alone, one thread, per level:

| level | cells | overlay nodes | before | after |
|---|---|---|---|---|
| 0 | 497,965 | 36 | 7.23s | 3.89s |
| 1 | 98,375 | 30 | 5.06s | 0.81s |
| 2 | 24,384 | 45 | 4.74s | 0.51s |
| 3 | 2,440 | 197 | 7.95s | 2.13s |
| 4 | 245 | 505 | 10.98s | 3.05s |
| 5 | 26 | 1,169 | 13.50s | 3.29s |

Floyd-Warshall against the searches it replaces, one thread, by level:

| level | nodes | every pair | searches |
|---|---|---|---|
| 0 | 36 | 4.15s | **3.74s** |
| 1 | 30 | **0.77s** | 2.07s |
| 2 | 45 | **0.49s** | 1.69s |
| 3 | 197 | **2.20s** | 2.65s |
| 4 | 505 | 3.88s | **3.07s** |
| 5 | 1,169 | 11.69s | **3.40s** |

Handing out the widest cell first, eight threads: level 3 1.33s to 0.96s,
level 4 1.53s to 1.15s, level 5 3.08s to 1.51s, whole 11.01s to 7.11s. It
also took processor time from 73.1s to 40.8s, of which system time was 12.6s
and is now 1.85s, and peak memory from 7.3 GB to 3.3 GB: widest first, a
thread grows the room it keeps to the most it will need in its first few
cells and then stops asking.

## Tried and not kept

Splitting the searches of one wide cell across threads. Level 5 alone went
3.08s to 2.5s, but the nested parallelism cost the other levels more than it
won: 11.33s and 11.34s on repeats against 11.01s without it. It also made the
one-cell-at-a-time path use every core, which would have left no serial
number to compare against.

## What it leaves

- **Level 0 is now the largest level**, 1.91s of the 7.11s, and 37% of that is
  building a 36 entry map half a million times. `nodes_of_cell` is sorted, so
  a binary search would do it with no allocation at all.
- **Levels 4 and 5 materialise the cliques of the cells below into an
  adjacency array and then relax them scattered.** Reading the tables of those
  cells directly is one run of memory per relaxation.
- **Topology is rebuilt per metric.** The cell graphs, the border numbering and
  the layout do not depend on the weights, and 5.16s of the serial time works
  them out again. A re-customization is exactly the case that should not pay
  for it.