### PR TITLE
Rework Level construction: shared border table, partition lookups, flat arrays

### DIFF
--- a/benches/benchmarks/mld_query.rs
+++ b/benches/benchmarks/mld_query.rs
@@ -113,7 +113,7 @@ pub fn customization_benchmark(c: &mut Criterion) {
                 },
                 |customization| {
                     for level in 0..levels {
-                        let cells = customization.level(level).nodes_of_cell.len();
+                        let cells = customization.level(level).cells();
                         for cell in 0..cells {
                             black_box(customization.distances_of(level, cell as u32));
                         }

--- a/examples/customize.rs
+++ b/examples/customize.rs
@@ -81,26 +81,28 @@ fn main() {
         ARCS[level].fetch_add(report.arcs as u64, Ordering::Relaxed);
     });
     println!(
-        "{:>5} {:>8} {:>9} {:>12} {:>8} {:>9} {:>9} {:>8} {:>8} {:>6}",
-        "level", "cells", "entries", "arcs", "V", "wall", "search", "build", "b/V", "build%"
+        "{:>5} {:>8} {:>9} {:>6} {:>7} {:>7} {:>7} {:>10} {:>10} {:>9}",
+        "level", "cells", "entries", "V", "wall", "search", "build", "tables", "levelled", "a cell"
     );
 
     let mut whole = std::time::Duration::ZERO;
     let mut all_entries = 0usize;
+    let mut all_bytes = 0usize;
     for level in 0..levels {
         let cells = customization.cells_on_level(level);
         let started = Instant::now();
         let of_cell = |cell: usize| {
             customization
                 .distances_of(level, cell as u32)
-                .map_or((0, 0, 0), |distances| {
+                .map_or((0, 0, 0, 0), |distances| {
                     let wide = distances.border_nodes.len();
-                    (1, wide, wide * wide)
+                    (1, wide, wide * wide, distances.bytes())
                 })
         };
-        let add =
-            |a: (usize, usize, usize), b: (usize, usize, usize)| (a.0 + b.0, a.1 + b.1, a.2 + b.2);
-        let (tabulated, border, entries) = if parallel {
+        let add = |a: (usize, usize, usize, usize), b: (usize, usize, usize, usize)| {
+            (a.0 + b.0, a.1 + b.1, a.2 + b.2, a.3 + b.3)
+        };
+        let (tabulated, border, entries, bytes) = if parallel {
             // Widest cell first.
             //
             // A level is handed out a cell to a thread, and the coarsest level
@@ -115,9 +117,12 @@ fn main() {
             order.sort_unstable_by_key(|&cell| {
                 std::cmp::Reverse(holding.nodes_of(cell as u32).len())
             });
-            order.into_par_iter().map(of_cell).reduce(|| (0, 0, 0), add)
+            order
+                .into_par_iter()
+                .map(of_cell)
+                .reduce(|| (0, 0, 0, 0), add)
         } else {
-            (0..cells).map(of_cell).fold((0, 0, 0), add)
+            (0..cells).map(of_cell).fold((0, 0, 0, 0), add)
         };
         let elapsed = started.elapsed();
         whole += elapsed;
@@ -126,15 +131,20 @@ fn main() {
         let searching = SEARCHING[level].load(Ordering::Relaxed) as f64 / 1e9;
         let searched = NODES[level].load(Ordering::Relaxed);
         let arcs = ARCS[level].load(Ordering::Relaxed);
+        let holding = customization.level(level).bytes();
+        all_bytes += bytes + holding;
         println!(
-            "{level:>5} {cells:>8} {entries:>9} {arcs:>12} {:>8} {:>9} {:>9} {:>8} {:>8} {:>5.0}%",
+            "{level:>5} {cells:>8} {entries:>9} {:>6} {:>7} {:>7} {:>7} {:>10} {:>10} {:>9}",
             searched / tabulated.max(1) as u64,
             format!("{:.2}s", elapsed.as_secs_f64()),
             format!("{searching:.2}s"),
             format!("{building:.2}s"),
-            format!("{:.2}", border as f64 / searched.max(1) as f64),
-            100.0 * building / (building + searching).max(1e-9),
+            in_bytes(bytes),
+            in_bytes(holding),
+            in_bytes(bytes / tabulated.max(1)),
         );
+        // the arcs and the border nodes are counted for whoever wants them
+        debug_assert!(arcs >= border as u64 || border == 0);
         // a level is built out of the one below, so the ones below a level
         // asked for are worked out and reported on the way up to it
         if only.is_some_and(|wanted| wanted == level) {
@@ -142,10 +152,34 @@ fn main() {
         }
     }
 
+    // one table of borders for the whole partition rather than one a level
+    let shared = customization.directory().number_of_nodes();
     println!(
         "customized {} cells in {:.2?}, {all_entries} entries, {:.0} entries a second",
         customization.customized_cells(),
         whole,
         all_entries as f64 / whole.as_secs_f64()
     );
+    println!(
+        "holding {} in all: {} of tables and levels, {} of borders shared by every level",
+        in_bytes(all_bytes + shared),
+        in_bytes(all_bytes),
+        in_bytes(shared)
+    );
+}
+
+/// A count of bytes, in whichever unit says it in fewest digits.
+fn in_bytes(count: usize) -> String {
+    const STEPS: [(f64, &str); 4] = [
+        (1024.0 * 1024.0 * 1024.0, "GiB"),
+        (1024.0 * 1024.0, "MiB"),
+        (1024.0, "KiB"),
+        (1.0, "B"),
+    ];
+    for (size, name) in STEPS {
+        if count as f64 >= size {
+            return format!("{:.1} {name}", count as f64 / size);
+        }
+    }
+    format!("{count} B")
 }

--- a/examples/customize.rs
+++ b/examples/customize.rs
@@ -112,8 +112,9 @@ fn main() {
             // as many numbers as the level has cells.
             let holding = customization.level(level);
             let mut order: Vec<usize> = (0..cells).collect();
-            order
-                .sort_unstable_by_key(|&cell| std::cmp::Reverse(holding.nodes_of_cell[cell].len()));
+            order.sort_unstable_by_key(|&cell| {
+                std::cmp::Reverse(holding.nodes_of(cell as u32).len())
+            });
             order.into_par_iter().map(of_cell).reduce(|| (0, 0, 0), add)
         } else {
             (0..cells).map(of_cell).fold((0, 0, 0), add)

--- a/examples/on_demand.rs
+++ b/examples/on_demand.rs
@@ -1,0 +1,105 @@
+//! What a query costs when nothing has been worked out yet.
+//!
+//! ```text
+//! on_demand <graph> <directory> <source> <target> [queries]
+//! ```
+//!
+//! The overlay is worked out as it is asked for: nothing is customized when
+//! the instance is built, and a cell is tabulated the first time a search
+//! wants it. So an instance is ready as soon as its files are read, and the
+//! cost of customizing is spread over the queries that turn out to need it.
+//!
+//! What that leaves is a first query that pays for everything it touches, and
+//! this says how much: how long the instance takes to build, what the first
+//! query costs against the hundredth, and how many cells each one had to work
+//! out before it could answer.
+
+use std::{env::args, time::Instant};
+
+use toolbox_rs::{
+    customization::Customization, io, level_directory::LevelDirectory, mld_query::MldQuery,
+    static_graph::StaticGraph,
+};
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!(
+                "usage: on_demand <graph> <directory> <source> <target> [queries]: missing {what}"
+            )
+        })
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let source: usize = next("source").parse().expect("a source node");
+    let target: usize = next("target").parse().expect("a target node");
+    let queries: usize = argv
+        .next()
+        .map_or(100, |count| count.parse().expect("a count"));
+
+    let reading = Instant::now();
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    let read = reading.elapsed();
+
+    // what the instance costs to stand up, which is what a startup pays
+    let building = Instant::now();
+    let customization = Customization::new(graph, directory);
+    let built = building.elapsed();
+    println!(
+        "read the files in {read:.2?}, stood the instance up in {built:.2?}, \
+         {} cells customized so far",
+        customization.customized_cells()
+    );
+
+    // What a level costs to work out, apart from the cells of it.
+    //
+    // A cell is tabulated on demand, but the cells of a level are not: the
+    // first cell of a level anyone asks for works out which cell every node of
+    // the graph sits in, which nodes each cell holds, and which of them sit on
+    // a border, and the last of those walks every arc there is. So a query
+    // that reaches the coarsest level pays that six times over before it
+    // tabulates anything at all.
+    if std::env::var("TOOLBOX_TIME_LEVELS").is_ok() {
+        let mut whole = std::time::Duration::ZERO;
+        for level in 0..customization.directory().levels() {
+            let started = Instant::now();
+            let cells = customization.level(level);
+            let elapsed = started.elapsed();
+            whole += elapsed;
+            println!(
+                "  level {level}: {:>8} for {} cells, {} of the nodes on a border",
+                format!("{elapsed:.2?}"),
+                cells.cells(),
+                (0..cells.of_node.len())
+                    .filter(|&node| cells.on_border(node))
+                    .count()
+            );
+        }
+        println!("  the levels alone: {whole:.2?}");
+    }
+
+    let mut query = MldQuery::new();
+    let mut before = 0;
+    for round in 0..queries {
+        query.clear();
+        let started = Instant::now();
+        let reached = query.run(&customization, source, &[target]);
+        let elapsed = started.elapsed();
+        let cells = customization.customized_cells();
+        // the first few are the ones worth naming, and then every hundredth
+        if round < 4 || (round + 1) % 100 == 0 || round + 1 == queries {
+            println!(
+                "query {:>4}: {:>9} {:>7} cells worked out, {} in all{}",
+                round + 1,
+                format!("{elapsed:.2?}"),
+                cells - before,
+                cells,
+                if reached { "" } else { ", target not reached" }
+            );
+        }
+        before = cells;
+    }
+}

--- a/examples/search_space.rs
+++ b/examples/search_space.rs
@@ -237,7 +237,7 @@ fn main() {
             .entry(*level)
             .or_insert_with(|| customization.level(*level))
             .clone();
-        let nodes = &holding.nodes_of_cell[*cell as usize];
+        let nodes = holding.nodes_of(*cell);
         let step = (nodes.len() / HULL_SAMPLE).max(1);
         let points: Vec<FPCoordinate> = nodes
             .iter()

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -24,12 +24,13 @@ use crate::{
     static_graph::StaticGraph,
 };
 use log::debug;
+use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 use std::{
     cell::RefCell,
     sync::{
         Arc, Mutex, OnceLock,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -212,15 +213,49 @@ pub(crate) fn distances_within_cell(
 /// them holds, and which of those nodes sit on a border.
 pub struct Level {
     pub of_node: Vec<CellId>,
-    pub nodes_of_cell: Vec<Vec<NodeID>>,
-    /// A node is on the border of its cell while an arc leaves it or reaches it
-    /// from outside. Both count: a road network is directed, and a node that
-    /// can only be entered from another cell is a way in that a path through
-    /// the cell above may take.
-    pub on_border: Vec<bool>,
+    /// The nodes of every cell laid end to end, and where each cell starts in
+    /// them.
+    ///
+    /// A vector per cell was a vector per cell: the finest level of a
+    /// continent has half a million of them holding some thirty numbers each,
+    /// and asking for half a million small pieces of room was the greater part
+    /// of what working the level out cost. One run of numbers and one of
+    /// offsets is the same answer, read the same way, in two allocations.
+    starts: Vec<u32>,
+    nodes: Vec<NodeID>,
+    /// The highest level at which each node sits on a border, plus one, shared
+    /// with every other level of the partition.
+    border: Arc<Vec<u8>>,
+    /// which level this is, to read `border` against
+    level: usize,
     /// the cells of the level below that each cell of this one is built out of,
     /// and empty on the finest level, which is built from the graph itself
     pub built_from: Vec<Vec<CellId>>,
+}
+
+impl Level {
+    /// How many cells the level holds.
+    #[must_use]
+    pub fn cells(&self) -> usize {
+        self.starts.len() - 1
+    }
+
+    /// The nodes of a cell, in increasing order.
+    #[must_use]
+    pub fn nodes_of(&self, cell: CellId) -> &[NodeID] {
+        let from = self.starts[cell as usize] as usize;
+        let to = self.starts[cell as usize + 1] as usize;
+        &self.nodes[from..to]
+    }
+
+    /// Whether a node sits on the border of its cell, an arc leaving it or
+    /// reaching it from outside. Both count: a road network is directed, and a
+    /// node that can only be entered from another cell is a way in that a path
+    /// through the cell above may take.
+    #[must_use]
+    pub fn on_border(&self, node: NodeID) -> bool {
+        self.border[node] as usize > self.level
+    }
 }
 
 /// What is called with each cell as it is worked out.
@@ -438,6 +473,16 @@ pub struct Customization {
     /// This is what a query asks per settled node, and the reason it is here
     /// rather than built per run is that it costs a walk of the whole graph.
     partition: OnceLock<PackedPartition>,
+    /// The highest level at which each node sits on a border, plus one, and
+    /// zero for a node no arc ever leaves.
+    ///
+    /// One walk of the arcs answers it for every level at once. Which level
+    /// two nodes part at is a question the packed partition answers from their
+    /// two words, and they part at every level below the coarsest one they
+    /// part at, so one number a node says the whole of it. It was a walk of
+    /// all forty-two million arcs per level, six times over, filling six
+    /// tables of eighteen million bytes.
+    border_of_node: OnceLock<Arc<Vec<u8>>>,
     /// The level each arc of the graph leaves a cell at, worked out on the
     /// first request for it. This is what a query reads instead of asking the
     /// partition about the far end of every arc it looks at.
@@ -474,6 +519,7 @@ impl Customization {
             report: None,
             tabulated,
             partition: OnceLock::new(),
+            border_of_node: OnceLock::new(),
             border_levels: OnceLock::new(),
             customized_cells: AtomicUsize::new(0),
             customization_nanos: AtomicU64::new(0),
@@ -561,6 +607,45 @@ impl Customization {
     }
 
     /// The cells of a level, worked out on the first request for it and kept.
+    /// The highest level at which each node sits on a border, plus one.
+    ///
+    /// Walked once, whichever level asks for it first, and read by all of
+    /// them. Two nodes an arc joins part at some coarsest level and at every
+    /// level below it, so the coarsest is the whole answer for that arc, and
+    /// the largest over the arcs of a node is the whole answer for the node.
+    fn border_of_node(&self) -> &Arc<Vec<u8>> {
+        self.border_of_node.get_or_init(|| {
+            let partition = self.partition();
+            // An arc puts both of its ends on a border, so a node is written
+            // by whichever thread holds the arc rather than by the one holding
+            // the node, and the two collide. A byte a node taken to the
+            // largest offered settles it without a lock: what comes out does
+            // not depend on the order the offers arrive in, so relaxed is
+            // enough.
+            let highest: Vec<AtomicU8> = (0..self.directory.number_of_nodes())
+                .map(|_| AtomicU8::new(0))
+                .collect();
+            self.graph.node_range().into_par_iter().for_each(|source| {
+                let word = partition.word(source);
+                for edge in self.graph.edge_range(source) {
+                    let target = self.graph.target(edge);
+                    // an arc that stays inside every cell it is in puts
+                    // neither of its ends on a border
+                    let Some(parting) =
+                        partition.highest_different_level(word, partition.word(target))
+                    else {
+                        continue;
+                    };
+                    // plus one, so that nought means no arc ever left
+                    let reached = u8::try_from(parting + 1).expect("more levels than a byte holds");
+                    highest[source].fetch_max(reached, Ordering::Relaxed);
+                    highest[target].fetch_max(reached, Ordering::Relaxed);
+                }
+            });
+            Arc::new(highest.into_iter().map(AtomicU8::into_inner).collect())
+        })
+    }
+
     pub fn level(&self, level: usize) -> Arc<Level> {
         if let Some(cells) = self
             .levels
@@ -571,32 +656,41 @@ impl Customization {
             return cells.clone();
         }
 
+        // Read off the packed partition rather than the directory. The
+        // directory holds a cell per node and a parent per cell per level, so
+        // it answers by walking up as many parent tables as the level is high,
+        // which is six random reads a node on the coarsest level of six. The
+        // partition holds the whole ancestry of a node in one word, where the
+        // cell at a level is a shift and a mask.
+        let partition = self.partition();
         let of_node = (0..self.directory.number_of_nodes())
-            .map(|node| self.directory.cell_of(node, level))
+            .into_par_iter()
+            .map(|node| partition.cell_in(partition.word(node), level))
             .collect::<Vec<_>>();
-        let mut nodes_of_cell: Vec<Vec<NodeID>> =
-            vec![Vec::new(); self.directory.cells_on_level(level)];
-        for (node, &cell) in of_node.iter().enumerate() {
-            nodes_of_cell[cell as usize].push(node as NodeID);
-        }
 
-        // one walk of the arcs marks both ends of every arc that leaves a cell,
-        // which saves holding the arcs of the graph the other way round
-        let mut on_border = vec![false; of_node.len()];
-        for source in self.graph.node_range() {
-            for edge in self.graph.edge_range(source) {
-                let target = self.graph.target(edge);
-                if of_node[source] != of_node[target] {
-                    on_border[source] = true;
-                    on_border[target] = true;
-                }
-            }
+        // The nodes of each cell, counted and then placed, which leaves them
+        // in increasing order within a cell. That order is relied on: the
+        // border nodes of a cell lead its numbering in the order they are met
+        // here, and a table is addressed by that numbering.
+        let count = self.directory.cells_on_level(level);
+        let mut starts = vec![0u32; count + 1];
+        for &cell in &of_node {
+            starts[cell as usize + 1] += 1;
+        }
+        for cell in 0..count {
+            starts[cell + 1] += starts[cell];
+        }
+        let mut filled = starts.clone();
+        let mut nodes = vec![0 as NodeID; of_node.len()];
+        for (node, &cell) in of_node.iter().enumerate() {
+            nodes[filled[cell as usize] as usize] = node as NodeID;
+            filled[cell as usize] += 1;
         }
 
         let built_from = if level == 0 {
             Vec::new()
         } else {
-            let mut children = vec![Vec::new(); self.directory.cells_on_level(level)];
+            let mut children = vec![Vec::new(); count];
             for (below, &above) in self
                 .directory
                 .parents_on_level(level - 1)
@@ -610,8 +704,10 @@ impl Customization {
 
         let cells = Arc::new(Level {
             of_node,
-            nodes_of_cell,
-            on_border,
+            starts,
+            nodes,
+            border: self.border_of_node().clone(),
+            level,
             built_from,
         });
         // another thread may have worked the same level out while this one
@@ -659,14 +755,17 @@ impl Customization {
         // the building being the part that asks for the room
         let mut scratch = SCRATCH.with_borrow_mut(Vec::pop).unwrap_or_default();
         let building = Instant::now();
-        let nodes = cells.nodes_of_cell.get(cell as usize)?;
+        if cell as usize >= cells.cells() {
+            return None;
+        }
+        let nodes = cells.nodes_of(cell);
 
         // the border nodes lead the numbering, so that they are the leading
         // rows and columns of the matrix
         scratch.border_nodes.clear();
         scratch
             .border_nodes
-            .extend(nodes.iter().copied().filter(|&node| cells.on_border[node]));
+            .extend(nodes.iter().copied().filter(|&node| cells.on_border(node)));
         if scratch.border_nodes.is_empty() {
             debug!("cell {cell} of level {level} has no border nodes");
             SCRATCH.with_borrow_mut(|pool| pool.push(scratch));
@@ -825,9 +924,10 @@ impl Customization {
 
         // the border nodes of this cell lead the numbering, the border nodes of
         // the cells below follow
-        for &node in cells.nodes_of_cell[cell as usize]
+        for &node in cells
+            .nodes_of(cell)
             .iter()
-            .filter(|&&node| cells.on_border[node])
+            .filter(|&&node| cells.on_border(node))
         {
             of_node.insert(node, of_node.len());
         }
@@ -858,8 +958,8 @@ impl Customization {
 
         // the arcs that cross from one cell below into another one of this cell
         for &child in &cells.built_from[cell as usize] {
-            for &node in &below.nodes_of_cell[child as usize] {
-                if !below.on_border[node] {
+            for &node in below.nodes_of(child) {
+                if !below.on_border(node) {
                     continue;
                 }
                 for edge in self.graph.edge_range(node) {
@@ -1089,8 +1189,8 @@ mod tests {
         let customization = Customization::new(StaticGraph::new(edges), directory);
 
         let cells = customization.level(0);
-        assert!(cells.on_border[0], "the node the arc leaves");
-        assert!(cells.on_border[1], "the node the arc reaches");
+        assert!(cells.on_border(0), "the node the arc leaves");
+        assert!(cells.on_border(1), "the node the arc reaches");
     }
 
     #[test]
@@ -1233,17 +1333,17 @@ mod tests {
         let customization = grid(8);
         let cells = customization.level(1);
 
-        for cell in 0..cells.nodes_of_cell.len() as CellId {
+        for cell in 0..cells.cells() as CellId {
             let Some(built_up) = customization.distances_of(1, cell) else {
                 continue;
             };
 
             // the same cell, searched over its own nodes instead
-            let nodes = &cells.nodes_of_cell[cell as usize];
+            let nodes = &cells.nodes_of(cell);
             let border = nodes
                 .iter()
                 .copied()
-                .filter(|&node| cells.on_border[node])
+                .filter(|&node| cells.on_border(node))
                 .collect::<Vec<_>>();
             let mut scratch = Scratch {
                 border_nodes: border.clone(),
@@ -1277,15 +1377,15 @@ mod tests {
         let cells = customization.level(1);
 
         let mut asymmetric = 0;
-        for cell in 0..cells.nodes_of_cell.len() as CellId {
+        for cell in 0..cells.cells() as CellId {
             let Some(built_up) = customization.distances_of(1, cell) else {
                 continue;
             };
-            let nodes = &cells.nodes_of_cell[cell as usize];
+            let nodes = &cells.nodes_of(cell);
             let border = nodes
                 .iter()
                 .copied()
-                .filter(|&node| cells.on_border[node])
+                .filter(|&node| cells.on_border(node))
                 .collect::<Vec<_>>();
             let mut scratch = Scratch {
                 border_nodes: border.clone(),
@@ -1394,8 +1494,9 @@ mod tests {
     fn a_cell_holds_the_nodes_the_directory_puts_in_it() {
         let customization = grid(8);
         let cells = customization.level(0);
-        assert_eq!(cells.nodes_of_cell.len(), 16, "squares of two by two");
-        for (cell, nodes) in cells.nodes_of_cell.iter().enumerate() {
+        assert_eq!(cells.cells(), 16, "squares of two by two");
+        for cell in 0..cells.cells() {
+            let nodes = cells.nodes_of(cell as CellId);
             assert_eq!(nodes.len(), 4);
             for &node in nodes {
                 assert_eq!(cells.of_node[node] as usize, cell);

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -76,6 +76,21 @@ pub struct CellDistances {
 }
 
 impl CellDistances {
+    /// What the table takes up, near enough to count with.
+    ///
+    /// The three runs of numbers are exact. The map of places is not: it is
+    /// asked how much room it took rather than how much it uses, and a hash
+    /// map keeps room for more than it holds, so what is counted for it is
+    /// that room at a key, a value and a byte of tag apiece.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>()
+            + self.border_nodes.capacity() * size_of::<u32>()
+            + self.matrix.capacity() * size_of::<u32>()
+            + self.transposed.capacity() * size_of::<u32>()
+            + self.place_of.capacity() * (size_of::<NodeID>() + size_of::<usize>() + 1)
+    }
+
     /// Holds a table and the same table with rows and columns swapped.
     ///
     /// `matrix` is by row: entry `source * width + target` is what it costs to
@@ -246,6 +261,25 @@ impl Level {
         let from = self.starts[cell as usize] as usize;
         let to = self.starts[cell as usize + 1] as usize;
         &self.nodes[from..to]
+    }
+
+    /// What the level takes up, apart from the tables of its cells.
+    ///
+    /// The table of borders is left out, being one table for the whole
+    /// partition rather than one a level, and counted by whoever asks about
+    /// the partition instead.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>()
+            + self.of_node.capacity() * size_of::<CellId>()
+            + self.starts.capacity() * size_of::<u32>()
+            + self.nodes.capacity() * size_of::<NodeID>()
+            + self.built_from.capacity() * size_of::<Vec<CellId>>()
+            + self
+                .built_from
+                .iter()
+                .map(|children| children.capacity() * size_of::<CellId>())
+                .sum::<usize>()
     }
 
     /// Whether a node sits on the border of its cell, an arc leaving it or

--- a/src/sound/bin/main.rs
+++ b/src/sound/bin/main.rs
@@ -58,10 +58,13 @@ struct LevelCheck {
 
 fn check_level(customization: &mut Customization, level: usize, keep: usize) -> LevelCheck {
     let cells = customization.level(level);
-    let count = cells.nodes_of_cell.len();
+    let count = cells.cells();
     info!(
         "checking {count} cells of level {level}, the largest holding {} nodes",
-        cells.nodes_of_cell.iter().map(Vec::len).max().unwrap_or(0)
+        (0..cells.cells())
+            .map(|cell| cells.nodes_of(cell as u32).len())
+            .max()
+            .unwrap_or(0)
     );
 
     let bar = ProgressBar::new(count as u64);
@@ -152,7 +155,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         info!(
             "level {level}: checked {} pairs over {} cells, leaving out {} that hold no border node",
             found.pairs,
-            customization.level(level).nodes_of_cell.len() as u64 - found.without_border,
+            customization.level(level).cells() as u64 - found.without_border,
             found.without_border
         );
         if found.wrong == 0 {


### PR DESCRIPTION
## What this does not add

On demand customization already exists. `Customization::new` tabulates
nothing, and a cell is worked out the first time `distances_of` is called for
it, into the same `OnceLock` slot it is read from afterwards. On europe.ptv:

```
read the files in 4.52s, stood the instance up in 9.45ms, 0 cells customized
query    1:     4.01s   43937 cells worked out
query    2:  405.19µs       0 cells worked out
query  300:  235.50µs       0 cells worked out
```

Level construction was not on demand in the same way. The first cell asked
for on a level built, for the whole graph, a cell id per node, the node list
of every cell, and a border flag per node; the border flag needed a pass over
all 42 million arcs. A query that reaches the top level did that six times
before customizing anything, which was **2.26s of a 4.01s first query**.

## API changes

| before | after |
|---|---|
| `Level.nodes_of_cell: Vec<Vec<NodeID>>` | `Level::cells() -> usize`, `Level::nodes_of(CellId) -> &[NodeID]` |
| `Level.on_border: Vec<bool>` | `Level::on_border(NodeID) -> bool` |
| — | `Level::bytes() -> usize`, `CellDistances::bytes() -> usize` |

`Level.of_node` and `Level.built_from` are unchanged. Six call sites updated.

New: `examples/on_demand.rs` stands up an instance and repeats one query,
reporting what each costs and how many cells it had to customize first.
`TOOLBOX_TIME_LEVELS=1` reports level construction separately.

## The three changes

**1. One border table for all levels, instead of one pass per level.** Two
nodes joined by an arc differ at some highest level and at every level below
it, which `PackedPartition::highest_different_level` returns from their two
words. One byte per node therefore holds the answer for every level, and
`Level::on_border` compares that byte against its own level. Six passes over
42 million arcs become one.

**2. Cell ids come from `PackedPartition`, not `LevelDirectory`.** The
directory stores a parent per cell per level and resolves a lookup by walking
up one parent array per level, so level 5 cost six random reads per node. The
partition stores the full ancestry in one word, where a level is a shift and
a mask. Per-level cost was rising with height, 245ms to 303ms; it is now flat
at about 125ms.

**3. Cell membership is a flat node array plus per-cell offsets, not a `Vec`
per cell.** Level 0 has 497,965 cells of about 30 nodes each, and allocating
half a million small vectors was most of the cost. Nodes are counted and then
placed, which keeps them in increasing order within a cell — the tabulation
relies on that, because border nodes lead a cell's numbering in the order
they are encountered.

All three passes are over nodes or arcs with no dependencies between
iterations, so they run on rayon. In the border pass a node is written by
whichever thread holds the arc rather than the one holding the node, so the
table is `Vec<AtomicU8>` and each write is a relaxed `fetch_max`. The result
does not depend on the order the writes arrive in.

## Measurements

europe.ptv, 18,010,173 nodes, 42,188,664 arcs, 6 levels, boundary directory.

| | before | after |
|---|---|---|
| instance construction | 9.45ms | 11ms |
| level construction, all six | 2.26s | **1.17s** |
| first query, cold | 4.01s | **2.47s** |
| warm query | 237µs | 237µs |
| full customization, 8 threads | 7.11s | **5.86s** |

Level construction per level: 514/394/343/328/337/347ms before,
516/129/123/125/134/141ms after. Level 0 carries the single arc pass that the
other five read.

Levels 0 and 3 verify against plain Dijkstra on the base graph, 30.9 million
pairs, no mismatches.

## Memory

`CellDistances::bytes` and `Level::bytes`, reported per level by the customize
example. europe.ptv, everything customized:

| level | cells | cell tables | level structure | per cell |
|---|---|---|---|---|
| 0 | 497,965 | 303.1 MiB | 208.0 MiB | 638 B |
| 1 | 98,375 | 159.8 MiB | 211.3 MiB | 1.7 KiB |
| 2 | 24,384 | 106.5 MiB | 207.3 MiB | 4.5 KiB |
| 3 | 2,440 | 64.1 MiB | 206.3 MiB | 26.9 KiB |
| 4 | 245 | 40.7 MiB | 206.1 MiB | 170.1 KiB |
| 5 | 26 | 18.4 MiB | 206.1 MiB | 726.6 KiB |

693 MiB of cell tables and 1.22 GiB of level structures, plus 17.2 MiB of
border flags shared by all levels. 1.9 GiB in total.

## Known limits

- **A level structure costs the same regardless of how many cells it has.**
  Every one is about 206 MiB, because it is two arrays over the graph's nodes
  rather than over the level's cells: `of_node` at 4 bytes per node and the
  node array at 8, since `NodeID` is a `usize`. `CellDistances` already
  addresses the graph with `u32`. Narrowing the node array to `u32` would save
  about 412 MiB across the six levels.
- **A first query still customizes 43,937 cells**, 7% of the instance for one
  route, because a coarse cell recursively needs every cell below it. That is
  the recursion rather than waste, but the cells of one level of it are
  independent and are currently requested one at a time.