### PR TITLE
Draw the search space with a level at every height

### DIFF
--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -40,7 +40,8 @@
 //! # What goes in the file
 //!
 //! One feature collection, every feature carrying `kind`, `level`, a `colour`,
-//! and the two heights it is to be drawn between. The heights and the colours
+//! the `step` of the search it happened at, and the two heights it is to be
+//! drawn between. The heights and the colours
 //! are worked out here rather than in the viewer, so that the viewer only has
 //! to draw what it is given.
 //!
@@ -59,10 +60,10 @@
 //! point at a height: what a map draws at a height is a polygon pushed up
 //! between two of them.
 
-use std::{collections::BTreeSet, env::args, fs::File, io::BufWriter};
+use std::{collections::BTreeMap, env::args, fs::File, io::BufWriter};
 
 use geojson::{Feature, FeatureWriter, Geometry, GeometryValue, JsonObject, JsonValue, Position};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use toolbox_rs::{
     convex_hull::monotone_chain,
@@ -137,10 +138,17 @@ fn main() {
         .retrieve_packed_path(target)
         .expect("the target was not reached");
     let way = unpack(&customization, &packed).expect("the cells offer what they said");
-    let settled: FxHashSet<NodeID> = query.stats().settled().iter().copied().collect();
+    // the clock everything is stamped by: where a node came off the queue
+    let settled_at: FxHashMap<NodeID, usize> = query
+        .stats()
+        .settled()
+        .iter()
+        .enumerate()
+        .map(|(index, &node)| (node, index + 1))
+        .collect();
     println!(
         "{} settled of {} reached, {} steps, {} nodes once put back, costing {}",
-        settled.len(),
+        settled_at.len(),
         query.stats().reached().len(),
         packed.len(),
         way.len(),
@@ -204,10 +212,14 @@ fn main() {
     let width = (((east - west).max(north - south)) * 0.0025).max(0.000_02);
 
     // the cells the search stepped over, per level
-    let mut stepped: BTreeSet<(usize, CellId)> = BTreeSet::new();
-    for &node in query.stats().settled() {
+    // the settled come in the order they were settled, so the first mention of
+    // a cell is the step the search first stepped over it
+    let mut stepped: BTreeMap<(usize, CellId), usize> = BTreeMap::new();
+    for (index, &node) in query.stats().settled().iter().enumerate() {
         if let Some(level) = partition.query_level(source_word, target_word, node) {
-            stepped.insert((level, partition.cell_of(node, level)));
+            stepped
+                .entry((level, partition.cell_of(node, level)))
+                .or_insert(index + 1);
         }
     }
     println!("{} cells were stepped over", stepped.len());
@@ -217,7 +229,7 @@ fn main() {
     let mut centre_of: FxHashMap<(usize, CellId), ((f64, f64), String)> = FxHashMap::default();
     let mut nodes_of: FxHashMap<usize, std::sync::Arc<toolbox_rs::customization::Level>> =
         FxHashMap::default();
-    for (level, cell) in &stepped {
+    for ((level, cell), first) in &stepped {
         let holding = nodes_of
             .entry(*level)
             .or_insert_with(|| customization.level(*level))
@@ -258,11 +270,14 @@ fn main() {
                 GeometryValue::Polygon {
                     coordinates: vec![ring],
                 },
-                "cell",
-                *level as isize,
-                base,
-                base + SHEET,
-                &colour,
+                Mark {
+                    kind: "cell",
+                    level: *level as isize,
+                    base,
+                    height: base + SHEET,
+                    colour: &colour,
+                    step: *first,
+                },
             ))
             .expect("the cell cannot be written");
         centre_of.insert((*level, *cell), (middle, colour));
@@ -282,7 +297,7 @@ fn main() {
     // a table between two border nodes of a cell, and a straight line is what
     // an entry in a table looks like.
     let mut relaxed = 0usize;
-    let mut crossings: BTreeSet<(usize, CellId, CellId)> = BTreeSet::new();
+    let mut crossings: BTreeMap<(usize, CellId, CellId), usize> = BTreeMap::new();
     for &node in query.stats().reached() {
         let Some(parent) = query.parent(node) else {
             continue;
@@ -306,7 +321,11 @@ fn main() {
                 partition.cell_of(node, from),
             );
             if here != there {
-                crossings.insert((from, here.min(there), here.max(there)));
+                let at = settled_at.get(&parent).copied().unwrap_or(0);
+                crossings
+                    .entry((from, here.min(there), here.max(there)))
+                    .and_modify(|first| *first = (*first).min(at))
+                    .or_insert(at);
             }
         }
         let (level, height) = height_of(parent);
@@ -319,11 +338,16 @@ fn main() {
                 GeometryValue::Polygon {
                     coordinates: vec![ring],
                 },
-                "relaxed",
-                level,
-                height + SHEET,
-                height + SHEET * ARC_TOP,
-                &shade(parent, 0.5, 0.7),
+                Mark {
+                    kind: "relaxed",
+                    level,
+                    base: height + SHEET,
+                    height: height + SHEET * ARC_TOP,
+                    colour: &shade(parent, 0.5, 0.7),
+                    // an arc is drawn the moment the node it leaves comes off
+                    // the queue, that being when the search walked it
+                    step: settled_at.get(&parent).copied().unwrap_or(0),
+                },
             ))
             .expect("the arc cannot be written");
         written += 1;
@@ -346,7 +370,7 @@ fn main() {
     // here: what a map draws at a height is a polygon, a polygon is solid, so
     // every dash has to be one of its own.
     let mut linked = 0usize;
-    for (level, here, there) in &crossings {
+    for ((level, here, there), first) in &crossings {
         let (Some((from, tint)), Some((to, other))) = (
             centre_of.get(&(*level, *here)),
             centre_of.get(&(*level, *there)),
@@ -369,11 +393,14 @@ fn main() {
                 GeometryValue::MultiPolygon {
                     coordinates: cut.into_iter().map(|ring| vec![ring]).collect(),
                 },
-                "link",
-                *level as isize,
-                base + SHEET * LINK_BASE,
-                base + SHEET * LINK_TOP,
-                &blend(tint, other),
+                Mark {
+                    kind: "link",
+                    level: *level as isize,
+                    base: base + SHEET * LINK_BASE,
+                    height: base + SHEET * LINK_TOP,
+                    colour: &blend(tint, other),
+                    step: *first,
+                },
             ))
             .expect("the link cannot be written");
         written += 1;
@@ -390,7 +417,18 @@ fn main() {
     // reached, and the difference is most of what a search does.
     for &node in query.stats().reached() {
         let (level, height) = height_of(node);
-        let settled_here = settled.contains(&node);
+        // a node it settled is stamped where it came off, and one it only
+        // reached is stamped where the node that reached it came off, that
+        // being when it appeared
+        let settled_here = settled_at.contains_key(&node);
+        let stamp = if settled_here {
+            settled_at[&node]
+        } else {
+            query
+                .parent(node)
+                .and_then(|parent| settled_at.get(&parent).copied())
+                .unwrap_or(0)
+        };
         let (top, size, colour) = if settled_here {
             (SETTLED_TOP, 0.55, shade(node, 0.68, 0.78))
         } else {
@@ -401,11 +439,14 @@ fn main() {
                 GeometryValue::Polygon {
                     coordinates: vec![footprint(at(node), width * size)],
                 },
-                if settled_here { "settled" } else { "reached" },
-                level,
-                height + SHEET,
-                height + SHEET * top,
-                &colour,
+                Mark {
+                    kind: if settled_here { "settled" } else { "reached" },
+                    level,
+                    base: height + SHEET,
+                    height: height + SHEET * top,
+                    colour: &colour,
+                    step: stamp,
+                },
             ))
             .expect("the node cannot be written");
         written += 1;
@@ -423,6 +464,10 @@ fn main() {
     // Which arcs a step stands for is not asked again here. The way was put
     // back by laying the steps end to end, so it comes apart at the nodes the
     // search handed over, each of which it holds once.
+    // the way is not known until the target comes off the queue, so that is
+    // the step every piece of it appears at
+    let found_at = settled_at.get(&target).copied().unwrap_or(0);
+
     let mut seam = Vec::with_capacity(packed.len());
     seam.push(0usize);
     for &node in &packed[1..] {
@@ -455,15 +500,18 @@ fn main() {
                 GeometryValue::Polygon {
                     coordinates: vec![ring],
                 },
-                "packed",
-                level,
-                // clear over the sheet its level is drawn as and over
-                // everything standing on it, rather than inside any of it
-                height + SHEET * WAY_BASE,
-                height + SHEET * WAY_TOP,
-                // the fullest the cell's family goes, so the way is the first
-                // thing read at a level and still plainly of that level
-                &shade(pair[0], 0.82, 0.76),
+                Mark {
+                    kind: "packed",
+                    level,
+                    // clear over the sheet its level is drawn as and over
+                    // everything standing on it, rather than inside any of it
+                    base: height + SHEET * WAY_BASE,
+                    height: height + SHEET * WAY_TOP,
+                    // the fullest the cell's family goes, so the way is the
+                    // first thing read at a level and still of that level
+                    colour: &shade(pair[0], 0.82, 0.76),
+                    step: found_at,
+                },
             ))
             .expect("the step cannot be written");
         written += 1;
@@ -502,11 +550,14 @@ fn main() {
                 GeometryValue::Polygon {
                     coordinates: vec![footprint(at(node), width * 0.75)],
                 },
-                "riser",
-                level,
-                low + SHEET * WAY_BASE,
-                high + SHEET * WAY_TOP,
-                &shade(arrived, 0.82, 0.76),
+                Mark {
+                    kind: "riser",
+                    level,
+                    base: low + SHEET * WAY_BASE,
+                    height: high + SHEET * WAY_TOP,
+                    colour: &shade(arrived, 0.82, 0.76),
+                    step: found_at,
+                },
             ))
             .expect("the riser cannot be written");
         written += 1;
@@ -525,13 +576,16 @@ fn main() {
             GeometryValue::LineString {
                 coordinates: ground,
             },
-            "unpacked",
-            -1,
-            0.0,
-            0.0,
-            // the one thing on screen that is not of a cell, being the answer
-            // rather than a part of the working
-            "#ece9e2",
+            Mark {
+                kind: "unpacked",
+                level: -1,
+                base: 0.0,
+                height: 0.0,
+                // the one thing on screen that is not of a cell, being the
+                // answer rather than a part of the working
+                colour: "#ece9e2",
+                step: found_at,
+            },
         ))
         .expect("the way cannot be written");
     written += 1;
@@ -540,21 +594,35 @@ fn main() {
     println!("wrote {written} features to {out_path}");
 }
 
-/// A feature carrying what the viewer draws it by.
-fn feature(
-    geometry: GeometryValue,
-    kind: &str,
+/// What the viewer draws a feature by.
+///
+/// Passed as one thing rather than as six arguments in a row, which is how a
+/// base and a height end up the wrong way round.
+struct Mark<'a> {
+    kind: &'a str,
     level: isize,
     base: f64,
     height: f64,
-    colour: &str,
-) -> Feature {
+    colour: &'a str,
+    /// How far into the search this happened, counted in nodes settled.
+    ///
+    /// One clock for all of it. A node is stamped with where it came off the
+    /// queue, and everything a node caused -- the arcs relaxed from it, the
+    /// nodes those reached, the first crossing into a cell -- is stamped with
+    /// the same, so a picture cut off at a step is the search as it stood when
+    /// it had settled that many.
+    step: usize,
+}
+
+/// A feature carrying what the viewer draws it by.
+fn feature(geometry: GeometryValue, mark: Mark) -> Feature {
     let mut properties = JsonObject::new();
-    properties.insert("kind".to_string(), JsonValue::from(kind));
-    properties.insert("level".to_string(), JsonValue::from(level));
-    properties.insert("base".to_string(), JsonValue::from(base));
-    properties.insert("height".to_string(), JsonValue::from(height));
-    properties.insert("colour".to_string(), JsonValue::from(colour));
+    properties.insert("kind".to_string(), JsonValue::from(mark.kind));
+    properties.insert("level".to_string(), JsonValue::from(mark.level));
+    properties.insert("base".to_string(), JsonValue::from(mark.base));
+    properties.insert("height".to_string(), JsonValue::from(mark.height));
+    properties.insert("colour".to_string(), JsonValue::from(mark.colour));
+    properties.insert("step".to_string(), JsonValue::from(mark.step));
     Feature {
         bbox: None,
         geometry: Some(Geometry::new(geometry)),

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -102,6 +102,9 @@ const HULL_SAMPLE: usize = 200_000;
 /// it came away with floats clear over all of it.
 const ARC_TOP: f64 = 1.15;
 const LINK_BASE: f64 = 1.15;
+
+/// What a link between two cells is drawn in.
+const CROSSING: &str = "#ffffff";
 const LINK_TOP: f64 = 1.28;
 const REACHED_TOP: f64 = 1.3;
 const SETTLED_TOP: f64 = 1.9;
@@ -371,7 +374,7 @@ fn main() {
     // every dash has to be one of its own.
     let mut linked = 0usize;
     for ((level, here, there), first) in &crossings {
-        let (Some((from, tint)), Some((to, other))) = (
+        let (Some((from, _)), Some((to, _))) = (
             centre_of.get(&(*level, *here)),
             centre_of.get(&(*level, *there)),
         ) else {
@@ -398,7 +401,13 @@ fn main() {
                     level: *level as isize,
                     base: base + SHEET * LINK_BASE,
                     height: base + SHEET * LINK_TOP,
-                    colour: &blend(tint, other),
+                    // white, alone of everything here. A link is not of
+                    // either cell it joins and colouring it of both said
+                    // neither: two blends of pale neighbours come out the
+                    // same pale nothing, and the one mark that is about the
+                    // partition rather than about a cell was the hardest to
+                    // see. Off the family altogether, it reads at a glance.
+                    colour: CROSSING,
                     step: *first,
                 },
             ))
@@ -789,20 +798,6 @@ fn dashes(from: (f64, f64), to: (f64, f64), width: f64, dash: f64) -> Vec<Vec<Po
         })
         .filter(|ring| !ring.is_empty())
         .collect()
-}
-
-/// The colour halfway between two, for something belonging to both.
-fn blend(one: &str, other: &str) -> String {
-    let band = |colour: &str, at: usize| {
-        u16::from_str_radix(&colour[at..at + 2], 16).expect("a colour is six hex digits")
-    };
-    let mixed: Vec<String> = (0..3)
-        .map(|index| {
-            let at = 1 + index * 2;
-            format!("{:02x}", (band(one, at) + band(other, at)) / 2)
-        })
-        .collect();
-    format!("#{}", mixed.concat())
 }
 
 /// The footprint a riser or a node is pushed up from.

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -1,0 +1,321 @@
+//! Writes out what a search over the cells looked at, for looking at.
+//!
+//! ```text
+//! search_space <graph> <directory> <coordinates> <source> <target> <out.geojson>
+//! ```
+//!
+//! # What is drawn, and why in three dimensions
+//!
+//! A search over the cells is a thing of levels: it steps over the coarsest
+//! cell it may, drops to a finer one as it nears an end, and reaches the arcs
+//! of the graph only inside the two cells holding the ends. Drawn flat, all of
+//! that lands on top of itself and the picture says nothing about which level
+//! anything happened at, which is the one thing worth seeing.
+//!
+//! So each level is given a height. The arcs of the graph lie on the ground,
+//! the cells of the finest level float above them, and each level above that
+//! floats higher again. A step across a cell is drawn at the height of the
+//! level it was taken at, and under each of its ends a column runs down to the
+//! ground, so the way the search took can be followed from the coarse step it
+//! made down to the arcs that step really stands for.
+//!
+//! # What goes in the file
+//!
+//! One feature collection, every feature carrying `kind`, `level`, and the two
+//! heights it is to be drawn between. The heights are worked out here rather
+//! than in the viewer, so that the viewer only has to draw what it is given.
+//!
+//! | `kind`     | what it is                                        |
+//! |------------|---------------------------------------------------|
+//! | `cell`     | the outline of a cell the search stepped over     |
+//! | `settled`  | a node the search took off its queue              |
+//! | `packed`   | a step of the way the search found                |
+//! | `unpacked` | the way through the graph that step stands for    |
+//! | `column`   | the drop from a packed node to the ground         |
+
+use std::{collections::BTreeSet, env::args, fs::File, io::BufWriter};
+
+use geojson::{Feature, FeatureWriter, Geometry, GeometryValue, JsonObject, JsonValue, Position};
+use rustc_hash::FxHashMap;
+
+use toolbox_rs::{
+    convex_hull::monotone_chain,
+    customization::Customization,
+    geometry::FPCoordinate,
+    graph::NodeID,
+    heap_stats::SettledNodes,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    mld_query::MldSearch,
+    path_unpacking::{cost_of_way, unpack},
+    static_graph::StaticGraph,
+};
+
+/// How high a level floats above the one below it, in metres.
+///
+/// Large enough that the levels do not run into one another when the whole of
+/// a continent is on screen, which is the view this is drawn for.
+const LEVEL_HEIGHT: f64 = 60_000.0;
+
+/// How thick a floating sheet is drawn, so that it reads as a surface rather
+/// than as nothing at all.
+const SHEET: f64 = 4_000.0;
+
+/// A cell of more nodes than this has its outline taken from a sample of them.
+/// A hull is decided by the points on the outside, and a coarse cell holds
+/// millions of nodes that are nowhere near it.
+const HULL_SAMPLE: usize = 200_000;
+
+fn main() {
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next()
+            .unwrap_or_else(|| panic!("usage: search_space <graph> <directory> <coordinates> <source> <target> <out.geojson>: missing {what}"))
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let coordinates_path = next("coordinates");
+    let source: NodeID = next("source").parse().expect("source is a node id");
+    let target: NodeID = next("target").parse().expect("target is a node id");
+    let out_path = next("output");
+
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&coordinates_path);
+    let levels = directory.levels();
+    println!(
+        "{} nodes over {levels} levels, {} coordinates",
+        directory.number_of_nodes(),
+        coordinates.len()
+    );
+
+    let customization = Customization::new(graph, directory);
+    let mut query = MldSearch::<SettledNodes>::new();
+    query.run(&customization, source, &[target]);
+    let packed = query
+        .retrieve_packed_path(target)
+        .expect("the target was not reached");
+    let way = unpack(&customization, &packed).expect("the cells offer what they said");
+    println!(
+        "{} settled, {} steps, {} nodes once put back, costing {}",
+        query.stats().settled().len(),
+        packed.len(),
+        way.len(),
+        query.distance(target)
+    );
+    assert_eq!(
+        cost_of_way(customization.graph(), &way),
+        Some(query.distance(target)),
+        "the way put back is not the way that was found"
+    );
+
+    let partition = customization.partition();
+    let source_word = partition.word(source);
+    let target_word = partition.word(target);
+    // the level a node was stepped over at, which is the height it belongs at
+    let height_of = |node: NodeID| -> (isize, f64) {
+        match partition.query_level(source_word, target_word, node) {
+            // the arcs of the graph lie on the ground, so a node the search
+            // walked arcs at belongs there too
+            None => (-1, 0.0),
+            Some(level) => (level as isize, (level + 1) as f64 * LEVEL_HEIGHT),
+        }
+    };
+
+    let at = |node: NodeID| -> (f64, f64) {
+        let c = coordinates[node];
+        (f64::from(c.lon) / 1e6, f64::from(c.lat) / 1e6)
+    };
+
+    let file = BufWriter::new(File::create(&out_path).expect("output file cannot be opened"));
+    let mut writer = FeatureWriter::from_writer(file);
+    let mut written = 0usize;
+
+    // how wide a drawn line is, taken from how much ground is on screen, so
+    // that a way across a town and a way across a continent both read
+    let mut west = f64::MAX;
+    let mut east = f64::MIN;
+    for &node in &way {
+        let (lon, _) = at(node);
+        west = west.min(lon);
+        east = east.max(lon);
+    }
+    let width = ((east - west) * 0.004).max(0.000_02);
+
+    // the cells the search stepped over, per level
+    let mut stepped: BTreeSet<(usize, CellId)> = BTreeSet::new();
+    for &node in query.stats().settled() {
+        if let Some(level) = partition.query_level(source_word, target_word, node) {
+            stepped.insert((level, partition.cell_of(node, level)));
+        }
+    }
+    println!("{} cells were stepped over", stepped.len());
+
+    let mut nodes_of: FxHashMap<usize, std::sync::Arc<toolbox_rs::customization::Level>> =
+        FxHashMap::default();
+    for (level, cell) in &stepped {
+        let holding = nodes_of
+            .entry(*level)
+            .or_insert_with(|| customization.level(*level))
+            .clone();
+        let nodes = &holding.nodes_of_cell[*cell as usize];
+        let step = (nodes.len() / HULL_SAMPLE).max(1);
+        let points: Vec<FPCoordinate> = nodes
+            .iter()
+            .step_by(step)
+            .map(|&node| coordinates[node])
+            .collect();
+        let hull = monotone_chain(&points);
+        if hull.len() < 3 {
+            continue;
+        }
+        let ring: Vec<Position> = hull
+            .iter()
+            .chain(std::iter::once(&hull[0]))
+            .map(|c| Position::from(vec![f64::from(c.lon) / 1e6, f64::from(c.lat) / 1e6]))
+            .collect();
+        let base = (*level + 1) as f64 * LEVEL_HEIGHT;
+        writer
+            .write_feature(&feature(
+                GeometryValue::Polygon {
+                    coordinates: vec![ring],
+                },
+                "cell",
+                *level as isize,
+                base,
+                base + SHEET,
+            ))
+            .expect("the cell cannot be written");
+        written += 1;
+    }
+
+    // what the search settled, at the height of the level it settled it at
+    for &node in query.stats().settled() {
+        let (level, height) = height_of(node);
+        let (lon, lat) = at(node);
+        writer
+            .write_feature(&feature(
+                GeometryValue::Point {
+                    coordinates: Position::from(vec![lon, lat]),
+                },
+                "settled",
+                level,
+                height,
+                height,
+            ))
+            .expect("the node cannot be written");
+        written += 1;
+    }
+
+    // the way the search found, each step at the height it was taken at, and a
+    // column under each of its ends running down to the ground
+    for pair in packed.windows(2) {
+        let (from, to) = (pair[0], pair[1]);
+        let (level, height) = height_of(from);
+        writer
+            .write_feature(&feature(
+                GeometryValue::Polygon {
+                    coordinates: vec![ribbon(at(from), at(to), width)],
+                },
+                "packed",
+                level,
+                height,
+                height + SHEET / 4.0,
+            ))
+            .expect("the step cannot be written");
+        written += 1;
+    }
+    for &node in &packed {
+        let (level, height) = height_of(node);
+        if height <= 0.0 {
+            continue;
+        }
+        writer
+            .write_feature(&feature(
+                GeometryValue::Polygon {
+                    coordinates: vec![column(at(node), width * 0.6)],
+                },
+                "column",
+                level,
+                0.0,
+                height,
+            ))
+            .expect("the column cannot be written");
+        written += 1;
+    }
+
+    // and the way through the graph that all of it stands for, on the ground
+    let ground: Vec<Position> = way
+        .iter()
+        .map(|&node| {
+            let (lon, lat) = at(node);
+            Position::from(vec![lon, lat])
+        })
+        .collect();
+    writer
+        .write_feature(&feature(
+            GeometryValue::LineString {
+                coordinates: ground,
+            },
+            "unpacked",
+            -1,
+            0.0,
+            0.0,
+        ))
+        .expect("the way cannot be written");
+    written += 1;
+
+    writer.finish().expect("the file cannot be closed");
+    println!("wrote {written} features to {out_path}");
+}
+
+/// A feature carrying what the viewer draws it by.
+fn feature(geometry: GeometryValue, kind: &str, level: isize, base: f64, height: f64) -> Feature {
+    let mut properties = JsonObject::new();
+    properties.insert("kind".to_string(), JsonValue::from(kind));
+    properties.insert("level".to_string(), JsonValue::from(level));
+    properties.insert("base".to_string(), JsonValue::from(base));
+    properties.insert("height".to_string(), JsonValue::from(height));
+    Feature {
+        bbox: None,
+        geometry: Some(Geometry::new(geometry)),
+        id: None,
+        properties: Some(properties),
+        foreign_members: None,
+    }
+}
+
+/// A step drawn as a quad, since a line cannot be lifted off the ground.
+///
+/// Nothing draws a line at a height: what a map draws at a height is a
+/// polygon pushed up between two of them. So a step is widened into a quad
+/// about its own direction and pushed up as a sheet, which reads as a line
+/// from anywhere but directly on.
+fn ribbon(from: (f64, f64), to: (f64, f64), width: f64) -> Vec<Position> {
+    let (dx, dy) = (to.0 - from.0, to.1 - from.1);
+    let length = dx.hypot(dy);
+    // a step from a node to itself has no direction to be widened about
+    let (nx, ny) = if length < f64::EPSILON {
+        (width, 0.0)
+    } else {
+        (-dy / length * width, dx / length * width)
+    };
+    vec![
+        Position::from(vec![from.0 + nx, from.1 + ny]),
+        Position::from(vec![to.0 + nx, to.1 + ny]),
+        Position::from(vec![to.0 - nx, to.1 - ny]),
+        Position::from(vec![from.0 - nx, from.1 - ny]),
+        Position::from(vec![from.0 + nx, from.1 + ny]),
+    ]
+}
+
+/// The footprint of the drop from a node to the ground.
+fn column(at: (f64, f64), width: f64) -> Vec<Position> {
+    vec![
+        Position::from(vec![at.0 - width, at.1 - width]),
+        Position::from(vec![at.0 + width, at.1 - width]),
+        Position::from(vec![at.0 + width, at.1 + width]),
+        Position::from(vec![at.0 - width, at.1 + width]),
+        Position::from(vec![at.0 - width, at.1 - width]),
+    ]
+}

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -20,34 +20,52 @@
 //! and comes back down. Followed end to end it never breaks, and every jump in
 //! it is a level the search changed at.
 //!
+//! # What the colours say
+//!
+//! A cell is drawn in a shade of the cell holding it. The hue is picked within
+//! a span of the parent's and the span narrows at every level, so a family of
+//! cells reads as a family however deep it is cut, and the level reads by how
+//! light the shade is. Everything the search did inside a cell takes that
+//! cell's hue: the arcs it relaxed, the nodes it reached, the nodes it settled
+//! and the step of the way it came away with, each at its own brightness. So
+//! the colour says where, and the height says how coarse.
+//!
 //! # What goes in the file
 //!
-//! One feature collection, every feature carrying `kind`, `level`, and the two
-//! heights it is to be drawn between. The heights are worked out here rather
-//! than in the viewer, so that the viewer only has to draw what it is given.
+//! One feature collection, every feature carrying `kind`, `level`, a `colour`,
+//! and the two heights it is to be drawn between. The heights and the colours
+//! are worked out here rather than in the viewer, so that the viewer only has
+//! to draw what it is given.
 //!
-//! | `kind`     | what it is                                        |
-//! |------------|---------------------------------------------------|
-//! | `cell`     | the outline of a cell the search stepped over     |
-//! | `settled`  | a node the search took off its queue              |
-//! | `packed`   | a step of the way the search found                |
-//! | `unpacked` | the way through the graph that step stands for    |
-//! | `riser`    | where the way changes level, drawn upright        |
+//! | `kind`     | what it is                                          |
+//! |------------|-----------------------------------------------------|
+//! | `cell`     | the outline of a cell the search stepped over       |
+//! | `relaxed`  | an arc the search relaxed and kept                  |
+//! | `reached`  | a node it put on its queue and never took off       |
+//! | `settled`  | a node it took off its queue                        |
+//! | `packed`   | the way a step stands for, at the step's height     |
+//! | `riser`    | where the way changes level, drawn upright          |
+//! | `unpacked` | the whole way through the graph, on the ground      |
+//!
+//! Everything but `unpacked` is a polygon, since nothing draws a line or a
+//! point at a height: what a map draws at a height is a polygon pushed up
+//! between two of them.
 
 use std::{collections::BTreeSet, env::args, fs::File, io::BufWriter};
 
 use geojson::{Feature, FeatureWriter, Geometry, GeometryValue, JsonObject, JsonValue, Position};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use toolbox_rs::{
     convex_hull::monotone_chain,
     customization::Customization,
     geometry::FPCoordinate,
     graph::NodeID,
-    heap_stats::SettledNodes,
+    heap_stats::Frontier,
     io,
     level_directory::{CellId, LevelDirectory},
     mld_query::MldSearch,
+    packed_partition::PackedPartition,
     path_unpacking::{cost_of_way, unpack},
     static_graph::StaticGraph,
 };
@@ -66,6 +84,18 @@ const SHEET: f64 = 4_000.0;
 /// A hull is decided by the points on the outside, and a coarse cell holds
 /// millions of nodes that are nowhere near it.
 const HULL_SAMPLE: usize = 200_000;
+
+/// What stands where above the sheet of a level, in thicknesses of it.
+///
+/// Everything a search did at a level is drawn over that level's sheet, and
+/// what stands taller is what is worth seeing first. The arcs lie flattest,
+/// a node it only reached is a stub, a node it settled stands up, and the way
+/// it came away with floats clear over all of it.
+const ARC_TOP: f64 = 1.15;
+const REACHED_TOP: f64 = 1.3;
+const SETTLED_TOP: f64 = 1.9;
+const WAY_BASE: f64 = 2.2;
+const WAY_TOP: f64 = 3.1;
 
 fn main() {
     let mut argv = args().skip(1);
@@ -91,15 +121,17 @@ fn main() {
     );
 
     let customization = Customization::new(graph, directory);
-    let mut query = MldSearch::<SettledNodes>::new();
+    let mut query = MldSearch::<Frontier>::new();
     query.run(&customization, source, &[target]);
     let packed = query
         .retrieve_packed_path(target)
         .expect("the target was not reached");
     let way = unpack(&customization, &packed).expect("the cells offer what they said");
+    let settled: FxHashSet<NodeID> = query.stats().settled().iter().copied().collect();
     println!(
-        "{} settled, {} steps, {} nodes once put back, costing {}",
-        query.stats().settled().len(),
+        "{} settled of {} reached, {} steps, {} nodes once put back, costing {}",
+        settled.len(),
+        query.stats().reached().len(),
         packed.len(),
         way.len(),
         query.distance(target)
@@ -121,6 +153,17 @@ fn main() {
             None => (-1, 0.0),
             Some(level) => (level as isize, (level + 1) as f64 * LEVEL_HEIGHT),
         }
+    };
+
+    // What a node is coloured by: the cell it was stepped over in, or the
+    // finest cell holding it where the search was walking arcs and there is no
+    // such level. Either way it is a cell of the partition, so everything on
+    // screen is coloured by where it happened.
+    let shade = |node: NodeID, saturation: f64, lightness: f64| -> String {
+        let level = partition
+            .query_level(source_word, target_word, node)
+            .unwrap_or(0);
+        hsl(hue_of(partition, node, level, levels), saturation, lightness)
     };
 
     let at = |node: NodeID| -> (f64, f64) {
@@ -179,6 +222,13 @@ fn main() {
             .map(|c| Position::from(vec![f64::from(c.lon) / 1e6, f64::from(c.lat) / 1e6]))
             .collect();
         let base = (*level + 1) as f64 * LEVEL_HEIGHT;
+        // a sheet is the dark end of its family, so that everything the search
+        // did on it is the same colour only brighter
+        let colour = hsl(
+            hue_of(partition, nodes[0], *level, levels),
+            0.45,
+            0.20 + 0.075 * (levels - 1 - *level) as f64,
+        );
         writer
             .write_feature(&feature(
                 GeometryValue::Polygon {
@@ -188,24 +238,77 @@ fn main() {
                 *level as isize,
                 base,
                 base + SHEET,
+                &colour,
             ))
             .expect("the cell cannot be written");
         written += 1;
     }
 
-    // what the search settled, at the height of the level it settled it at
-    for &node in query.stats().settled() {
-        let (level, height) = height_of(node);
-        let (lon, lat) = at(node);
+    // Every arc the search relaxed and kept.
+    //
+    // The queue holds, for each node it ever held, the node that node was
+    // reached from, so the arcs are read back off it afterwards rather than
+    // recorded as the search runs. One arc per node reached, being the last
+    // one to improve it, which is the tree the search ends up with.
+    //
+    // These are drawn straight, unlike the way. A step of the way stands for a
+    // path through a cell and is drawn as that path, but an arc of the overlay
+    // stands for nothing further down until it is unpacked: it is an entry in
+    // a table between two border nodes of a cell, and a straight line is what
+    // an entry in a table looks like.
+    let mut relaxed = 0usize;
+    for &node in query.stats().reached() {
+        let Some(parent) = query.parent(node) else {
+            continue;
+        };
+        // the source was reached from nowhere
+        if parent == node {
+            continue;
+        }
+        let (level, height) = height_of(parent);
+        let ring = ribbon_along(&[at(parent), at(node)], width * 0.3);
+        if ring.is_empty() {
+            continue;
+        }
         writer
             .write_feature(&feature(
-                GeometryValue::Point {
-                    coordinates: Position::from(vec![lon, lat]),
+                GeometryValue::Polygon {
+                    coordinates: vec![ring],
                 },
-                "settled",
+                "relaxed",
                 level,
-                height,
-                height,
+                height + SHEET,
+                height + SHEET * ARC_TOP,
+                &shade(parent, 0.5, 0.38),
+            ))
+            .expect("the arc cannot be written");
+        written += 1;
+        relaxed += 1;
+    }
+    println!("{relaxed} arcs were relaxed and kept");
+
+    // What the search reached and never got round to, and what it settled. A
+    // stub for the one and something standing up for the other: the search
+    // knows a distance to a node it settled and only a bound for one it
+    // reached, and the difference is most of what a search does.
+    for &node in query.stats().reached() {
+        let (level, height) = height_of(node);
+        let settled_here = settled.contains(&node);
+        let (top, size, colour) = if settled_here {
+            (SETTLED_TOP, 0.55, shade(node, 0.85, 0.62))
+        } else {
+            (REACHED_TOP, 0.4, shade(node, 0.4, 0.42))
+        };
+        writer
+            .write_feature(&feature(
+                GeometryValue::Polygon {
+                    coordinates: vec![footprint(at(node), width * size)],
+                },
+                if settled_here { "settled" } else { "reached" },
+                level,
+                height + SHEET,
+                height + SHEET * top,
+                &colour,
             ))
             .expect("the node cannot be written");
         written += 1;
@@ -257,10 +360,13 @@ fn main() {
                 },
                 "packed",
                 level,
-                // on top of the sheet its level is drawn as, not inside it:
-                // the sheet is the thicker of the two and would swallow it
-                height + SHEET,
-                height + SHEET * 1.35,
+                // clear over the sheet its level is drawn as and over
+                // everything standing on it, rather than inside any of it
+                height + SHEET * WAY_BASE,
+                height + SHEET * WAY_TOP,
+                // the brightest the cell's family goes, so the way is the
+                // first thing read at a level and still plainly of that level
+                &shade(pair[0], 1.0, 0.66),
             ))
             .expect("the step cannot be written");
         written += 1;
@@ -287,6 +393,13 @@ fn main() {
             continue;
         }
         let (low, high) = (leaving.min(arriving), leaving.max(arriving));
+        // the colour of the end it is climbing to, so a riser reads as
+        // arriving somewhere rather than as leaving somewhere
+        let arrived = if arriving >= leaving {
+            node
+        } else {
+            packed[index - 1]
+        };
         writer
             .write_feature(&feature(
                 GeometryValue::Polygon {
@@ -294,8 +407,9 @@ fn main() {
                 },
                 "riser",
                 level,
-                low + SHEET,
-                high + SHEET * 1.35,
+                low + SHEET * WAY_BASE,
+                high + SHEET * WAY_TOP,
+                &shade(arrived, 1.0, 0.66),
             ))
             .expect("the riser cannot be written");
         written += 1;
@@ -318,6 +432,9 @@ fn main() {
             -1,
             0.0,
             0.0,
+            // the one thing on screen that is not of a cell, being the answer
+            // rather than a part of the working
+            "#f2f2f0",
         ))
         .expect("the way cannot be written");
     written += 1;
@@ -327,12 +444,20 @@ fn main() {
 }
 
 /// A feature carrying what the viewer draws it by.
-fn feature(geometry: GeometryValue, kind: &str, level: isize, base: f64, height: f64) -> Feature {
+fn feature(
+    geometry: GeometryValue,
+    kind: &str,
+    level: isize,
+    base: f64,
+    height: f64,
+    colour: &str,
+) -> Feature {
     let mut properties = JsonObject::new();
     properties.insert("kind".to_string(), JsonValue::from(kind));
     properties.insert("level".to_string(), JsonValue::from(level));
     properties.insert("base".to_string(), JsonValue::from(base));
     properties.insert("height".to_string(), JsonValue::from(height));
+    properties.insert("colour".to_string(), JsonValue::from(colour));
     Feature {
         bbox: None,
         geometry: Some(Geometry::new(geometry)),
@@ -340,6 +465,65 @@ fn feature(geometry: GeometryValue, kind: &str, level: isize, base: f64, height:
         properties: Some(properties),
         foreign_members: None,
     }
+}
+
+/// The hue a cell is drawn in, which is a hue within its parent's.
+///
+/// The walk starts at the coarsest level and comes down to the one asked for,
+/// each cell along the way moving the hue within a span of where its parent
+/// left it, and the span narrowing at every level. So two cells of one parent
+/// come out near one another, two cells of one grandparent further apart, and
+/// how far apart two cells look is how far apart they are in the partition.
+///
+/// The narrowing is what makes it a shade of the parent rather than a colour
+/// of its own. It also means the finest levels have little room left, which is
+/// right: at that depth what is worth seeing is which coarse cell something
+/// belongs to, not which of a thousand fine ones.
+fn hue_of(partition: &PackedPartition, node: NodeID, level: usize, levels: usize) -> f64 {
+    let mut hue = 0.0;
+    let mut span = 360.0;
+    for above in (level..levels).rev() {
+        hue += span * (scatter(partition.cell_of(node, above)) - 0.5);
+        span *= 0.42;
+    }
+    hue
+}
+
+/// A number in zero to one from a cell.
+///
+/// Cells that are next to one another are numbered next to one another, and a
+/// hue taken straight from the number would draw half a country in one sweep
+/// of the spectrum. Stirring the bits first is what makes neighbours tell
+/// apart.
+fn scatter(cell: CellId) -> f64 {
+    let mut hash = u64::from(cell).wrapping_add(0x9e37_79b9_7f4a_7c15);
+    hash = (hash ^ (hash >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    hash = (hash ^ (hash >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    hash ^= hash >> 31;
+    (hash >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// A colour as `#rrggbb`, from a hue in degrees and a saturation and lightness
+/// in zero to one.
+///
+/// Hue, saturation and lightness rather than red, green and blue because the
+/// three things being said are which family, how much of the search, and how
+/// coarse, and those are three knobs here and none there.
+fn hsl(hue: f64, saturation: f64, lightness: f64) -> String {
+    let sixth = hue.rem_euclid(360.0) / 60.0;
+    let chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
+    let second = chroma * (1.0 - (sixth % 2.0 - 1.0).abs());
+    let (red, green, blue) = match sixth as usize {
+        0 => (chroma, second, 0.0),
+        1 => (second, chroma, 0.0),
+        2 => (0.0, chroma, second),
+        3 => (0.0, second, chroma),
+        4 => (second, 0.0, chroma),
+        _ => (chroma, 0.0, second),
+    };
+    let base = lightness - chroma / 2.0;
+    let byte = |value: f64| ((value + base).clamp(0.0, 1.0) * 255.0).round() as u8;
+    format!("#{:02x}{:02x}{:02x}", byte(red), byte(green), byte(blue))
 }
 
 /// A way drawn as a ribbon, since a line cannot be lifted off the ground.
@@ -406,7 +590,7 @@ fn ribbon_along(points: &[(f64, f64)], width: f64) -> Vec<Position> {
     ring
 }
 
-/// The footprint a riser is pushed up from.
+/// The footprint a riser or a node is pushed up from.
 fn footprint(at: (f64, f64), width: f64) -> Vec<Position> {
     vec![
         Position::from(vec![at.0 - width, at.1 - width]),

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -131,16 +131,19 @@ fn main() {
     let mut writer = FeatureWriter::from_writer(file);
     let mut written = 0usize;
 
-    // how wide a drawn line is, taken from how much ground is on screen, so
-    // that a way across a town and a way across a continent both read
-    let mut west = f64::MAX;
-    let mut east = f64::MIN;
+    // how wide a drawn way is, taken from how much ground it covers, so that a
+    // way across a town and a way across a continent both read. Narrow enough
+    // that the shape of the way is what shows rather than the width of it.
+    let (mut west, mut east) = (f64::MAX, f64::MIN);
+    let (mut south, mut north) = (f64::MAX, f64::MIN);
     for &node in &way {
-        let (lon, _) = at(node);
+        let (lon, lat) = at(node);
         west = west.min(lon);
         east = east.max(lon);
+        south = south.min(lat);
+        north = north.max(lat);
     }
-    let width = ((east - west) * 0.004).max(0.000_02);
+    let width = (((east - west).max(north - south)) * 0.0025).max(0.000_02);
 
     // the cells the search stepped over, per level
     let mut stepped: BTreeSet<(usize, CellId)> = BTreeSet::new();
@@ -207,20 +210,56 @@ fn main() {
         written += 1;
     }
 
-    // the way the search found, each step at the height it was taken at, and a
-    // column under each of its ends running down to the ground
-    for pair in packed.windows(2) {
-        let (from, to) = (pair[0], pair[1]);
-        let (level, height) = height_of(from);
+    // The way the search found, each step drawn at the height it was taken at.
+    //
+    // A step is drawn as the way it stands for and not as the line between its
+    // ends. The two are nothing alike -- a step over a coarse cell is a
+    // straight line across a country, and the way beneath it runs where the
+    // roads run -- and the straight one says a road runs where none does. Told
+    // truthfully, a level shows the same way as the ground does, coarsened
+    // only in where it may leave a cell.
+    //
+    // Which arcs a step stands for is not asked again here. The way was put
+    // back by laying the steps end to end, so it comes apart at the nodes the
+    // search handed over, each of which it holds once.
+    let mut seam = Vec::with_capacity(packed.len());
+    seam.push(0usize);
+    for &node in &packed[1..] {
+        let from = seam.last().expect("a seam was pushed before the loop") + 1;
+        let found = way[from..]
+            .iter()
+            .position(|&held| held == node)
+            .map(|offset| from + offset)
+            .expect("the way does not hold a node the search stepped to");
+        seam.push(found);
+    }
+    assert_eq!(
+        seam.last().copied(),
+        Some(way.len() - 1),
+        "the way holds more than the steps it was laid out of"
+    );
+
+    for (step, pair) in packed.windows(2).enumerate() {
+        let (level, height) = height_of(pair[0]);
+        let along: Vec<(f64, f64)> = way[seam[step]..=seam[step + 1]]
+            .iter()
+            .map(|&node| at(node))
+            .collect();
+        let ring = ribbon_along(&along, width);
+        if ring.is_empty() {
+            continue;
+        }
         writer
             .write_feature(&feature(
                 GeometryValue::Polygon {
-                    coordinates: vec![ribbon(at(from), at(to), width)],
+                    coordinates: vec![ring],
                 },
                 "packed",
                 level,
-                height,
-                height + SHEET / 4.0,
+                // on top of the sheet its level is drawn as, not inside it:
+                // the sheet is the thicker of the two and would swallow it
+                height + SHEET,
+                height + SHEET * 1.35,
             ))
             .expect("the step cannot be written");
         written += 1;
@@ -238,7 +277,9 @@ fn main() {
                 "column",
                 level,
                 0.0,
-                height,
+                // up to the way rather than to the sheet below it, so that a
+                // drop meets the step it belongs to
+                height + SHEET,
             ))
             .expect("the column cannot be written");
         written += 1;
@@ -285,28 +326,68 @@ fn feature(geometry: GeometryValue, kind: &str, level: isize, base: f64, height:
     }
 }
 
-/// A step drawn as a quad, since a line cannot be lifted off the ground.
+/// A way drawn as a ribbon, since a line cannot be lifted off the ground.
 ///
-/// Nothing draws a line at a height: what a map draws at a height is a
-/// polygon pushed up between two of them. So a step is widened into a quad
-/// about its own direction and pushed up as a sheet, which reads as a line
-/// from anywhere but directly on.
-fn ribbon(from: (f64, f64), to: (f64, f64), width: f64) -> Vec<Position> {
-    let (dx, dy) = (to.0 - from.0, to.1 - from.1);
-    let length = dx.hypot(dy);
-    // a step from a node to itself has no direction to be widened about
-    let (nx, ny) = if length < f64::EPSILON {
-        (width, 0.0)
-    } else {
-        (-dy / length * width, dx / length * width)
+/// Nothing draws a line at a height: what a map draws at a height is a polygon
+/// pushed up between two of them. So the way is widened about itself, out along
+/// one side and back along the other, and pushed up as a sheet, which reads as
+/// a line from anywhere but directly on.
+///
+/// The widening is done with longitude scaled to the latitude it is at, so that
+/// a way running east is drawn as wide as one running north. Away from the
+/// equator a degree of longitude is the shorter of the two, and a ribbon that
+/// does not say so is fat one way and thin the other.
+fn ribbon_along(points: &[(f64, f64)], width: f64) -> Vec<Position> {
+    // a way that stands still has no direction to be widened about
+    let mut along: Vec<(f64, f64)> = Vec::with_capacity(points.len());
+    for &point in points {
+        if along.last() != Some(&point) {
+            along.push(point);
+        }
+    }
+    if along.len() < 2 {
+        return Vec::new();
+    }
+
+    let middle = along.iter().map(|&(_, lat)| lat).sum::<f64>() / along.len() as f64;
+    let stretch = middle.to_radians().cos().max(0.01);
+    let flat: Vec<(f64, f64)> = along.iter().map(|&(x, y)| (x * stretch, y)).collect();
+
+    // the way each step of it faces, turned a quarter
+    let sideways: Vec<(f64, f64)> = flat
+        .windows(2)
+        .map(|step| {
+            let (dx, dy) = (step[1].0 - step[0].0, step[1].1 - step[0].1);
+            let length = dx.hypot(dy);
+            (-dy / length, dx / length)
+        })
+        .collect();
+
+    // and at a node, the two steps meeting there, averaged. A corner comes out
+    // narrower than a straight, which is what a corner should look like.
+    let out_at = |index: usize| -> (f64, f64) {
+        let before = sideways[index.saturating_sub(1)];
+        let after = sideways[index.min(sideways.len() - 1)];
+        let (x, y) = (before.0 + after.0, before.1 + after.1);
+        let length = x.hypot(y);
+        if length < 1e-12 {
+            after
+        } else {
+            (x / length * width, y / length * width)
+        }
     };
-    vec![
-        Position::from(vec![from.0 + nx, from.1 + ny]),
-        Position::from(vec![to.0 + nx, to.1 + ny]),
-        Position::from(vec![to.0 - nx, to.1 - ny]),
-        Position::from(vec![from.0 - nx, from.1 - ny]),
-        Position::from(vec![from.0 + nx, from.1 + ny]),
-    ]
+
+    let mut ring: Vec<Position> = Vec::with_capacity(flat.len() * 2 + 1);
+    for (index, point) in flat.iter().enumerate() {
+        let (dx, dy) = out_at(index);
+        ring.push(Position::from(vec![(point.0 + dx) / stretch, point.1 + dy]));
+    }
+    for (index, point) in flat.iter().enumerate().rev() {
+        let (dx, dy) = out_at(index);
+        ring.push(Position::from(vec![(point.0 - dx) / stretch, point.1 - dy]));
+    }
+    ring.push(ring[0].clone());
+    ring
 }
 
 /// The footprint of the drop from a node to the ground.

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -15,9 +15,10 @@
 //! So each level is given a height. The arcs of the graph lie on the ground,
 //! the cells of the finest level float above them, and each level above that
 //! floats higher again. A step across a cell is drawn at the height of the
-//! level it was taken at, and under each of its ends a column runs down to the
-//! ground, so the way the search took can be followed from the coarse step it
-//! made down to the arcs that step really stands for.
+//! level it was taken at, and where it changes level a riser joins the two
+//! heights, so that the way climbs from the ground to each cell it steps over
+//! and comes back down. Followed end to end it never breaks, and every jump in
+//! it is a level the search changed at.
 //!
 //! # What goes in the file
 //!
@@ -31,7 +32,7 @@
 //! | `settled`  | a node the search took off its queue              |
 //! | `packed`   | a step of the way the search found                |
 //! | `unpacked` | the way through the graph that step stands for    |
-//! | `column`   | the drop from a packed node to the ground         |
+//! | `riser`    | where the way changes level, drawn upright        |
 
 use std::{collections::BTreeSet, env::args, fs::File, io::BufWriter};
 
@@ -264,24 +265,39 @@ fn main() {
             .expect("the step cannot be written");
         written += 1;
     }
-    for &node in &packed {
-        let (level, height) = height_of(node);
-        if height <= 0.0 {
+    // Where the way changes level, a riser at the node the two steps share.
+    //
+    // This is what makes the way one thing rather than a handful of pieces
+    // floating at heights that have to be matched up by eye: it starts on the
+    // ground, climbs to each cell it steps over, and comes back down to the
+    // ground at the far end. Both ends of every riser are the ends of steps
+    // already drawn, so the whole of it can be followed without a break.
+    //
+    // A riser is upright because a map has no way to draw anything else. What
+    // is drawn at a height is a polygon pushed up between two of them, and a
+    // polygon has one footprint, so a way from one height to another can only
+    // go straight up. It reads well enough: the way runs level over a cell and
+    // jumps where it changes level, which is what it does.
+    for index in 1..packed.len().saturating_sub(1) {
+        let node = packed[index];
+        let (was, leaving) = height_of(packed[index - 1]);
+        let (level, arriving) = height_of(node);
+        // two steps at the same level are already laid end to end
+        if was == level {
             continue;
         }
+        let (low, high) = (leaving.min(arriving), leaving.max(arriving));
         writer
             .write_feature(&feature(
                 GeometryValue::Polygon {
-                    coordinates: vec![column(at(node), width * 0.6)],
+                    coordinates: vec![footprint(at(node), width * 0.75)],
                 },
-                "column",
+                "riser",
                 level,
-                0.0,
-                // up to the way rather than to the sheet below it, so that a
-                // drop meets the step it belongs to
-                height + SHEET,
+                low + SHEET,
+                high + SHEET * 1.35,
             ))
-            .expect("the column cannot be written");
+            .expect("the riser cannot be written");
         written += 1;
     }
 
@@ -390,8 +406,8 @@ fn ribbon_along(points: &[(f64, f64)], width: f64) -> Vec<Position> {
     ring
 }
 
-/// The footprint of the drop from a node to the ground.
-fn column(at: (f64, f64), width: f64) -> Vec<Position> {
+/// The footprint a riser is pushed up from.
+fn footprint(at: (f64, f64), width: f64) -> Vec<Position> {
     vec![
         Position::from(vec![at.0 - width, at.1 - width]),
         Position::from(vec![at.0 + width, at.1 - width]),

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -27,8 +27,15 @@
 //! cells reads as a family however deep it is cut, and the level reads by how
 //! light the shade is. Everything the search did inside a cell takes that
 //! cell's hue: the arcs it relaxed, the nodes it reached, the nodes it settled
-//! and the step of the way it came away with, each at its own brightness. So
-//! the colour says where, and the height says how coarse.
+//! and the step of the way it came away with, each at its own strength. So the
+//! colour says where, and the height says how coarse.
+//!
+//! The shades are pale and weak -- high lightness, low saturation. There are
+//! thousands of marks on one screen and a hue at full strength beside another
+//! at full strength fights it, which is fine for six colours and unreadable
+//! for six hundred. Weak colours also leave somewhere to go: what matters most
+//! is drawn stronger rather than drawn in a different colour altogether, so
+//! the family holds all the way up.
 //!
 //! # What goes in the file
 //!
@@ -239,12 +246,12 @@ fn main() {
             hull.iter().map(|c| f64::from(c.lon) / 1e6).sum::<f64>() / hull.len() as f64,
             hull.iter().map(|c| f64::from(c.lat) / 1e6).sum::<f64>() / hull.len() as f64,
         );
-        // a sheet is the dark end of its family, so that everything the search
-        // did on it is the same colour only brighter
+        // a sheet is the palest and least of its family, everything the search
+        // did on it being the same hue carried further
         let colour = hsl(
             hue_of(partition, nodes[0], *level, levels),
-            0.45,
-            0.20 + 0.075 * (levels - 1 - *level) as f64,
+            0.42,
+            0.58 + 0.05 * (levels - 1 - *level) as f64,
         );
         writer
             .write_feature(&feature(
@@ -316,7 +323,7 @@ fn main() {
                 level,
                 height + SHEET,
                 height + SHEET * ARC_TOP,
-                &shade(parent, 0.5, 0.38),
+                &shade(parent, 0.5, 0.7),
             ))
             .expect("the arc cannot be written");
         written += 1;
@@ -385,9 +392,9 @@ fn main() {
         let (level, height) = height_of(node);
         let settled_here = settled.contains(&node);
         let (top, size, colour) = if settled_here {
-            (SETTLED_TOP, 0.55, shade(node, 0.85, 0.62))
+            (SETTLED_TOP, 0.55, shade(node, 0.68, 0.78))
         } else {
-            (REACHED_TOP, 0.4, shade(node, 0.4, 0.42))
+            (REACHED_TOP, 0.4, shade(node, 0.34, 0.56))
         };
         writer
             .write_feature(&feature(
@@ -454,9 +461,9 @@ fn main() {
                 // everything standing on it, rather than inside any of it
                 height + SHEET * WAY_BASE,
                 height + SHEET * WAY_TOP,
-                // the brightest the cell's family goes, so the way is the
-                // first thing read at a level and still plainly of that level
-                &shade(pair[0], 1.0, 0.66),
+                // the fullest the cell's family goes, so the way is the first
+                // thing read at a level and still plainly of that level
+                &shade(pair[0], 0.82, 0.76),
             ))
             .expect("the step cannot be written");
         written += 1;
@@ -499,7 +506,7 @@ fn main() {
                 level,
                 low + SHEET * WAY_BASE,
                 high + SHEET * WAY_TOP,
-                &shade(arrived, 1.0, 0.66),
+                &shade(arrived, 0.82, 0.76),
             ))
             .expect("the riser cannot be written");
         written += 1;
@@ -524,7 +531,7 @@ fn main() {
             0.0,
             // the one thing on screen that is not of a cell, being the answer
             // rather than a part of the working
-            "#f2f2f0",
+            "#ece9e2",
         ))
         .expect("the way cannot be written");
     written += 1;
@@ -574,7 +581,7 @@ fn hue_of(partition: &PackedPartition, node: NodeID, level: usize, levels: usize
     let mut span = 360.0;
     for above in (level..levels).rev() {
         hue += span * (scatter(partition.cell_of(node, above)) - 0.5);
-        span *= 0.42;
+        span *= 0.48;
     }
     hue
 }

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -40,6 +40,7 @@
 //! | `kind`     | what it is                                          |
 //! |------------|-----------------------------------------------------|
 //! | `cell`     | the outline of a cell the search stepped over       |
+//! | `link`     | two cells of a level the search crossed between     |
 //! | `relaxed`  | an arc the search relaxed and kept                  |
 //! | `reached`  | a node it put on its queue and never took off       |
 //! | `settled`  | a node it took off its queue                        |
@@ -92,6 +93,8 @@ const HULL_SAMPLE: usize = 200_000;
 /// a node it only reached is a stub, a node it settled stands up, and the way
 /// it came away with floats clear over all of it.
 const ARC_TOP: f64 = 1.15;
+const LINK_BASE: f64 = 1.15;
+const LINK_TOP: f64 = 1.28;
 const REACHED_TOP: f64 = 1.3;
 const SETTLED_TOP: f64 = 1.9;
 const WAY_BASE: f64 = 2.2;
@@ -163,7 +166,11 @@ fn main() {
         let level = partition
             .query_level(source_word, target_word, node)
             .unwrap_or(0);
-        hsl(hue_of(partition, node, level, levels), saturation, lightness)
+        hsl(
+            hue_of(partition, node, level, levels),
+            saturation,
+            lightness,
+        )
     };
 
     let at = |node: NodeID| -> (f64, f64) {
@@ -198,6 +205,9 @@ fn main() {
     }
     println!("{} cells were stepped over", stepped.len());
 
+    // where each drawn cell sits and what it came out, for the links between
+    // them to be drawn from and coloured by
+    let mut centre_of: FxHashMap<(usize, CellId), ((f64, f64), String)> = FxHashMap::default();
     let mut nodes_of: FxHashMap<usize, std::sync::Arc<toolbox_rs::customization::Level>> =
         FxHashMap::default();
     for (level, cell) in &stepped {
@@ -222,6 +232,13 @@ fn main() {
             .map(|c| Position::from(vec![f64::from(c.lon) / 1e6, f64::from(c.lat) / 1e6]))
             .collect();
         let base = (*level + 1) as f64 * LEVEL_HEIGHT;
+        // the middle of the outline rather than of the nodes: a link is drawn
+        // between two shapes on screen, so it should leave from the middle of
+        // the shape and not from wherever the nodes happen to crowd
+        let middle = (
+            hull.iter().map(|c| f64::from(c.lon) / 1e6).sum::<f64>() / hull.len() as f64,
+            hull.iter().map(|c| f64::from(c.lat) / 1e6).sum::<f64>() / hull.len() as f64,
+        );
         // a sheet is the dark end of its family, so that everything the search
         // did on it is the same colour only brighter
         let colour = hsl(
@@ -241,6 +258,7 @@ fn main() {
                 &colour,
             ))
             .expect("the cell cannot be written");
+        centre_of.insert((*level, *cell), (middle, colour));
         written += 1;
     }
 
@@ -257,6 +275,7 @@ fn main() {
     // a table between two border nodes of a cell, and a straight line is what
     // an entry in a table looks like.
     let mut relaxed = 0usize;
+    let mut crossings: BTreeSet<(usize, CellId, CellId)> = BTreeSet::new();
     for &node in query.stats().reached() {
         let Some(parent) = query.parent(node) else {
             continue;
@@ -264,6 +283,24 @@ fn main() {
         // the source was reached from nowhere
         if parent == node {
             continue;
+        }
+        // An arc whose ends are at one level in two cells is the search
+        // leaving the one and entering the other, which is the whole of what
+        // it means for two cells to be next to each other here. Nothing else
+        // has to be asked of the partition: the arcs the search relaxed
+        // already say which cells it found its way between.
+        if let (Some(from), Some(to)) = (
+            partition.query_level(source_word, target_word, parent),
+            partition.query_level(source_word, target_word, node),
+        ) && from == to
+        {
+            let (here, there) = (
+                partition.cell_of(parent, from),
+                partition.cell_of(node, from),
+            );
+            if here != there {
+                crossings.insert((from, here.min(there), here.max(there)));
+            }
         }
         let (level, height) = height_of(parent);
         let ring = ribbon_along(&[at(parent), at(node)], width * 0.3);
@@ -286,6 +323,59 @@ fn main() {
         relaxed += 1;
     }
     println!("{relaxed} arcs were relaxed and kept");
+
+    // The cells of a level, joined where the search crossed between them.
+    //
+    // Drawn on their own the cells of a level are a scattering of islands and
+    // nothing says which one leads to which, though that is what the search
+    // spent its time on: it steps across a cell, leaves by an arc into the
+    // next, and steps across that one. A link says the two are next to each
+    // other and the search went that way.
+    //
+    // Dashed, because it is not a thing on the ground. A step of the way is a
+    // path through a cell and an arc is an entry in a table, but a link is
+    // neither -- it is two shapes on screen having something to do with each
+    // other -- and a dashed line is how a drawing says so. The gaps are cut
+    // here: what a map draws at a height is a polygon, a polygon is solid, so
+    // every dash has to be one of its own.
+    let mut linked = 0usize;
+    for (level, here, there) in &crossings {
+        let (Some((from, tint)), Some((to, other))) = (
+            centre_of.get(&(*level, *here)),
+            centre_of.get(&(*level, *there)),
+        ) else {
+            // a cell the search crossed into and never settled in was never
+            // drawn, and a link to a shape that is not there is a line to
+            // nowhere
+            continue;
+        };
+        let cut = dashes(*from, *to, width * 0.45, width * 4.0);
+        if cut.is_empty() {
+            continue;
+        }
+        let base = (*level + 1) as f64 * LEVEL_HEIGHT;
+        // one feature for the link and its dashes as the parts of it, rather
+        // than one feature per dash: a link is one thing about the partition,
+        // and cut into pieces it would be counted and hidden as many
+        writer
+            .write_feature(&feature(
+                GeometryValue::MultiPolygon {
+                    coordinates: cut.into_iter().map(|ring| vec![ring]).collect(),
+                },
+                "link",
+                *level as isize,
+                base + SHEET * LINK_BASE,
+                base + SHEET * LINK_TOP,
+                &blend(tint, other),
+            ))
+            .expect("the link cannot be written");
+        written += 1;
+        linked += 1;
+    }
+    println!(
+        "{linked} pairs of cells were crossed between, of {} the search found",
+        crossings.len()
+    );
 
     // What the search reached and never got round to, and what it settled. A
     // stub for the one and something standing up for the other: the search
@@ -588,6 +678,56 @@ fn ribbon_along(points: &[(f64, f64)], width: f64) -> Vec<Position> {
     }
     ring.push(ring[0].clone());
     ring
+}
+
+/// A line from one place to another, cut into dashes.
+///
+/// `dash` is how long a dash is meant to be, and it is met as nearly as a
+/// whole number of them fits the distance, so that dashes come out the same
+/// length whether a link is short or long. Half of each is drawn and half is
+/// left, which is what makes it read as dashed rather than as dotted.
+fn dashes(from: (f64, f64), to: (f64, f64), width: f64, dash: f64) -> Vec<Vec<Position>> {
+    let (dx, dy) = (to.0 - from.0, to.1 - from.1);
+    let length = dx.hypot(dy);
+    // two cells whose outlines have the same middle are not two shapes to
+    // draw a line between
+    if length < f64::EPSILON {
+        return Vec::new();
+    }
+    // and one too short to break up is drawn whole rather than dropped: it is
+    // as much a crossing as a long one, and a link that is not drawn reads as
+    // two cells the search never went between
+    if length < dash * 2.0 {
+        let whole = ribbon_along(&[from, to], width);
+        return if whole.is_empty() {
+            Vec::new()
+        } else {
+            vec![whole]
+        };
+    }
+    let count = (length / (dash * 2.0)).round().max(1.0);
+    let at = |along: f64| (from.0 + dx * along, from.1 + dy * along);
+    (0..count as usize)
+        .map(|step| {
+            let start = step as f64 / count;
+            ribbon_along(&[at(start), at(start + 0.5 / count)], width)
+        })
+        .filter(|ring| !ring.is_empty())
+        .collect()
+}
+
+/// The colour halfway between two, for something belonging to both.
+fn blend(one: &str, other: &str) -> String {
+    let band = |colour: &str, at: usize| {
+        u16::from_str_radix(&colour[at..at + 2], 16).expect("a colour is six hex digits")
+    };
+    let mixed: Vec<String> = (0..3)
+        .map(|index| {
+            let at = 1 + index * 2;
+            format!("{:02x}", (band(one, at) + band(other, at)) / 2)
+        })
+        .collect();
+    format!("#{}", mixed.concat())
 }
 
 /// The footprint a riser or a node is pushed up from.

--- a/src/heap_stats.rs
+++ b/src/heap_stats.rs
@@ -156,6 +156,68 @@ impl<Node> HeapStats<Node> for SettledNodes<Node> {
     fn decreased(&mut self, _node: Node) {}
 }
 
+/// Every node that went onto the queue, and every node that came off it.
+///
+/// [`SettledNodes`] keeps what a search decided. This also keeps what it looked
+/// at and never got round to deciding, which is the other half of a picture of
+/// a search: a node it settled is one it knows the distance to, and a node it
+/// only reached is one it had a distance for and stopped before using. Drawn
+/// alike the two say the search did more work than it did.
+///
+/// Both are kept in the order the queue handed them over, and neither is
+/// de-duplicated because neither has to be: a node goes onto an addressable
+/// queue once and comes off it once. So the reached hold every node the search
+/// touched, exactly once each, and the settled are a subset of them.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Frontier<Node = NodeID> {
+    settled: Vec<Node>,
+    reached: Vec<Node>,
+}
+
+/// Written out rather than derived, as a derived one would ask the node type
+/// to have a default of its own and nothing here ever needs one.
+impl<Node> Default for Frontier<Node> {
+    fn default() -> Self {
+        Self {
+            settled: Vec::new(),
+            reached: Vec::new(),
+        }
+    }
+}
+
+impl<Node> Frontier<Node> {
+    /// The nodes that came off the queue, in the order they came off.
+    #[must_use]
+    pub fn settled(&self) -> &[Node] {
+        &self.settled
+    }
+
+    /// Every node that went onto the queue, in the order it went on.
+    ///
+    /// This holds the settled as well. What was reached and not settled is the
+    /// one without the other, which is a question for whoever is asking rather
+    /// than a second list to keep.
+    #[must_use]
+    pub fn reached(&self) -> &[Node] {
+        &self.reached
+    }
+}
+
+impl<Node> HeapStats<Node> for Frontier<Node> {
+    #[inline]
+    fn inserted(&mut self, node: Node) {
+        self.reached.push(node);
+    }
+
+    #[inline]
+    fn deleted(&mut self, node: Node) {
+        self.settled.push(node);
+    }
+
+    #[inline]
+    fn decreased(&mut self, _node: Node) {}
+}
+
 /// The node settled at each power of two, and nothing else.
 ///
 /// The place of a node in the settling is its Dijkstra rank from the source,
@@ -258,6 +320,21 @@ mod tests {
         // of five while 8 is not
         assert_eq!(ranks.targets(), &[(1, 0), (2, 1), (4, 3)]);
         assert_eq!(ranks.settled_count(), 5);
+    }
+
+    #[test]
+    fn the_frontier_keeps_what_went_on_and_what_came_off() {
+        let mut frontier = Frontier::default();
+        frontier.inserted(1);
+        frontier.inserted(2);
+        frontier.inserted(3);
+        frontier.decreased(2);
+        frontier.deleted(1);
+        frontier.deleted(2);
+
+        // the reached hold the settled as well, and a decrease is neither
+        assert_eq!(frontier.reached(), &[1, 2, 3]);
+        assert_eq!(frontier.settled(), &[1, 2]);
     }
 
     #[test]

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -115,6 +115,17 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         self.queue.weight(node)
     }
 
+    /// The node a reached node was reached from.
+    ///
+    /// `None` if the search never reached it, and the node itself if it is the
+    /// source, there being nowhere it was reached from. Every node the search
+    /// reached has one, so this is the tree of the arcs it relaxed and kept:
+    /// one arc per node, the last one to improve it.
+    #[must_use]
+    pub fn parent(&self, node: NodeID) -> Option<NodeID> {
+        self.queue.inserted(node).then(|| self.queue.data(node))
+    }
+
     /// The nodes of the way to a target, as the search found them.
     ///
     /// These are not all the nodes of the way. A step over a cell is one entry

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -1,0 +1,31 @@
+# Viewers
+
+Pages for looking at what the crate produced, drawn in a browser because the
+thing being looked at is a map.
+
+## `search_space.html`
+
+What a search over the cells looked at, with each level at its own height.
+
+```
+cargo run --release --example search_space -- \
+    graph.toolbox levels.bin coordinates.toolbox <source> <target> \
+    viewer/search_space.geojson
+
+python3 -m http.server 8000
+open http://localhost:8000/viewer/search_space.html
+```
+
+`?data=<path>` points it at another file.
+
+Serve it rather than opening the file directly: reading the data is a fetch,
+and a page opened off the filesystem is not allowed to make one.
+
+The page needs the tab to be visible. A map draws on animation frames, and a
+browser does not run those for a tab in the background, so a hidden tab sits
+there with nothing on it. The page says so rather than leaving a black screen.
+
+MapLibre is loaded from unpkg, so the page wants the network the first time.
+There is no basemap: the tiles would say nothing this is about, and asking for
+them means asking somebody else's server for permission to look at your own
+data.

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -79,13 +79,13 @@ const RAISE = 230;
 // two heights, and every one of them carries the colour it is drawn in, so
 // there is one paint block here and the file decides the rest.
 const LIFTED = [
-  { id: 'cells',   kind: 'cell',    opacity: 0.32, label: null },
-  { id: 'links',   kind: 'link',    opacity: 0.85, label: 'cells it crossed between' },
-  { id: 'relaxed', kind: 'relaxed', opacity: 0.7,  label: 'arcs it relaxed' },
-  { id: 'reached', kind: 'reached', opacity: 0.8,  label: 'reached, not settled' },
+  { id: 'cells',   kind: 'cell',    opacity: 0.58, label: null },
+  { id: 'links',   kind: 'link',    opacity: 0.9,  label: 'cells it crossed between' },
+  { id: 'relaxed', kind: 'relaxed', opacity: 0.8,  label: 'arcs it relaxed' },
+  { id: 'reached', kind: 'reached', opacity: 0.85, label: 'reached, not settled' },
   { id: 'settled', kind: 'settled', opacity: 0.95, label: 'settled' },
   { id: 'packed',  kind: 'packed',  opacity: 1,    label: 'the way, by level' },
-  { id: 'riser',   kind: 'riser',   opacity: 0.9,  label: 'jumps between levels' },
+  { id: 'riser',   kind: 'riser',   opacity: 0.95, label: 'jumps between levels' },
 ];
 // what a level's checkbox hides, being everything that happened at a level
 const BY_LEVEL = ['cells', 'links', 'relaxed', 'reached', 'settled'];
@@ -205,7 +205,7 @@ function draw(data) {
       kinds.append(toggle(layer.label, mean(of(layer.kind).map(f => f.properties.colour)),
         on => map.setLayoutProperty(layer.id, 'visibility', on ? 'visible' : 'none')));
     }
-    kinds.append(toggle('the way through the graph', '#f2f2f0',
+    kinds.append(toggle('the way through the graph', '#ece9e2',
       on => map.setLayoutProperty('unpacked', 'visibility', on ? 'visible' : 'none')));
 
     // The levels are drawn where the file said, and this scales that. Pulling

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -10,12 +10,12 @@
   A search over the cells is a thing of levels, and drawn flat it all lands on
   top of itself. So each level is given a height: the arcs of the graph lie on
   the ground, the cells of the finest level float above them, and each level
-  above that floats higher again. Under each node of the way the search found,
-  a column runs down to the ground, so a coarse step can be followed to the
-  arcs it stands for.
+  above that floats higher again. The way the search found climbs from the
+  ground to each cell it steps over and comes back down, so it can be followed
+  end to end and every jump in it is a level the search changed at.
 
   Nothing draws a line at a height. What a map draws at a height is a polygon
-  pushed up between two of them, so the steps and the columns were written out
+  pushed up between two of them, so the steps and the risers were written out
   as polygons already, each carrying the two heights it is drawn between.
 
   There is no basemap. The tiles would say nothing this is about, and asking
@@ -60,8 +60,8 @@
     <span class="sw" style="background:#6f8fd8"></span>settled nodes</label></div>
   <div class="row"><label><input type="checkbox" id="packed" checked>
     <span class="sw" style="background:#e0a33c"></span>the way, by level</label></div>
-  <div class="row"><label><input type="checkbox" id="column" checked>
-    <span class="sw" style="background:#7c6ba8"></span>drops to the ground</label></div>
+  <div class="row"><label><input type="checkbox" id="riser" checked>
+    <span class="sw" style="background:#7c6ba8"></span>jumps between levels</label></div>
   <div class="row"><label><input type="checkbox" id="unpacked" checked>
     <span class="sw" style="background:#e8503c"></span>the way through the graph</label></div>
   <hr>
@@ -191,10 +191,10 @@ function draw(data) {
       },
     });
 
-    // and the drop from each of its nodes to the ground
+    // and the jump where it changes level, joining the two heights
     map.addLayer({
-      id: 'column', type: 'fill-extrusion', source: 'space',
-      filter: ['==', ['get', 'kind'], 'column'],
+      id: 'riser', type: 'fill-extrusion', source: 'space',
+      filter: ['==', ['get', 'kind'], 'riser'],
       paint: {
         'fill-extrusion-color': '#7c6ba8',
         'fill-extrusion-base': ['get', 'base'],
@@ -222,7 +222,7 @@ function draw(data) {
     map.panBy([0, -RAISE], { duration: 0 });
 
     for (const [box, layer] of [['settled','settled'], ['packed','packed'],
-                                ['column','column'], ['unpacked','unpacked']]) {
+                                ['riser','riser'], ['unpacked','unpacked']]) {
       document.getElementById(box).addEventListener('change', event => {
         map.setLayoutProperty(layer, 'visibility', event.target.checked ? 'visible' : 'none');
       });
@@ -234,9 +234,9 @@ function draw(data) {
     const spread = document.getElementById('spread');
     spread.addEventListener('input', () => {
       const factor = spread.value / 100;
-      for (const layer of ['cells', 'packed', 'column']) {
+      for (const layer of ['cells', 'packed', 'riser']) {
         map.setPaintProperty(layer, 'fill-extrusion-base',
-          layer === 'column' ? ['get', 'base'] : ['*', ['get', 'base'], factor]);
+          ['*', ['get', 'base'], factor]);
         map.setPaintProperty(layer, 'fill-extrusion-height', ['*', ['get', 'height'], factor]);
       }
     });

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -47,6 +47,9 @@
   .stat { display: flex; justify-content: space-between; font-size: 11.5px; color: #a9a9b2; }
   .stat b { color: #e8e8e6; font-weight: 600; font-variant-numeric: tabular-nums; }
   input[type=range] { width: 100%; }
+  button { background: #24242a; color: #e8e8e6; border: 1px solid #34343c;
+           border-radius: 5px; padding: 3px 12px; font: inherit; cursor: pointer; }
+  button:hover { background: #2e2e36; }
   #err { position: absolute; inset: 0; display: none; place-items: center; z-index: 3;
          background: #0e0e10; color: #e0605a; padding: 40px; text-align: center; }
 </style>
@@ -59,6 +62,11 @@
   <div id="levels"></div>
   <hr>
   <div id="kinds"></div>
+  <hr>
+  <div class="row"><label for="progress">search progress</label>
+    <span class="count" id="at"></span></div>
+  <input type="range" id="progress" min="0" max="0" value="0">
+  <div class="row"><button id="play">play</button></div>
   <hr>
   <div class="row"><label for="spread">level spacing</label></div>
   <input type="range" id="spread" min="0" max="200" value="100">
@@ -172,6 +180,7 @@ function draw(data) {
       map.addLayer({
         id: layer.id, type: 'fill-extrusion', source: 'space',
         filter: ['==', ['get', 'kind'], layer.kind],
+        // replaced by refilter below, which is the one place that decides
         paint: {
           'fill-extrusion-color': ['get', 'colour'],
           'fill-extrusion-base': ['get', 'base'],
@@ -190,6 +199,67 @@ function draw(data) {
         'line-color': ['get', 'colour'],
         'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.2, 12, 5],
       },
+    });
+
+    // What is drawn is decided in one place, from which levels are wanted and
+    // how far into the search the cursor is. Two things composing a filter
+    // from opposite ends of the file is how one of them ends up quietly
+    // dropping what the other asked for.
+    const ALL = [...LIFTED, { id: 'unpacked', kind: 'unpacked' }];
+    const shown = new Set(levels);
+    const last = Math.max(...features.map(f => f.properties.step));
+    let cursor = last;
+
+    const refilter = () => {
+      for (const layer of ALL) {
+        const terms = [['==', ['get', 'kind'], layer.kind],
+                       ['<=', ['get', 'step'], cursor]];
+        if (BY_LEVEL.includes(layer.id)) {
+          const keep = ['in', ['get', 'level'], ['literal', [...shown]]];
+          // what happened below the levels happened on the ground, and no
+          // level's checkbox owns it
+          terms.push(layer.id === 'cells' ? keep
+                                          : ['any', ['<', ['get', 'level'], 0], keep]);
+        }
+        map.setFilter(layer.id, ['all', ...terms]);
+      }
+    };
+
+    // The search, as it stood when it had settled so many nodes. Every mark
+    // carries the step it happened at, so running the cursor is running the
+    // search: nothing is recomputed and nothing is animated but the filter.
+    const progress = document.getElementById('progress');
+    const reading = document.getElementById('at');
+    progress.max = last;
+    progress.value = last;
+    const cut = step => {
+      cursor = Math.round(step);
+      progress.value = cursor;
+      reading.textContent = `${cursor.toLocaleString()} / ${last.toLocaleString()} settled`;
+      refilter();
+    };
+    progress.addEventListener('input', () => cut(Number(progress.value)));
+    // the animation is driven from outside as well, a frame at a time
+    window.cut = cut;
+    cut(last);
+
+    let running = null;
+    document.getElementById('play').addEventListener('click', event => {
+      if (running) {
+        cancelAnimationFrame(running);
+        running = null;
+        event.target.textContent = 'play';
+        return;
+      }
+      event.target.textContent = 'stop';
+      let step = 0;
+      const tick = () => {
+        step += Math.max(1, last / 300);
+        cut(Math.min(step, last));
+        running = step < last ? requestAnimationFrame(tick) : null;
+        if (!running) event.target.textContent = 'play';
+      };
+      tick();
     });
 
     // Fitting the bounds frames the ground, and everything else stands
@@ -224,20 +294,12 @@ function draw(data) {
     // the middle of what that level's cells came out, there being no one
     // colour for a level any more.
     const rows = document.getElementById('levels');
-    const shown = new Set(levels);
     for (const level of [...levels].reverse()) {
       const cells = features.filter(f => f.properties.level === level
                                       && f.properties.kind === 'cell');
       const row = toggle(`level ${level}`, mean(cells.map(f => f.properties.colour)), on => {
         if (on) { shown.add(level); } else { shown.delete(level); }
-        const keep = ['in', ['get', 'level'], ['literal', [...shown]]];
-        for (const id of BY_LEVEL) {
-          const kind = LIFTED.find(l => l.id === id).kind;
-          // what happened below the levels happened on the ground, and no
-          // level's checkbox owns it
-          map.setFilter(id, ['all', ['==', ['get', 'kind'], kind],
-            id === 'cells' ? keep : ['any', ['<', ['get', 'level'], 0], keep]]);
-        }
+        refilter();
       });
       const count = document.createElement('span');
       count.className = 'count';

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Search space over the cells</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  Draws what `cargo run --example search_space` wrote.
+
+  A search over the cells is a thing of levels, and drawn flat it all lands on
+  top of itself. So each level is given a height: the arcs of the graph lie on
+  the ground, the cells of the finest level float above them, and each level
+  above that floats higher again. Under each node of the way the search found,
+  a column runs down to the ground, so a coarse step can be followed to the
+  arcs it stands for.
+
+  Nothing draws a line at a height. What a map draws at a height is a polygon
+  pushed up between two of them, so the steps and the columns were written out
+  as polygons already, each carrying the two heights it is drawn between.
+
+  There is no basemap. The tiles would say nothing this is about, and asking
+  for them means asking somebody else's server for permission to look at your
+  own data.
+
+    python3 -m http.server 8000
+    open http://localhost:8000/viewer/search_space.html?data=search_space.geojson
+-->
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
+<style>
+  html, body { margin: 0; height: 100%; background: #0e0e10; color: #e8e8e6;
+               font: 13px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  #map { position: absolute; inset: 0; }
+  .panel {
+    position: absolute; top: 12px; left: 12px; z-index: 2; width: 232px;
+    background: #17171a; border: 1px solid #2b2b30; border-radius: 8px;
+    padding: 12px 14px; box-shadow: 0 6px 24px rgba(0,0,0,.45);
+  }
+  .panel h1 { font-size: 13px; margin: 0 0 2px; font-weight: 600; }
+  .panel .sub { color: #8d8d95; font-size: 11.5px; margin: 0 0 10px; }
+  .row { display: flex; align-items: center; gap: 8px; margin: 5px 0; }
+  .row label { flex: 1; display: flex; align-items: center; gap: 7px; cursor: pointer; }
+  .sw { width: 12px; height: 12px; border-radius: 3px; flex: none; }
+  .count { color: #75757d; font-variant-numeric: tabular-nums; font-size: 11px; }
+  hr { border: 0; border-top: 1px solid #2b2b30; margin: 10px 0; }
+  .stat { display: flex; justify-content: space-between; font-size: 11.5px; color: #a9a9b2; }
+  .stat b { color: #e8e8e6; font-weight: 600; font-variant-numeric: tabular-nums; }
+  input[type=range] { width: 100%; }
+  #err { position: absolute; inset: 0; display: none; place-items: center; z-index: 3;
+         background: #0e0e10; color: #e0605a; padding: 40px; text-align: center; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div class="panel">
+  <h1>Search space over the cells</h1>
+  <p class="sub">Each level floats above the one below. Drag with the right button to tilt.</p>
+  <div id="levels"></div>
+  <hr>
+  <div class="row"><label><input type="checkbox" id="settled" checked>
+    <span class="sw" style="background:#6f8fd8"></span>settled nodes</label></div>
+  <div class="row"><label><input type="checkbox" id="packed" checked>
+    <span class="sw" style="background:#e0a33c"></span>the way, by level</label></div>
+  <div class="row"><label><input type="checkbox" id="column" checked>
+    <span class="sw" style="background:#7c6ba8"></span>drops to the ground</label></div>
+  <div class="row"><label><input type="checkbox" id="unpacked" checked>
+    <span class="sw" style="background:#e8503c"></span>the way through the graph</label></div>
+  <hr>
+  <div class="row"><label for="spread">level spacing</label></div>
+  <input type="range" id="spread" min="0" max="200" value="100">
+  <hr>
+  <div class="stat"><span>settled</span><b id="n-settled">-</b></div>
+  <div class="stat"><span>cells stepped over</span><b id="n-cells">-</b></div>
+  <div class="stat"><span>steps</span><b id="n-packed">-</b></div>
+  <div class="stat"><span>levels</span><b id="n-levels">-</b></div>
+</div>
+<div id="err"></div>
+
+<script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+<script>
+const source = new URLSearchParams(location.search).get('data') || 'search_space.geojson';
+
+const fail = message => {
+  const box = document.getElementById('err');
+  box.style.display = 'grid';
+  box.textContent = message;
+};
+
+// One hue per level, coarse levels warmer, so a glance says how high something
+// is without reading the panel.
+const LEVEL_COLOURS = ['#3f7fbf', '#3f9f9f', '#5fae5f', '#c9a83c', '#d1783c', '#c9503c', '#b03c8f'];
+const colourFor = level => LEVEL_COLOURS[Math.max(0, level) % LEVEL_COLOURS.length];
+
+fetch(source)
+  .then(r => r.ok ? r.json() : Promise.reject(new Error(`${source}: ${r.status}`)))
+  .then(draw)
+  .catch(e => fail(`${e.message}\n\nRun the search_space example to write it, and serve this directory over http.`));
+
+function draw(data) {
+  window.onerror = (m, _f, l) => fail(`${m} (line ${l})`);
+  // A map loads on an animation frame, and a tab that is hidden never runs
+  // one, so it would sit here for ever saying nothing about why.
+  if (document.hidden) {
+    setTimeout(() => {
+      if (!window.map || !window.map.isStyleLoaded()) {
+        fail('this tab is not visible, so the browser is not running animation '
+           + 'frames and the map cannot finish loading. Bring the window to the '
+           + 'front and reload.');
+      }
+    }, 4000);
+  }
+  const features = data.features || [];
+  if (!features.length) return fail('the file holds no features');
+
+  const of = kind => features.filter(f => f.properties.kind === kind);
+  const levels = [...new Set(features.map(f => f.properties.level))]
+    .filter(l => l >= 0).sort((a, b) => a - b);
+
+  document.getElementById('n-settled').textContent = of('settled').length.toLocaleString();
+  document.getElementById('n-cells').textContent = of('cell').length.toLocaleString();
+  document.getElementById('n-packed').textContent = of('packed').length.toLocaleString();
+  document.getElementById('n-levels').textContent = levels.length;
+
+  const bounds = new maplibregl.LngLatBounds();
+  for (const f of features) {
+    const walk = c => Array.isArray(c[0]) ? c.forEach(walk) : bounds.extend(c);
+    walk(f.geometry.coordinates);
+  }
+
+  const map = new maplibregl.Map({
+    container: 'map',
+    style: { version: 8, sources: {}, layers: [
+      { id: 'bg', type: 'background', paint: { 'background-color': '#0e0e10' } },
+    ]},
+    bounds, fitBoundsOptions: { padding: 90, pitch: 62, bearing: -22 },
+    maxPitch: 85,
+    antialias: true,
+  });
+  map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), 'top-right');
+  window.map = map;
+
+  // maplibre reports plenty that is not fatal, so this says so rather than
+  // taking the screen away from whatever is already drawn
+  map.on('error', e => console.warn('maplibre:', (e.error && e.error.message) || e));
+
+  map.on('load', () => {
+    map.addSource('space', { type: 'geojson', data });
+
+    // the sheets a level's cells are drawn as
+    map.addLayer({
+      id: 'cells', type: 'fill-extrusion', source: 'space',
+      filter: ['==', ['get', 'kind'], 'cell'],
+      paint: {
+        'fill-extrusion-color': ['case',
+          ...levels.flatMap(l => [['==', ['get', 'level'], l], colourFor(l)]), '#666'],
+        'fill-extrusion-base': ['get', 'base'],
+        'fill-extrusion-height': ['get', 'height'],
+        'fill-extrusion-opacity': 0.30,
+      },
+    });
+
+    // what the search took off its queue, at the height it took it
+    map.addLayer({
+      id: 'settled', type: 'circle', source: 'space',
+      filter: ['==', ['get', 'kind'], 'settled'],
+      paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 1.6, 10, 3.4],
+        'circle-color': ['case',
+          ['<', ['get', 'level'], 0], '#8d8d95',
+          ...levels.flatMap(l => [['==', ['get', 'level'], l], colourFor(l)]), '#888'],
+        'circle-opacity': 0.85,
+      },
+    });
+
+    // the way the search found, each step at its own level
+    map.addLayer({
+      id: 'packed', type: 'fill-extrusion', source: 'space',
+      filter: ['==', ['get', 'kind'], 'packed'],
+      paint: {
+        'fill-extrusion-color': '#e0a33c',
+        'fill-extrusion-base': ['get', 'base'],
+        'fill-extrusion-height': ['get', 'height'],
+        'fill-extrusion-opacity': 0.95,
+      },
+    });
+
+    // and the drop from each of its nodes to the ground
+    map.addLayer({
+      id: 'column', type: 'fill-extrusion', source: 'space',
+      filter: ['==', ['get', 'kind'], 'column'],
+      paint: {
+        'fill-extrusion-color': '#7c6ba8',
+        'fill-extrusion-base': ['get', 'base'],
+        'fill-extrusion-height': ['get', 'height'],
+        'fill-extrusion-opacity': 0.55,
+      },
+    });
+
+    // the way through the graph, on the ground, which is what all of it means
+    map.addLayer({
+      id: 'unpacked', type: 'line', source: 'space',
+      filter: ['==', ['get', 'kind'], 'unpacked'],
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-color': '#e8503c',
+        'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.2, 12, 5],
+      },
+    });
+
+    for (const [box, layer] of [['settled','settled'], ['packed','packed'],
+                                ['column','column'], ['unpacked','unpacked']]) {
+      document.getElementById(box).addEventListener('change', event => {
+        map.setLayoutProperty(layer, 'visibility', event.target.checked ? 'visible' : 'none');
+      });
+    }
+
+    // The levels are drawn where the file said, and this scales that. Pulling
+    // them together is how the way is read against the ground; pushing them
+    // apart is how a level with a lot in it is read on its own.
+    const spread = document.getElementById('spread');
+    spread.addEventListener('input', () => {
+      const factor = spread.value / 100;
+      for (const layer of ['cells', 'packed', 'column']) {
+        map.setPaintProperty(layer, 'fill-extrusion-base',
+          layer === 'column' ? ['get', 'base'] : ['*', ['get', 'base'], factor]);
+        map.setPaintProperty(layer, 'fill-extrusion-height', ['*', ['get', 'height'], factor]);
+      }
+    });
+
+    // one row per level, so a level can be looked at on its own
+    const rows = document.getElementById('levels');
+    for (const level of [...levels].reverse()) {
+      const row = document.createElement('div');
+      row.className = 'row';
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox'; box.checked = true;
+      const swatch = document.createElement('span');
+      swatch.className = 'sw'; swatch.style.background = colourFor(level);
+      const text = document.createElement('span');
+      text.textContent = `level ${level}`;
+      const count = document.createElement('span');
+      count.className = 'count';
+      count.textContent = features.filter(f => f.properties.level === level
+                                            && f.properties.kind === 'cell').length;
+      label.append(box, swatch, text);
+      row.append(label, count);
+      rows.append(row);
+      box.addEventListener('change', () => {
+        const shown = [...rows.querySelectorAll('input')]
+          .map((b, i) => b.checked ? [...levels].reverse()[i] : null)
+          .filter(l => l !== null);
+        const keep = ['in', ['get', 'level'], ['literal', shown]];
+        map.setFilter('cells', ['all', ['==', ['get', 'kind'], 'cell'], keep]);
+        map.setFilter('settled', ['all', ['==', ['get', 'kind'], 'settled'],
+          ['any', ['<', ['get', 'level'], 0], keep]]);
+      });
+    }
+  });
+}
+</script>
+</body>
+</html>

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -30,7 +30,7 @@
 
     python3 -m http.server 8000
     open http://localhost:8000/viewer/search_space.html?data=search_space.geojson
-    open http://localhost:8000/viewer/search_space.html?basemap=positron
+    open http://localhost:8000/viewer/search_space.html?basemap=dark
     open http://localhost:8000/viewer/search_space.html?basemap=off
 -->
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
@@ -86,12 +86,10 @@
 const asked = new URLSearchParams(location.search);
 const source = asked.get('data') || 'search_space.geojson';
 
-// Keyless OSM vector tiles. The dark one, because what is drawn over it is
-// pale and pale over pale is nothing: under the veil, positron comes out a
-// mid grey the marks have to fight, and this comes out a ground they sit on.
-// positron, liberty and bright are there to be asked for, and off is no
-// basemap at all.
-const BASEMAP = asked.get('basemap') || 'dark';
+// Keyless OSM vector tiles. positron is the grey one, meant to be built on.
+// dark, liberty and bright are there to be asked for with ?basemap=, and off
+// is no basemap at all.
+const BASEMAP = asked.get('basemap') || 'positron';
 const GROUND = '#0e0e10';
 const BARE = { version: 8, sources: {}, layers: [
   { id: 'bg', type: 'background', paint: { 'background-color': GROUND } },
@@ -317,7 +315,7 @@ function draw(data, ground) {
     kinds.append(toggle('the way through the graph', '#ece9e2',
       on => map.setLayoutProperty('unpacked', 'visibility', on ? 'visible' : 'none')));
     if (ground.base.length) {
-      kinds.append(toggle('the ground under it', '#4a4a52', on => {
+      kinds.append(toggle('the ground under it', '#b6b6bc', on => {
         for (const layer of [...ground.base, 'veil']) {
           map.setLayoutProperty(layer, 'visibility', on ? 'visible' : 'none');
         }

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -80,6 +80,7 @@ const RAISE = 230;
 // there is one paint block here and the file decides the rest.
 const LIFTED = [
   { id: 'cells',   kind: 'cell',    opacity: 0.32, label: null },
+  { id: 'links',   kind: 'link',    opacity: 0.85, label: 'cells it crossed between' },
   { id: 'relaxed', kind: 'relaxed', opacity: 0.7,  label: 'arcs it relaxed' },
   { id: 'reached', kind: 'reached', opacity: 0.8,  label: 'reached, not settled' },
   { id: 'settled', kind: 'settled', opacity: 0.95, label: 'settled' },
@@ -87,7 +88,7 @@ const LIFTED = [
   { id: 'riser',   kind: 'riser',   opacity: 0.9,  label: 'jumps between levels' },
 ];
 // what a level's checkbox hides, being everything that happened at a level
-const BY_LEVEL = ['cells', 'relaxed', 'reached', 'settled'];
+const BY_LEVEL = ['cells', 'links', 'relaxed', 'reached', 'settled'];
 
 const fail = message => {
   const box = document.getElementById('err');
@@ -124,6 +125,7 @@ function draw(data) {
   for (const [name, count] of [['settled', of('settled').length],
                                ['reached, not settled', of('reached').length],
                                ['arcs relaxed', of('relaxed').length],
+                               ['cells crossed between', of('link').length],
                                ['cells stepped over', of('cell').length],
                                ['steps', of('packed').length],
                                ['levels', levels.length]]) {

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -14,9 +14,11 @@
   ground to each cell it steps over and comes back down, so it can be followed
   end to end and every jump in it is a level the search changed at.
 
-  Nothing draws a line at a height. What a map draws at a height is a polygon
-  pushed up between two of them, so the steps and the risers were written out
-  as polygons already, each carrying the two heights it is drawn between.
+  Nothing draws a line or a point at a height. What a map draws at a height is
+  a polygon pushed up between two of them, so every mark here was written out
+  as a polygon already, each carrying the two heights it is drawn between and
+  the colour it is drawn in. Which is why there is so little in this file: the
+  thinking is upstream, and this only hands it to maplibre.
 
   There is no basemap. The tiles would say nothing this is about, and asking
   for them means asking somebody else's server for permission to look at your
@@ -31,7 +33,7 @@
                font: 13px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif; }
   #map { position: absolute; inset: 0; }
   .panel {
-    position: absolute; top: 12px; left: 12px; z-index: 2; width: 232px;
+    position: absolute; top: 12px; left: 12px; z-index: 2; width: 252px;
     background: #17171a; border: 1px solid #2b2b30; border-radius: 8px;
     padding: 12px 14px; box-shadow: 0 6px 24px rgba(0,0,0,.45);
   }
@@ -53,25 +55,15 @@
 <div id="map"></div>
 <div class="panel">
   <h1>Search space over the cells</h1>
-  <p class="sub">Each level floats above the one below. Drag with the right button to tilt.</p>
+  <p class="sub">A cell is a shade of the cell holding it. Drag with the right button to tilt.</p>
   <div id="levels"></div>
   <hr>
-  <div class="row"><label><input type="checkbox" id="settled" checked>
-    <span class="sw" style="background:#6f8fd8"></span>settled nodes</label></div>
-  <div class="row"><label><input type="checkbox" id="packed" checked>
-    <span class="sw" style="background:#e0a33c"></span>the way, by level</label></div>
-  <div class="row"><label><input type="checkbox" id="riser" checked>
-    <span class="sw" style="background:#7c6ba8"></span>jumps between levels</label></div>
-  <div class="row"><label><input type="checkbox" id="unpacked" checked>
-    <span class="sw" style="background:#e8503c"></span>the way through the graph</label></div>
+  <div id="kinds"></div>
   <hr>
   <div class="row"><label for="spread">level spacing</label></div>
   <input type="range" id="spread" min="0" max="200" value="100">
   <hr>
-  <div class="stat"><span>settled</span><b id="n-settled">-</b></div>
-  <div class="stat"><span>cells stepped over</span><b id="n-cells">-</b></div>
-  <div class="stat"><span>steps</span><b id="n-packed">-</b></div>
-  <div class="stat"><span>levels</span><b id="n-levels">-</b></div>
+  <div id="stats"></div>
 </div>
 <div id="err"></div>
 
@@ -79,20 +71,29 @@
 <script>
 const source = new URLSearchParams(location.search).get('data') || 'search_space.geojson';
 
+// How far the camera is lifted off the ground fit, in pixels, so that the
+// levels standing over it are on screen.
+const RAISE = 230;
+
+// Everything drawn but the way on the ground is a polygon pushed up between
+// two heights, and every one of them carries the colour it is drawn in, so
+// there is one paint block here and the file decides the rest.
+const LIFTED = [
+  { id: 'cells',   kind: 'cell',    opacity: 0.32, label: null },
+  { id: 'relaxed', kind: 'relaxed', opacity: 0.7,  label: 'arcs it relaxed' },
+  { id: 'reached', kind: 'reached', opacity: 0.8,  label: 'reached, not settled' },
+  { id: 'settled', kind: 'settled', opacity: 0.95, label: 'settled' },
+  { id: 'packed',  kind: 'packed',  opacity: 1,    label: 'the way, by level' },
+  { id: 'riser',   kind: 'riser',   opacity: 0.9,  label: 'jumps between levels' },
+];
+// what a level's checkbox hides, being everything that happened at a level
+const BY_LEVEL = ['cells', 'relaxed', 'reached', 'settled'];
+
 const fail = message => {
   const box = document.getElementById('err');
   box.style.display = 'grid';
   box.textContent = message;
 };
-
-// One hue per level, coarse levels warmer, so a glance says how high something
-// is without reading the panel.
-// How far the camera is lifted off the ground fit, in pixels, so that the
-// levels standing over it are on screen.
-const RAISE = 230;
-
-const LEVEL_COLOURS = ['#3f7fbf', '#3f9f9f', '#5fae5f', '#c9a83c', '#d1783c', '#c9503c', '#b03c8f'];
-const colourFor = level => LEVEL_COLOURS[Math.max(0, level) % LEVEL_COLOURS.length];
 
 fetch(source)
   .then(r => r.ok ? r.json() : Promise.reject(new Error(`${source}: ${r.status}`)))
@@ -119,10 +120,22 @@ function draw(data) {
   const levels = [...new Set(features.map(f => f.properties.level))]
     .filter(l => l >= 0).sort((a, b) => a - b);
 
-  document.getElementById('n-settled').textContent = of('settled').length.toLocaleString();
-  document.getElementById('n-cells').textContent = of('cell').length.toLocaleString();
-  document.getElementById('n-packed').textContent = of('packed').length.toLocaleString();
-  document.getElementById('n-levels').textContent = levels.length;
+  const stats = document.getElementById('stats');
+  for (const [name, count] of [['settled', of('settled').length],
+                               ['reached, not settled', of('reached').length],
+                               ['arcs relaxed', of('relaxed').length],
+                               ['cells stepped over', of('cell').length],
+                               ['steps', of('packed').length],
+                               ['levels', levels.length]]) {
+    const row = document.createElement('div');
+    row.className = 'stat';
+    const what = document.createElement('span');
+    what.textContent = name;
+    const many = document.createElement('b');
+    many.textContent = count.toLocaleString();
+    row.append(what, many);
+    stats.append(row);
+  }
 
   const bounds = new maplibregl.LngLatBounds();
   for (const f of features) {
@@ -153,55 +166,18 @@ function draw(data) {
   map.on('load', () => {
     map.addSource('space', { type: 'geojson', data });
 
-    // the sheets a level's cells are drawn as
-    map.addLayer({
-      id: 'cells', type: 'fill-extrusion', source: 'space',
-      filter: ['==', ['get', 'kind'], 'cell'],
-      paint: {
-        'fill-extrusion-color': ['case',
-          ...levels.flatMap(l => [['==', ['get', 'level'], l], colourFor(l)]), '#666'],
-        'fill-extrusion-base': ['get', 'base'],
-        'fill-extrusion-height': ['get', 'height'],
-        'fill-extrusion-opacity': 0.30,
-      },
-    });
-
-    // what the search took off its queue, at the height it took it
-    map.addLayer({
-      id: 'settled', type: 'circle', source: 'space',
-      filter: ['==', ['get', 'kind'], 'settled'],
-      paint: {
-        'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 1.6, 10, 3.4],
-        'circle-color': ['case',
-          ['<', ['get', 'level'], 0], '#8d8d95',
-          ...levels.flatMap(l => [['==', ['get', 'level'], l], colourFor(l)]), '#888'],
-        'circle-opacity': 0.85,
-      },
-    });
-
-    // the way the search found, each step at its own level
-    map.addLayer({
-      id: 'packed', type: 'fill-extrusion', source: 'space',
-      filter: ['==', ['get', 'kind'], 'packed'],
-      paint: {
-        'fill-extrusion-color': '#e0a33c',
-        'fill-extrusion-base': ['get', 'base'],
-        'fill-extrusion-height': ['get', 'height'],
-        'fill-extrusion-opacity': 0.95,
-      },
-    });
-
-    // and the jump where it changes level, joining the two heights
-    map.addLayer({
-      id: 'riser', type: 'fill-extrusion', source: 'space',
-      filter: ['==', ['get', 'kind'], 'riser'],
-      paint: {
-        'fill-extrusion-color': '#7c6ba8',
-        'fill-extrusion-base': ['get', 'base'],
-        'fill-extrusion-height': ['get', 'height'],
-        'fill-extrusion-opacity': 0.55,
-      },
-    });
+    for (const layer of LIFTED) {
+      map.addLayer({
+        id: layer.id, type: 'fill-extrusion', source: 'space',
+        filter: ['==', ['get', 'kind'], layer.kind],
+        paint: {
+          'fill-extrusion-color': ['get', 'colour'],
+          'fill-extrusion-base': ['get', 'base'],
+          'fill-extrusion-height': ['get', 'height'],
+          'fill-extrusion-opacity': layer.opacity,
+        },
+      });
+    }
 
     // the way through the graph, on the ground, which is what all of it means
     map.addLayer({
@@ -209,7 +185,7 @@ function draw(data) {
       filter: ['==', ['get', 'kind'], 'unpacked'],
       layout: { 'line-cap': 'round', 'line-join': 'round' },
       paint: {
-        'line-color': '#e8503c',
+        'line-color': ['get', 'colour'],
         'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.2, 12, 5],
       },
     });
@@ -221,12 +197,14 @@ function draw(data) {
     // and the camera is then lifted to put the levels in the picture.
     map.panBy([0, -RAISE], { duration: 0 });
 
-    for (const [box, layer] of [['settled','settled'], ['packed','packed'],
-                                ['riser','riser'], ['unpacked','unpacked']]) {
-      document.getElementById(box).addEventListener('change', event => {
-        map.setLayoutProperty(layer, 'visibility', event.target.checked ? 'visible' : 'none');
-      });
+    // one row per thing the search did, so any of it can be looked at alone
+    const kinds = document.getElementById('kinds');
+    for (const layer of LIFTED.filter(l => l.label)) {
+      kinds.append(toggle(layer.label, mean(of(layer.kind).map(f => f.properties.colour)),
+        on => map.setLayoutProperty(layer.id, 'visibility', on ? 'visible' : 'none')));
     }
+    kinds.append(toggle('the way through the graph', '#f2f2f0',
+      on => map.setLayoutProperty('unpacked', 'visibility', on ? 'visible' : 'none')));
 
     // The levels are drawn where the file said, and this scales that. Pulling
     // them together is how the way is read against the ground; pushing them
@@ -234,43 +212,68 @@ function draw(data) {
     const spread = document.getElementById('spread');
     spread.addEventListener('input', () => {
       const factor = spread.value / 100;
-      for (const layer of ['cells', 'packed', 'riser']) {
-        map.setPaintProperty(layer, 'fill-extrusion-base',
-          ['*', ['get', 'base'], factor]);
-        map.setPaintProperty(layer, 'fill-extrusion-height', ['*', ['get', 'height'], factor]);
+      for (const layer of LIFTED) {
+        map.setPaintProperty(layer.id, 'fill-extrusion-base', ['*', ['get', 'base'], factor]);
+        map.setPaintProperty(layer.id, 'fill-extrusion-height', ['*', ['get', 'height'], factor]);
       }
     });
 
-    // one row per level, so a level can be looked at on its own
+    // one row per level, so a level can be looked at on its own. The swatch is
+    // the middle of what that level's cells came out, there being no one
+    // colour for a level any more.
     const rows = document.getElementById('levels');
+    const shown = new Set(levels);
     for (const level of [...levels].reverse()) {
-      const row = document.createElement('div');
-      row.className = 'row';
-      const label = document.createElement('label');
-      const box = document.createElement('input');
-      box.type = 'checkbox'; box.checked = true;
-      const swatch = document.createElement('span');
-      swatch.className = 'sw'; swatch.style.background = colourFor(level);
-      const text = document.createElement('span');
-      text.textContent = `level ${level}`;
+      const cells = features.filter(f => f.properties.level === level
+                                      && f.properties.kind === 'cell');
+      const row = toggle(`level ${level}`, mean(cells.map(f => f.properties.colour)), on => {
+        if (on) { shown.add(level); } else { shown.delete(level); }
+        const keep = ['in', ['get', 'level'], ['literal', [...shown]]];
+        for (const id of BY_LEVEL) {
+          const kind = LIFTED.find(l => l.id === id).kind;
+          // what happened below the levels happened on the ground, and no
+          // level's checkbox owns it
+          map.setFilter(id, ['all', ['==', ['get', 'kind'], kind],
+            id === 'cells' ? keep : ['any', ['<', ['get', 'level'], 0], keep]]);
+        }
+      });
       const count = document.createElement('span');
       count.className = 'count';
-      count.textContent = features.filter(f => f.properties.level === level
-                                            && f.properties.kind === 'cell').length;
-      label.append(box, swatch, text);
-      row.append(label, count);
+      count.textContent = cells.length;
+      row.append(count);
       rows.append(row);
-      box.addEventListener('change', () => {
-        const shown = [...rows.querySelectorAll('input')]
-          .map((b, i) => b.checked ? [...levels].reverse()[i] : null)
-          .filter(l => l !== null);
-        const keep = ['in', ['get', 'level'], ['literal', shown]];
-        map.setFilter('cells', ['all', ['==', ['get', 'kind'], 'cell'], keep]);
-        map.setFilter('settled', ['all', ['==', ['get', 'kind'], 'settled'],
-          ['any', ['<', ['get', 'level'], 0], keep]]);
-      });
     }
   });
+}
+
+// a labelled checkbox with a colour beside it
+function toggle(label, colour, onChange) {
+  const row = document.createElement('div');
+  row.className = 'row';
+  const box = document.createElement('input');
+  box.type = 'checkbox'; box.checked = true;
+  const swatch = document.createElement('span');
+  swatch.className = 'sw'; swatch.style.background = colour;
+  const text = document.createElement('span');
+  text.textContent = label;
+  const wrap = document.createElement('label');
+  wrap.append(box, swatch, text);
+  row.append(wrap);
+  box.addEventListener('change', () => onChange(box.checked));
+  return row;
+}
+
+// the middle of a set of colours, for a swatch standing in for all of them
+function mean(colours) {
+  if (!colours.length) return '#777777';
+  const sum = [0, 0, 0];
+  for (const colour of colours) {
+    for (let band = 0; band < 3; band++) {
+      sum[band] += parseInt(colour.slice(1 + band * 2, 3 + band * 2), 16);
+    }
+  }
+  return '#' + sum.map(v => Math.round(v / colours.length)
+    .toString(16).padStart(2, '0')).join('');
 }
 </script>
 </body>

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -20,12 +20,18 @@
   the colour it is drawn in. Which is why there is so little in this file: the
   thinking is upstream, and this only hands it to maplibre.
 
-  There is no basemap. The tiles would say nothing this is about, and asking
-  for them means asking somebody else's server for permission to look at your
-  own data.
+  Under it all is an OpenStreetMap basemap, at half transparency so that it
+  says where without arguing with what is drawn over it. It comes from
+  openfreemap.org, which serves vector tiles of OSM without an account or a
+  key, and asking for it means asking somebody else's server for the ground
+  under whatever is on screen. `?basemap=off` does without, and the page draws
+  the same as it did before there was one; so does having no network, which is
+  the same case and is fallen back to rather than failed on.
 
     python3 -m http.server 8000
     open http://localhost:8000/viewer/search_space.html?data=search_space.geojson
+    open http://localhost:8000/viewer/search_space.html?basemap=positron
+    open http://localhost:8000/viewer/search_space.html?basemap=off
 -->
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
 <style>
@@ -77,7 +83,40 @@
 
 <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
 <script>
-const source = new URLSearchParams(location.search).get('data') || 'search_space.geojson';
+const asked = new URLSearchParams(location.search);
+const source = asked.get('data') || 'search_space.geojson';
+
+// Keyless OSM vector tiles. The dark one, because what is drawn over it is
+// pale and pale over pale is nothing: under the veil, positron comes out a
+// mid grey the marks have to fight, and this comes out a ground they sit on.
+// positron, liberty and bright are there to be asked for, and off is no
+// basemap at all.
+const BASEMAP = asked.get('basemap') || 'dark';
+const GROUND = '#0e0e10';
+const BARE = { version: 8, sources: {}, layers: [
+  { id: 'bg', type: 'background', paint: { 'background-color': GROUND } },
+]};
+
+// Half transparent is a veil of the page's own colour over the whole basemap
+// rather than every one of its fifty-five layers turned down by half. Turned
+// down one by one they show through one another -- a road at half over a
+// landuse at half is not half of the two -- and the result is uneven in a way
+// that reads as a rendering fault. One veil is even everywhere.
+async function groundFor() {
+  if (BASEMAP === 'off') return { style: BARE, base: [] };
+  try {
+    const style = await (await fetch(`https://tiles.openfreemap.org/styles/${BASEMAP}`)).json();
+    const base = style.layers.map(layer => layer.id);
+    style.layers.push({
+      id: 'veil', type: 'background',
+      paint: { 'background-color': GROUND, 'background-opacity': 0.5 },
+    });
+    return { style, base };
+  } catch (e) {
+    console.warn(`no basemap (${e.message}), carrying on without one`);
+    return { style: BARE, base: [] };
+  }
+}
 
 // How far the camera is lifted off the ground fit, in pixels, so that the
 // levels standing over it are on screen.
@@ -104,12 +143,14 @@ const fail = message => {
   box.textContent = message;
 };
 
-fetch(source)
-  .then(r => r.ok ? r.json() : Promise.reject(new Error(`${source}: ${r.status}`)))
-  .then(draw)
+Promise.all([
+  fetch(source).then(r => r.ok ? r.json() : Promise.reject(new Error(`${source}: ${r.status}`))),
+  groundFor(),
+])
+  .then(([data, ground]) => draw(data, ground))
   .catch(e => fail(`${e.message}\n\nRun the search_space example to write it, and serve this directory over http.`));
 
-function draw(data) {
+function draw(data, ground) {
   window.onerror = (m, _f, l) => fail(`${m} (line ${l})`);
   // A map loads on an animation frame, and a tab that is hidden never runs
   // one, so it would sit here for ever saying nothing about why.
@@ -155,9 +196,7 @@ function draw(data) {
 
   const map = new maplibregl.Map({
     container: 'map',
-    style: { version: 8, sources: {}, layers: [
-      { id: 'bg', type: 'background', paint: { 'background-color': '#0e0e10' } },
-    ]},
+    style: ground.style,
     bounds,
     fitBoundsOptions: {
       padding: { top: 90, bottom: 90, left: 330, right: 80 },
@@ -277,6 +316,13 @@ function draw(data) {
     }
     kinds.append(toggle('the way through the graph', '#ece9e2',
       on => map.setLayoutProperty('unpacked', 'visibility', on ? 'visible' : 'none')));
+    if (ground.base.length) {
+      kinds.append(toggle('the ground under it', '#4a4a52', on => {
+        for (const layer of [...ground.base, 'veil']) {
+          map.setLayoutProperty(layer, 'visibility', on ? 'visible' : 'none');
+        }
+      }));
+    }
 
     // The levels are drawn where the file said, and this scales that. Pulling
     // them together is how the way is read against the ground; pushing them

--- a/viewer/search_space.html
+++ b/viewer/search_space.html
@@ -87,6 +87,10 @@ const fail = message => {
 
 // One hue per level, coarse levels warmer, so a glance says how high something
 // is without reading the panel.
+// How far the camera is lifted off the ground fit, in pixels, so that the
+// levels standing over it are on screen.
+const RAISE = 230;
+
 const LEVEL_COLOURS = ['#3f7fbf', '#3f9f9f', '#5fae5f', '#c9a83c', '#d1783c', '#c9503c', '#b03c8f'];
 const colourFor = level => LEVEL_COLOURS[Math.max(0, level) % LEVEL_COLOURS.length];
 
@@ -131,7 +135,11 @@ function draw(data) {
     style: { version: 8, sources: {}, layers: [
       { id: 'bg', type: 'background', paint: { 'background-color': '#0e0e10' } },
     ]},
-    bounds, fitBoundsOptions: { padding: 90, pitch: 62, bearing: -22 },
+    bounds,
+    fitBoundsOptions: {
+      padding: { top: 90, bottom: 90, left: 330, right: 80 },
+      pitch: 62, bearing: -22,
+    },
     maxPitch: 85,
     antialias: true,
   });
@@ -205,6 +213,13 @@ function draw(data) {
         'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.2, 12, 5],
       },
     });
+
+    // Fitting the bounds frames the ground, and everything else stands
+    // hundreds of kilometres over it, which on a tilted map is straight up the
+    // screen. Padding the fit would only zoom out again -- it shrinks the
+    // viewport it fits into -- so the ground is fitted at the size it wants
+    // and the camera is then lifted to put the levels in the picture.
+    map.panBy([0, -RAISE], { duration: 0 });
 
     for (const [box, layer] of [['settled','settled'], ['packed','packed'],
                                 ['column','column'], ['unpacked','unpacked']]) {


### PR DESCRIPTION
Stacked on #600, which it needs for `path_unpacking`. Review that one first;
this diff is against it.

## What changes

### New

- `examples/search_space.rs` — runs a query and writes one GeoJSON of what it
  looked at. `search_space <graph> <directory> <coordinates> <source> <target> <out.geojson>`
- `viewer/search_space.html` — a MapLibre page that draws it. No build step,
  no bundler.
- `viewer/README.md`

### Changed signatures

| before | after |
|---|---|
| — | `heap_stats::Frontier<Node>` with `settled(&self) -> &[Node]` and `reached(&self) -> &[Node]` |
| — | `MldSearch::parent(&self, NodeID) -> Option<NodeID>` |

`Frontier` is a `HeapStats` collector like `SettledNodes`, keeping what went
onto the queue as well as what came off. `parent` hands back the node a
reached node was reached from, which the queue already held for
`retrieve_packed_path` to walk.

### Behaviour

No search changes. Nothing was added to a heap entry and no branch to a
relaxation; `Frontier` is only paid for by a caller that asks for it.

## What the file holds

One feature collection. Every feature carries `kind`, `level`, `colour`, the
`step` of the search it happened at, and the two heights it is drawn between.

| `kind` | what it is |
|---|---|
| `cell` | the outline of a cell the search stepped over |
| `link` | two cells of a level the search crossed between |
| `relaxed` | an arc the search relaxed and kept |
| `reached` | a node it put on its queue and never took off |
| `settled` | a node it took off its queue |
| `packed` | the way a step stands for, at the step's height |
| `riser` | where the way changes level, drawn upright |
| `unpacked` | the whole way through the graph, on the ground |

Everything but `unpacked` is a polygon. Nothing draws a line or a point at a
height: what a map draws at a height is a polygon pushed up between two of
them. So a step is widened into a ribbon about its own direction, a node is a
footprint pushed up, and a dashed link has its gaps cut in the emitter. The
heights and the colours are worked out in Rust, which leaves the viewer one
paint block for the six extruded layers.

## Decisions worth flagging

**A step is drawn as the way it stands for, not as the line between its ends.**
A step over a coarse cell is a straight line across a country and the way
beneath it runs where the roads run. Which arcs a step stands for is not asked
again: the way was put back by laying the steps end to end, so it comes apart
at the nodes the search handed over. Checked — 36 steps covering exactly the
172 arcs of a 173 node way, no gaps and nothing counted twice.

**An arc of the overlay is drawn straight, unlike the way.** A step of the way
is a path through a cell. An arc is an entry in a table between two border
nodes, and a straight line is what that is.

**Which cells are next to each other is not asked of the partition.** An arc
whose ends sit at one level in two different cells is the search leaving one
and entering the other, so the arcs already gathered say it.

**A cell is coloured by descent.** A hue within a span of its parent's, the
span narrowing by .48 a level, so cells of one parent come out near one
another. Level is carried by lightness. Everything the search did inside a
cell takes that cell's hue at its own strength: sheet .42, reached .34, arcs
.50, settled .68, way .82. A crossing is white, being of neither cell it
joins.

**Every mark is extruded.** A `circle` layer draws on the ground whatever
height it is given, so the settled nodes had been lying flat while claiming a
level.

**The basemap is the only part that leaves the machine.** OSM vector tiles
from openfreemap.org, no account or key, veiled by half in the page's own
colour — one veil rather than fifty-five layers turned down, which comes out
uneven. Fetched before the map is built rather than by it: without it the page
draws on the same plain dark ground as before. `?basemap=` picks a style,
`?basemap=off` does without.

## Measurements

europe.ptv, source 11655526 to target 11840216, rank 2^18, boundary directory.
1,037 settled of 1,575 reached, 1,574 arcs relaxed, 50 cells stepped over, 55
pairs of cells crossed between of which 54 join two drawn cells, 36 steps,
173 nodes once put back, costing 43,666. 3,301 features, 1.1 MB.

The same query against the unbalanced directory gives 977 settled and 23
steps — and the same way at the same cost, which is a free check that the two
partitions agree on the answer.

## What it leaves for later

- **Cell outlines are convex hulls**, and a coarse cell is nowhere near convex,
  so the coarse sheets cover far more than the cells do. `alpha_shape` is in
  the crate.
- **A riser is upright** because a polygon has one footprint, so nothing can
  move sideways and up at once. A sloped one needs a custom WebGL layer.
- **`LEVEL_HEIGHT` is a constant** tuned for a continent. On an 85 km route the
  stack runs off the top and the spacing slider has to be pulled down; it
  should come from the extent of what is drawn.