### PR TITLE
Add the cell tree, and run the searches over a trait

### DIFF
--- a/examples/ordering_check.rs
+++ b/examples/ordering_check.rs
@@ -15,13 +15,17 @@
 //! pieces as the numbering broke it into, and the store would have to hold a
 //! list for it.
 //!
-//! `TOOLBOX_CELL_MAJOR=1` picks the other numbering.
+//! A third argument of `cell-path` picks the other numbering.
 
 use std::{env::args, time::Instant};
 
 use toolbox_rs::{
-    graph::NodeID, io, level_directory::LevelDirectory, node_ordering::NodeOrdering,
-    packed_partition::PackedPartition, static_graph::StaticGraph,
+    graph::NodeID,
+    io,
+    level_directory::LevelDirectory,
+    node_ordering::{NodeOrdering, Numbering},
+    packed_partition::PackedPartition,
+    static_graph::StaticGraph,
 };
 
 fn main() {
@@ -34,18 +38,22 @@ fn main() {
     let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
     let directory: LevelDirectory = io::read_from_file(&next("directory"));
     let levels = directory.levels();
+    let numbering = match argv.next().as_deref() {
+        Some("cell-path") => Numbering::CellPath,
+        Some(other) => panic!("no numbering called {other}: border-first or cell-path"),
+        None => Numbering::BorderFirst,
+    };
 
     let partition = PackedPartition::of(&directory);
     let started = Instant::now();
-    let ordering = NodeOrdering::of(&graph, &partition);
+    let ordering = NodeOrdering::in_order(&graph, &partition, numbering);
     println!(
         "numbered {} nodes in {:.2?}, {}",
         ordering.len(),
         started.elapsed(),
-        if std::env::var("TOOLBOX_CELL_MAJOR").is_ok() {
-            "by cell path first"
-        } else {
-            "by border level first"
+        match numbering {
+            Numbering::CellPath => "by cell path first",
+            Numbering::BorderFirst => "by border level first",
         }
     );
 

--- a/examples/skeleton.rs
+++ b/examples/skeleton.rs
@@ -1,0 +1,93 @@
+//! Builds the cell tree of an instance and says what it costs to ship.
+//!
+//! ```text
+//! skeleton <graph> <directory> <coordinates> [out]
+//! ```
+//!
+//! The tree is the part of a store that everybody has: it says what cells
+//! there are, what each holds, where each is, and which key range each covers.
+//! Nothing can be looked up without it, so it is downloaded whole and its size
+//! is a number worth watching rather than discovering.
+//!
+//! Reports what it costs per level, writes it if asked where, and reads it
+//! back to check the writing.
+
+use std::{env::args, time::Instant};
+
+use toolbox_rs::{
+    cell_tree::CellTree, geometry::FPCoordinate, io, level_directory::LevelDirectory,
+    packed_partition::PackedPartition, static_graph::StaticGraph,
+};
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!("usage: skeleton <graph> <directory> <coordinates> [out]: missing {what}")
+        })
+    };
+    let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
+    let directory: LevelDirectory = io::read_from_file(&next("directory"));
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&next("coordinates"));
+    let out = argv.next();
+
+    let started = Instant::now();
+    let partition = PackedPartition::of(&directory);
+    let packed = started.elapsed();
+    let started = Instant::now();
+    let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+    println!(
+        "packed the partition in {packed:.2?}, built the tree in {:.2?}, key is {} bits wide",
+        started.elapsed(),
+        tree.key_bits()
+    );
+
+    println!(
+        "{:>5} {:>9} {:>7} {:>12} {:>12} {:>9} {:>18}",
+        "level", "cells", "bits", "nodes", "on border", "share", "widest key range"
+    );
+    for level in 0..tree.levels() {
+        let cells = tree.cells_on_level(level);
+        let mut nodes = 0_u64;
+        let mut border = 0_u64;
+        let mut widest = 0_u128;
+        for cell in 0..cells {
+            let facts = tree.facts(level, cell as u32);
+            nodes += u64::from(facts.nodes);
+            border += u64::from(facts.on_border);
+            let (first, last) = tree.range_of(level, cell as u32);
+            widest = widest.max(last - first + 1);
+        }
+        let bits = if level + 1 < tree.levels() {
+            tree.begins_at(level + 1) - tree.begins_at(level)
+        } else {
+            tree.key_bits() - tree.begins_at(level)
+        };
+        println!(
+            "{level:>5} {cells:>9} {bits:>7} {nodes:>12} {border:>12} {:>9} {widest:>18}",
+            format!("{:.1}%", 100.0 * border as f64 / nodes as f64),
+        );
+    }
+
+    let Some(out) = out else {
+        return;
+    };
+    let started = Instant::now();
+    io::write_to_file(&out, &tree);
+    let written = started.elapsed();
+    let size = std::fs::metadata(&out).expect("the tree was written").len();
+    let started = Instant::now();
+    let read: CellTree = io::read_from_file(&out);
+    println!(
+        "wrote {:.1} MiB to {out} in {written:.2?}, read back in {:.2?}, {}",
+        size as f64 / (1024.0 * 1024.0),
+        started.elapsed(),
+        if read == tree {
+            "the same tree"
+        } else {
+            "A DIFFERENT TREE"
+        }
+    );
+    assert!(read.check_version().is_ok(), "a version this cannot read");
+}

--- a/src/bidirectional_mld_query.rs
+++ b/src/bidirectional_mld_query.rs
@@ -31,10 +31,10 @@ use log::debug;
 
 use crate::{
     border_levels::BorderLevels,
-    customization::Customization,
     dense_heap::DenseHeap,
     graph::{Graph, INVALID_NODE_ID, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
+    overlay::{CellTable, Overlay},
     packed_partition::PackedPartition,
 };
 
@@ -179,9 +179,9 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
     /// # Panics
     ///
     /// Panics if a level of the partition has no cells worked out for it.
-    pub fn run<G: Graph<u32>>(
+    pub fn run<O: Overlay, G: Graph<u32>>(
         &mut self,
-        customization: &Customization,
+        customization: &O,
         reverse: &G,
         reverse_borders: &BorderLevels,
         source: NodeID,
@@ -282,9 +282,9 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
     /// here to each of the others. The backward side reads its column, what it
     /// costs to get to here from each of the others.
     #[inline(never)]
-    fn relax_across_cell(
+    fn relax_across_cell<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        customization: &O,
         partition: &PackedPartition,
         side: Side,
         node: NodeID,
@@ -305,7 +305,7 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
         let here = u32::try_from(node).unwrap_or(u32::MAX);
         match side {
             Side::Forward => {
-                for (&other, &across) in distances.border_nodes.iter().zip(distances.row(place)) {
+                for (&other, &across) in distances.border_nodes().iter().zip(distances.row(place)) {
                     if across == u32::MAX || other == here {
                         continue;
                     }
@@ -313,7 +313,8 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
                 }
             }
             Side::Backward => {
-                for (&other, &across) in distances.border_nodes.iter().zip(distances.column(place))
+                for (&other, &across) in
+                    distances.border_nodes().iter().zip(distances.column(place))
                 {
                     if across == u32::MAX || other == here {
                         continue;

--- a/src/bounding_box.rs
+++ b/src/bounding_box.rs
@@ -1,6 +1,6 @@
 use crate::geometry::FPCoordinate;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct BoundingBox {
     min: FPCoordinate,
     max: FPCoordinate,

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -1,0 +1,540 @@
+//! The assembled partition as a tree of cells, and the key of a cell in it.
+//!
+//! # Why this exists beside the directory
+//!
+//! [`LevelDirectory`] holds the assembly's answer in the form the assembly
+//! left it: which cell each node is in, and which cell of the level above each
+//! cell belongs to. That is enough to ask about a node and nothing else. It
+//! cannot say what a cell holds without walking every node, how many of those
+//! sit on its border without walking every arc, or where it is on the ground
+//! at all.
+//!
+//! A store that hands out one cell at a time has to answer all three before it
+//! reads anything, so they are worked out once and written down.
+//!
+//! # The key of a cell
+//!
+//! A cell is named by the path from the root down to it, packed into one word
+//! the way [`PackedPartition`] already packs the path of a node: a level gets
+//! as many bits as its cells need, the coarse levels take the high bits, and
+//! the levels below the cell are left at nought.
+//!
+//! Two things follow, and they are the whole reason for the format.
+//!
+//! Sorting keys sorts by the coarsest cell first and by finer cells within it,
+//! which is the order a walk of the tree would visit them in. And a cell's
+//! subtree is exactly the keys from its own to its own with every bit below it
+//! set — one range, with nothing outside the subtree falling inside it and
+//! nothing inside falling outside. So a range of keys is a subtree, a block
+//! holds a range, and a range nobody has is a part of the map nobody
+//! downloaded.
+//!
+//! This is why the node numbering has to be [`Numbering::CellPath`]: the keys
+//! come out in one range either way, but the nodes only do under that one.
+//!
+//! [`Numbering::CellPath`]: crate::node_ordering::Numbering::CellPath
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::{
+    bounding_box::BoundingBox,
+    geometry::FPCoordinate,
+    graph::Graph,
+    level_directory::{CellId, LevelDirectory},
+    packed_partition::PackedPartition,
+};
+
+/// The version this is written under. A reader that does not know a version
+/// refuses the file rather than reading it as though it were another one.
+pub const VERSION: u16 = 1;
+
+/// Where a cell sits in the tree, as the path from the root packed into a word.
+///
+/// Ordering is by the word, which is by coarsest cell first. A key carries the
+/// level it names so that [`last`](Self::last) knows how much of the word
+/// below it is subtree rather than path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Archive, Serialize, Deserialize)]
+pub struct CellKey {
+    /// the path, with every level below `level` left at nought
+    word: u128,
+    /// the level the key names, counted from the finest
+    level: u8,
+}
+
+impl CellKey {
+    /// The word itself, which is the first key of the subtree.
+    #[must_use]
+    pub fn first(&self) -> u128 {
+        self.word
+    }
+
+    #[must_use]
+    pub fn level(&self) -> usize {
+        self.level as usize
+    }
+
+    /// The last key of the subtree: the path with everything below it set.
+    ///
+    /// `below` is where this key's level begins in the word, which the tree
+    /// knows and the key does not carry.
+    #[must_use]
+    pub fn last(&self, below: u32) -> u128 {
+        self.word | ((1_u128 << below) - 1)
+    }
+}
+
+/// What a cell holds, where it is, and how much of it faces outward.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct CellFacts {
+    /// how many nodes the cell holds
+    pub nodes: u32,
+    /// how many of them an arc leaves the cell from or reaches from outside
+    pub on_border: u32,
+}
+
+/// The assembled partition, with the parts of it a store has to ask about.
+#[derive(Clone, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct CellTree {
+    version: u16,
+    /// where each level's bits begin in a key, finest first; the last entry is
+    /// the width of a whole key in bits
+    begins_at: Vec<u32>,
+    /// per level above the finest, where the children of each cell begin in
+    /// `children`, with one past the end in the last entry
+    starts: Vec<Vec<u32>>,
+    /// per level above the finest, the cells of the level below that each cell
+    /// of this one is built out of, in increasing order
+    children: Vec<Vec<CellId>>,
+    /// per level below the topmost, the cell of the level above that each cell
+    /// belongs to
+    ///
+    /// Held rather than looked for. The children of a cell are one run, but a
+    /// child's number is not where it sits in that run, so the offsets cannot
+    /// be asked which run a given child fell in.
+    parents: Vec<Vec<CellId>>,
+    /// per level, what each of its cells holds
+    facts: Vec<Vec<CellFacts>>,
+    /// per level, the box each of its cells lies in, and an invalid box for a
+    /// cell holding no node with a coordinate
+    bounds: Vec<Vec<BoundingBox>>,
+}
+
+impl CellTree {
+    /// Works the tree out from the assembly's answer and the graph it was cut
+    /// from.
+    ///
+    /// One walk of the nodes counts what each cell holds and grows its box,
+    /// one walk of the arcs counts what faces outward, and one walk of the
+    /// parents lays out the children. Nothing here searches.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the graph, the partition and the coordinates are not over the
+    /// same nodes.
+    #[must_use]
+    pub fn of<G: Graph<u32>>(
+        directory: &LevelDirectory,
+        partition: &PackedPartition,
+        graph: &G,
+        coordinates: &[FPCoordinate],
+    ) -> Self {
+        let levels = directory.levels();
+        let nodes = directory.number_of_nodes();
+        assert_eq!(graph.number_of_nodes(), nodes, "another graph");
+        assert_eq!(coordinates.len(), nodes, "another set of coordinates");
+
+        let counts = (0..levels)
+            .map(|level| directory.cells_on_level(level))
+            .collect::<Vec<_>>();
+
+        // what each cell holds, and where it is
+        let mut facts = counts
+            .iter()
+            .map(|&count| {
+                vec![
+                    CellFacts {
+                        nodes: 0,
+                        on_border: 0
+                    };
+                    count
+                ]
+            })
+            .collect::<Vec<Vec<_>>>();
+        let mut bounds = counts
+            .iter()
+            .map(|&count| vec![BoundingBox::invalid(); count])
+            .collect::<Vec<Vec<_>>>();
+        for (node, coordinate) in coordinates.iter().enumerate() {
+            let word = partition.word(node);
+            let at = BoundingBox::from_coordinate(coordinate);
+            for (level, (holds, box_of)) in facts.iter_mut().zip(bounds.iter_mut()).enumerate() {
+                let cell = partition.cell_in(word, level) as usize;
+                holds[cell].nodes += 1;
+                box_of[cell].extend_with(&at);
+            }
+        }
+
+        // and how much of each faces outward. An arc that leaves a cell puts
+        // both of its ends on that cell's border, and a node is counted once
+        // however many arcs leave it, so the counting is over nodes with the
+        // arcs asked about rather than over arcs.
+        // An arc leaving a cell puts *both* of its ends on a border: a node an
+        // arc only reaches from outside is a way into the cell, and a path
+        // through the cell above may come in by it. So the arcs are walked
+        // once and both ends written, rather than each node asked about its
+        // own outgoing arcs, which would miss every node that can only be
+        // entered. On europe.ptv that is 261,684 nodes of the finest level,
+        // nearly a tenth of its border.
+        let mut highest = vec![0_u8; nodes];
+        for node in 0..nodes {
+            let word = partition.word(node);
+            for edge in graph.edge_range(node) {
+                let target = graph.target(edge);
+                if let Some(parting) =
+                    partition.highest_different_level(word, partition.word(target))
+                {
+                    // plus one, so that nought means no arc ever left
+                    let reached =
+                        u8::try_from(parting + 1).expect("more levels than a byte counts");
+                    highest[node] = highest[node].max(reached);
+                    highest[target] = highest[target].max(reached);
+                }
+            }
+        }
+        for (node, &reached) in highest.iter().enumerate() {
+            // a node parts from a neighbour at some coarsest level and at
+            // every level below it, so it is on a border at all of them
+            let word = partition.word(node);
+            for (level, holds) in facts
+                .iter_mut()
+                .enumerate()
+                .take((reached as usize).min(levels))
+            {
+                let cell = partition.cell_in(word, level) as usize;
+                holds[cell].on_border += 1;
+            }
+        }
+
+        // the children of each cell, laid out in one run per level
+        let mut starts = Vec::with_capacity(levels.saturating_sub(1));
+        let mut children = Vec::with_capacity(levels.saturating_sub(1));
+        let mut parents = Vec::with_capacity(levels.saturating_sub(1));
+        for (level, &above) in counts.iter().enumerate().take(levels).skip(1) {
+            let above_of = directory.parents_on_level(level - 1);
+            let mut begins = vec![0_u32; above + 1];
+            for &parent in above_of {
+                begins[parent as usize + 1] += 1;
+            }
+            for cell in 0..above {
+                begins[cell + 1] += begins[cell];
+            }
+            let mut filled = begins.clone();
+            let mut held = vec![0 as CellId; above_of.len()];
+            for (child, &parent) in above_of.iter().enumerate() {
+                held[filled[parent as usize] as usize] =
+                    CellId::try_from(child).expect("more cells than a cell id counts");
+                filled[parent as usize] += 1;
+            }
+            starts.push(begins);
+            children.push(held);
+            parents.push(above_of.to_vec());
+        }
+
+        Self {
+            version: VERSION,
+            begins_at: partition.level_layout().to_vec(),
+            starts,
+            children,
+            parents,
+            facts,
+            bounds,
+        }
+    }
+
+    #[must_use]
+    pub fn levels(&self) -> usize {
+        self.facts.len()
+    }
+
+    #[must_use]
+    pub fn cells_on_level(&self, level: usize) -> usize {
+        self.facts[level].len()
+    }
+
+    /// How wide a key is, in bits. The whole path fits in this many.
+    #[must_use]
+    pub fn key_bits(&self) -> u32 {
+        *self.begins_at.last().expect("a tree has a level")
+    }
+
+    /// Where a level's bits begin in a key.
+    #[must_use]
+    pub fn begins_at(&self, level: usize) -> u32 {
+        self.begins_at[level]
+    }
+
+    /// What a cell holds.
+    #[must_use]
+    pub fn facts(&self, level: usize, cell: CellId) -> CellFacts {
+        self.facts[level][cell as usize]
+    }
+
+    /// The box a cell's nodes lie in.
+    #[must_use]
+    pub fn bounds(&self, level: usize, cell: CellId) -> &BoundingBox {
+        &self.bounds[level][cell as usize]
+    }
+
+    /// The cells of the level below that a cell is built out of, and nothing
+    /// on the finest level, which is built out of the graph itself.
+    #[must_use]
+    pub fn children_of(&self, level: usize, cell: CellId) -> &[CellId] {
+        if level == 0 {
+            return &[];
+        }
+        let held = &self.children[level - 1];
+        let starts = &self.starts[level - 1];
+        let from = starts[cell as usize] as usize;
+        let to = starts[cell as usize + 1] as usize;
+        &held[from..to]
+    }
+
+    /// The key of a cell: the path from the root down to it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no such cell on that level.
+    #[must_use]
+    pub fn key_of(&self, level: usize, cell: CellId) -> CellKey {
+        assert!(
+            (cell as usize) < self.cells_on_level(level),
+            "no cell {cell} on level {level}"
+        );
+        let mut word = u128::from(cell) << self.begins_at[level];
+        let mut at = cell;
+        for above in level + 1..self.levels() {
+            at = self.parent_of(above - 1, at);
+            word |= u128::from(at) << self.begins_at[above];
+        }
+        CellKey {
+            word,
+            level: u8::try_from(level).expect("more levels than a byte counts"),
+        }
+    }
+
+    /// The keys a cell's subtree covers, first and last, both included.
+    #[must_use]
+    pub fn range_of(&self, level: usize, cell: CellId) -> (u128, u128) {
+        let key = self.key_of(level, cell);
+        (key.first(), key.last(self.begins_at[level]))
+    }
+
+    /// The cell of the level above that a cell belongs to.
+    ///
+    /// # Panics
+    ///
+    /// Panics on the topmost level, whose cells have nothing above them.
+    #[must_use]
+    pub fn parent_of(&self, level: usize, cell: CellId) -> CellId {
+        self.parents[level][cell as usize]
+    }
+
+    /// Refuses a tree written under a version this does not know.
+    ///
+    /// # Errors
+    ///
+    /// Returns the version found when it is not the one this reads.
+    pub fn check_version(&self) -> Result<(), u16> {
+        if self.version == VERSION {
+            Ok(())
+        } else {
+            Err(self.version)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{edge::InputEdge, grid_graph::grid_directory, static_graph::StaticGraph};
+
+    /// A square grid of `side` by `side`, cut into the levels the directory
+    /// asks for, with a coordinate a node.
+    fn grid(side: usize) -> (StaticGraph<u32>, LevelDirectory, Vec<FPCoordinate>) {
+        let mut edges = Vec::new();
+        for row in 0..side {
+            for column in 0..side {
+                let node = row * side + column;
+                if column + 1 < side {
+                    edges.push(InputEdge::new(node, node + 1, 1_u32));
+                    edges.push(InputEdge::new(node + 1, node, 1_u32));
+                }
+                if row + 1 < side {
+                    edges.push(InputEdge::new(node, node + side, 1_u32));
+                    edges.push(InputEdge::new(node + side, node, 1_u32));
+                }
+            }
+        }
+        let coordinates = (0..side * side)
+            .map(|node| {
+                FPCoordinate::new(
+                    i32::try_from(node / side).unwrap() * 1000,
+                    i32::try_from(node % side).unwrap() * 1000,
+                )
+            })
+            .collect();
+        (StaticGraph::new(edges), grid_directory(side), coordinates)
+    }
+
+    fn tree_of(side: usize) -> (CellTree, PackedPartition, LevelDirectory) {
+        let (graph, directory, coordinates) = grid(side);
+        let partition = PackedPartition::of(&directory);
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        (tree, partition, directory)
+    }
+
+    #[test]
+    fn a_cell_holds_what_the_directory_put_in_it() {
+        let (tree, partition, directory) = tree_of(8);
+        for level in 0..tree.levels() {
+            let mut counted = vec![0_u32; tree.cells_on_level(level)];
+            for node in 0..directory.number_of_nodes() {
+                counted[partition.cell_in(partition.word(node), level) as usize] += 1;
+            }
+            for (cell, &held) in counted.iter().enumerate() {
+                assert_eq!(
+                    tree.facts(level, cell as CellId).nodes,
+                    held,
+                    "level {level}, cell {cell}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_children_of_a_cell_are_the_cells_that_call_it_parent() {
+        let (tree, _, directory) = tree_of(8);
+        for level in 1..tree.levels() {
+            let parents = directory.parents_on_level(level - 1);
+            for cell in 0..tree.cells_on_level(level) {
+                let wanted = parents
+                    .iter()
+                    .enumerate()
+                    .filter(|&(_, &parent)| parent as usize == cell)
+                    .map(|(child, _)| child as CellId)
+                    .collect::<Vec<_>>();
+                assert_eq!(tree.children_of(level, cell as CellId), wanted);
+            }
+        }
+    }
+
+    #[test]
+    fn a_child_names_the_cell_that_holds_it() {
+        let (tree, _, _) = tree_of(8);
+        for level in 1..tree.levels() {
+            for cell in 0..tree.cells_on_level(level) {
+                for &child in tree.children_of(level, cell as CellId) {
+                    assert_eq!(tree.parent_of(level - 1, child), cell as CellId);
+                }
+            }
+        }
+    }
+
+    /// The property the whole format rests on.
+    #[test]
+    fn a_subtree_is_one_range_of_keys_and_holds_nothing_else() {
+        let (tree, partition, directory) = tree_of(8);
+        for level in 0..tree.levels() {
+            for cell in 0..tree.cells_on_level(level) {
+                let (first, last) = tree.range_of(level, cell as CellId);
+                assert!(first <= last, "a range runs forwards");
+                for node in 0..directory.number_of_nodes() {
+                    let word = partition.word(node);
+                    let inside = partition.cell_in(word, level) as usize == cell;
+                    assert_eq!(
+                        inside,
+                        (first..=last).contains(&word),
+                        "node {node} at level {level}, cell {cell}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_ranges_of_a_level_do_not_overlap_and_come_out_in_order() {
+        let (tree, _, _) = tree_of(8);
+        for level in 0..tree.levels() {
+            let mut ranges = (0..tree.cells_on_level(level))
+                .map(|cell| tree.range_of(level, cell as CellId))
+                .collect::<Vec<_>>();
+            ranges.sort_unstable();
+            for pair in ranges.windows(2) {
+                assert!(
+                    pair[0].1 < pair[1].0,
+                    "the range ending {} runs into the one starting {}",
+                    pair[0].1,
+                    pair[1].0
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_subtree_holds_the_subtrees_below_it() {
+        let (tree, _, _) = tree_of(8);
+        for level in 1..tree.levels() {
+            for cell in 0..tree.cells_on_level(level) {
+                let (first, last) = tree.range_of(level, cell as CellId);
+                for &child in tree.children_of(level, cell as CellId) {
+                    let (from, to) = tree.range_of(level - 1, child);
+                    assert!(first <= from && to <= last, "a child falls outside");
+                }
+            }
+        }
+    }
+
+    /// A road network is directed, and a node that can only be entered from
+    /// another cell is a way in that a path through the cell above may take.
+    /// Asking each node about its own outgoing arcs misses every one of them:
+    /// on europe.ptv that was 261,684 nodes, nearly a tenth of the border of
+    /// the finest level.
+    #[test]
+    fn a_node_an_arc_only_reaches_is_on_the_border_too() {
+        // two cells of two nodes, with one arc running between them one way
+        let edges = vec![
+            InputEdge::new(0, 1, 1_u32),
+            InputEdge::new(1, 0, 1_u32),
+            InputEdge::new(1, 2, 1_u32),
+            InputEdge::new(2, 3, 1_u32),
+            InputEdge::new(3, 2, 1_u32),
+        ];
+        let graph = StaticGraph::new(edges);
+        let directory = LevelDirectory::new(vec![0, 0, 1, 1], Vec::new());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); 4];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+        // node 1 leaves its cell and node 2 is only reached from outside; both
+        // are on the border of the cell they are in
+        assert_eq!(tree.facts(0, 0).on_border, 1, "the cell the arc leaves");
+        assert_eq!(tree.facts(0, 1).on_border, 1, "the cell the arc reaches");
+    }
+
+    #[test]
+    fn a_tree_reads_back_as_it_was_written() {
+        let (tree, _, _) = tree_of(8);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&tree).expect("a tree serializes");
+        let read: CellTree =
+            rkyv::from_bytes::<CellTree, rkyv::rancor::Error>(&bytes).expect("a tree deserializes");
+        assert_eq!(tree, read);
+        assert!(read.check_version().is_ok());
+    }
+
+    #[test]
+    fn a_tree_of_another_version_is_refused() {
+        let (mut tree, _, _) = tree_of(4);
+        tree.version = VERSION + 1;
+        assert_eq!(tree.check_version(), Err(VERSION + 1));
+    }
+}

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -20,6 +20,7 @@ use crate::{
     graph::{Graph, NodeID},
     level_directory::{CellId, LevelDirectory},
     one_to_many_dijkstra::OneToManyDijkstra,
+    overlay::{CellTable, Overlay},
     packed_partition::PackedPartition,
     static_graph::StaticGraph,
 };
@@ -76,6 +77,12 @@ pub struct CellDistances {
 }
 
 impl CellDistances {
+    /// The nodes on the border of the cell, in the order the table is in.
+    #[must_use]
+    pub fn border_nodes_of(&self) -> &[u32] {
+        &self.border_nodes
+    }
+
     /// What the table takes up, near enough to count with.
     ///
     /// The three runs of numbers are exact. The map of places is not: it is
@@ -1021,6 +1028,69 @@ impl Customization {
         let searched = of_node.len();
         edges.sort_unstable();
         (StaticGraph::from_sorted_slice(searched, edges), searched)
+    }
+}
+
+impl CellTable for &CellDistances {
+    #[inline]
+    fn border_nodes(&self) -> &[u32] {
+        CellDistances::border_nodes_of(self)
+    }
+
+    #[inline]
+    fn row(&self, source: usize) -> &[u32] {
+        CellDistances::row(self, source)
+    }
+
+    #[inline]
+    fn column(&self, target: usize) -> &[u32] {
+        CellDistances::column(self, target)
+    }
+
+    #[inline]
+    fn place_of(&self, node: NodeID) -> Option<usize> {
+        CellDistances::place_of(self, node)
+    }
+}
+
+/// The overlay a server runs on: every table in memory, worked out on the
+/// first request and kept.
+///
+/// Handing a table out is a load. Nothing here can be evicted while a search
+/// reads it, so the table is lent rather than guarded and the lifetime is the
+/// customization's own.
+impl Overlay for Customization {
+    type Graph = StaticGraph<u32>;
+    type Table<'a> = &'a CellDistances;
+
+    #[inline]
+    fn graph(&self) -> &Self::Graph {
+        Customization::graph(self)
+    }
+
+    #[inline]
+    fn partition(&self) -> &PackedPartition {
+        Customization::partition(self)
+    }
+
+    #[inline]
+    fn border_levels(&self) -> &BorderLevels {
+        Customization::border_levels(self)
+    }
+
+    #[inline]
+    fn levels(&self) -> usize {
+        self.directory().levels()
+    }
+
+    #[inline]
+    fn cells_on_level(&self, level: usize) -> usize {
+        Customization::cells_on_level(self, level)
+    }
+
+    #[inline]
+    fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>> {
+        Customization::distances_of(self, level, cell)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bloom_filter;
 pub mod border_levels;
 pub mod bounding_box;
 pub mod cell;
+pub mod cell_tree;
 pub mod complete_graph;
 pub mod convex_hull;
 pub mod count_min_sketch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod mvt;
 pub mod node_ordering;
 pub mod one_iterator;
 pub mod one_to_many_dijkstra;
+pub mod overlay;
 pub mod packed_partition;
 pub mod partition_id;
 pub mod path_based_scc;

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -34,10 +34,10 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     border_levels::BorderLevels,
-    customization::Customization,
     dense_heap::DenseHeap,
     graph::{Graph, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
+    overlay::{CellTable, Overlay},
     packed_partition::PackedPartition,
 };
 
@@ -169,8 +169,8 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     ///
     /// A second run over the same partition finds the room already there and
     /// the entries already put back by `clear`.
-    fn make_room_for(&mut self, customization: &Customization) {
-        let levels = customization.directory().levels();
+    fn make_room_for<O: Overlay>(&mut self, customization: &O) {
+        let levels = customization.levels();
         let mut at = Vec::with_capacity(levels + 1);
         let mut total = 0;
         for level in 0..levels {
@@ -195,9 +195,9 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     ///
     /// Panics if a level of the partition has no cells worked out for it,
     /// which would mean a directory that does not describe the graph.
-    pub fn run(
+    pub fn run<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        customization: &O,
         source: NodeID,
         targets: &[NodeID],
     ) -> bool {
@@ -288,9 +288,9 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
 
     /// The arcs across the cell, which the customization worked out.
     #[inline(never)]
-    fn relax_across_cell(
+    fn relax_across_cell<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        customization: &O,
         partition: &PackedPartition,
         node: NodeID,
         distance: usize,
@@ -311,7 +311,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         // the row and the nodes it is about, walked in step as two pieces of
         // memory rather than asked for an entry at a time
         let here = u32::try_from(node).unwrap_or(u32::MAX);
-        for (&target, &across) in distances.border_nodes.iter().zip(distances.row(from)) {
+        for (&target, &across) in distances.border_nodes().iter().zip(distances.row(from)) {
             if across == u32::MAX || target == here {
                 continue;
             }

--- a/src/node_ordering.rs
+++ b/src/node_ordering.rs
@@ -31,7 +31,7 @@
 //! near its own end ever reaches, and goes to the back. The sort being stable,
 //! the cells stay laid out side by side within each group.
 
-use std::{cmp::Reverse, sync::OnceLock};
+use std::cmp::Reverse;
 
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -58,16 +58,37 @@ pub struct NodeOrdering {
     on_a_border: usize,
 }
 
-/// Whether to number by cell path first and border level second, rather than
-/// the other way round.
+/// Which of the two orders a numbering is worked out in.
 ///
-/// Here to measure one against the other, and read once. The orders want
-/// opposite things -- one lays every subtree out in a single run of numbers,
-/// the other puts every coarse border node of the graph at the front of every
-/// array -- and which of them a run wants is not a thing this module can know.
-fn cell_major() -> bool {
-    static ASKED: OnceLock<bool> = OnceLock::new();
-    *ASKED.get_or_init(|| std::env::var("TOOLBOX_CELL_MAJOR").is_ok())
+/// They want opposite things and both are wanted somewhere, so this is asked
+/// for rather than decided here.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Numbering {
+    /// Border nodes of the coarsest cells first, over the whole graph.
+    ///
+    /// A search over the cells touches the border nodes of coarse cells, a few
+    /// hundred thousand of eighteen million, and this puts all of them at the
+    /// front of every array a search keeps a node in. It is what a search in
+    /// memory wants: measured over europe.ptv it is worth a quarter of the
+    /// median query and nearly half of a continental one.
+    ///
+    /// What it gives up is any grouping: a cell's nodes end up scattered the
+    /// width of the numbering.
+    #[default]
+    BorderFirst,
+    /// By cell path, and border nodes first only within a cell.
+    ///
+    /// Every cell of every level comes out one run of numbers, and so does
+    /// every subtree, since the cells of a cell are themselves next to one
+    /// another. That is what a store that hands out a subtree at a time wants:
+    /// a block holds a range, and a range nobody has is a part of the map
+    /// nobody downloaded.
+    ///
+    /// Measured over europe.ptv it costs a fifth of the median query against
+    /// [`BorderFirst`](Self::BorderFirst), all of it above rank 2^10. Below
+    /// that it is the faster of the two, a short search staying inside a few
+    /// cells being the case it lays out well.
+    CellPath,
 }
 
 impl NodeOrdering {
@@ -78,6 +99,20 @@ impl NodeOrdering {
     /// Panics if the graph and the partition are not over the same nodes.
     #[must_use]
     pub fn of<G: Graph<u32>>(graph: &G, partition: &PackedPartition) -> Self {
+        Self::in_order(graph, partition, Numbering::BorderFirst)
+    }
+
+    /// The same, in whichever of the two orders is asked for.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the graph and the partition are not over the same nodes.
+    #[must_use]
+    pub fn in_order<G: Graph<u32>>(
+        graph: &G,
+        partition: &PackedPartition,
+        numbering: Numbering,
+    ) -> Self {
         let nodes = partition.number_of_nodes();
         assert_eq!(
             graph.number_of_nodes(),
@@ -106,7 +141,7 @@ impl NodeOrdering {
 
         let mut to_old =
             (0..u32::try_from(nodes).expect("the graph is too large to hold")).collect::<Vec<_>>();
-        if cell_major() {
+        if numbering == Numbering::CellPath {
             // The same two keys the other way round: by cell path first and by
             // border level only within a cell. This keeps the nodes of a cell,
             // and so of every subtree above it, in one run of numbers, which

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,0 +1,215 @@
+//! What a search over the cells needs, and nothing about where it is kept.
+//!
+//! # Why a trait and not a type
+//!
+//! The same search has to run in two settings that agree on the algorithm and
+//! on nothing else.
+//!
+//! On a server the whole overlay is in memory. A table is worked out once and
+//! kept, and handing it to a search is a load: the table is lent out for as
+//! long as anyone wants it and nothing moves underneath.
+//!
+//! On a device it is on disk. A table is in a block that may not be
+//! decompressed yet, and holding one has to keep it from being evicted while
+//! the search reads it. That is a guard, not a reference, and it has a
+//! lifetime the store decides rather than the caller.
+//!
+//! Those two are the same shape once the difference is named: a store hands
+//! out something that reads like a table, for as long as the caller holds it.
+//! [`Overlay::Table`] is that something, and everything else a search asks for
+//! is the same in both settings.
+//!
+//! # What is deliberately not here
+//!
+//! Anything that builds. A store that reads a packed file cannot customize a
+//! cell and should not be asked to; a customization that works cells out on
+//! demand does so behind [`Overlay::distances_of`] and the search cannot tell.
+//! What the search wants is the answer, and both can give it.
+
+use crate::{
+    border_levels::BorderLevels,
+    graph::{Graph, NodeID},
+    level_directory::CellId,
+    packed_partition::PackedPartition,
+};
+
+/// The distances between the border nodes of one cell, however they are held.
+///
+/// A search reads a row of this once for every arc it takes across a cell, so
+/// everything here is a slice rather than an entry at a time: the row and the
+/// nodes it is about are walked in step, as two runs of memory.
+pub trait CellTable {
+    /// The nodes on the border of the cell, in the order the table is in.
+    fn border_nodes(&self) -> &[u32];
+
+    /// What it costs to get from the border node in `source` to each of them.
+    fn row(&self, source: usize) -> &[u32];
+
+    /// What it costs to reach the border node in `target` from each of them,
+    /// which is a column of the table and is held as a row of the transpose.
+    fn column(&self, target: usize) -> &[u32];
+
+    /// Where a node sits in the table, and `None` for a node of the cell that
+    /// is not on its border.
+    fn place_of(&self, node: NodeID) -> Option<usize>;
+}
+
+/// Whatever holds the cells a search runs over.
+pub trait Overlay {
+    /// the arcs of the graph itself, which a search walks near its ends
+    type Graph: Graph<u32>;
+
+    /// What [`distances_of`](Self::distances_of) hands out.
+    ///
+    /// A reference where the tables are in memory, and a guard where they are
+    /// in a cache that would otherwise evict one while it is being read.
+    type Table<'a>: CellTable
+    where
+        Self: 'a;
+
+    fn graph(&self) -> &Self::Graph;
+
+    /// The cell each node lies in on every level, one word apiece.
+    fn partition(&self) -> &PackedPartition;
+
+    /// The level at which each arc leaves a cell, which is how a search knows
+    /// an arc is worth taking without asking the partition about both ends.
+    fn border_levels(&self) -> &BorderLevels;
+
+    fn levels(&self) -> usize;
+
+    fn cells_on_level(&self, level: usize) -> usize;
+
+    /// The distances across a cell, and `None` for a cell with no border node
+    /// and so no table.
+    ///
+    /// Held for as long as the caller holds what comes back. A store that
+    /// pages may read and decompress here; one that does not is a load.
+    fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        customization::{CellDistances, Customization},
+        edge::InputEdge,
+        grid_graph::grid_directory,
+        mld_query::MldQuery,
+        static_graph::StaticGraph,
+    };
+    use std::cell::Cell;
+
+    /// A store shaped the way a paged one is: it hands out a guard rather than
+    /// a reference, and counts what was asked of it.
+    ///
+    /// The tables are in memory here, which is not the point. The point is
+    /// that [`Overlay::Table`] is not a reference, so a store whose tables sit
+    /// in a cache that may evict them can hold one open for as long as the
+    /// search reads it, and the search cannot tell the difference. If this
+    /// compiles and answers the same, a disk-backed store fits the same search.
+    struct Paged {
+        held: Customization,
+        asked: Cell<usize>,
+    }
+
+    struct Guard<'a> {
+        table: &'a CellDistances,
+    }
+
+    impl CellTable for Guard<'_> {
+        fn border_nodes(&self) -> &[u32] {
+            self.table.border_nodes_of()
+        }
+        fn row(&self, source: usize) -> &[u32] {
+            self.table.row(source)
+        }
+        fn column(&self, target: usize) -> &[u32] {
+            self.table.column(target)
+        }
+        fn place_of(&self, node: NodeID) -> Option<usize> {
+            self.table.place_of(node)
+        }
+    }
+
+    impl Overlay for Paged {
+        type Graph = StaticGraph<u32>;
+        type Table<'a>
+            = Guard<'a>
+        where
+            Self: 'a;
+
+        fn graph(&self) -> &Self::Graph {
+            Overlay::graph(&self.held)
+        }
+        fn partition(&self) -> &PackedPartition {
+            Overlay::partition(&self.held)
+        }
+        fn border_levels(&self) -> &BorderLevels {
+            Overlay::border_levels(&self.held)
+        }
+        fn levels(&self) -> usize {
+            Overlay::levels(&self.held)
+        }
+        fn cells_on_level(&self, level: usize) -> usize {
+            Overlay::cells_on_level(&self.held, level)
+        }
+        fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>> {
+            self.asked.set(self.asked.get() + 1);
+            Overlay::distances_of(&self.held, level, cell).map(|table| Guard { table })
+        }
+    }
+
+    fn grid(side: usize) -> Customization {
+        let mut edges = Vec::new();
+        for row in 0..side {
+            for column in 0..side {
+                let node = row * side + column;
+                if column + 1 < side {
+                    edges.push(InputEdge::new(node, node + 1, 1_u32));
+                    edges.push(InputEdge::new(node + 1, node, 1_u32));
+                }
+                if row + 1 < side {
+                    edges.push(InputEdge::new(node, node + side, 1_u32));
+                    edges.push(InputEdge::new(node + side, node, 1_u32));
+                }
+            }
+        }
+        Customization::new(StaticGraph::new(edges), grid_directory(side))
+    }
+
+    /// The one that matters: the same search, unchanged, over a store that
+    /// lends and one that guards, answering the same.
+    #[test]
+    fn the_same_search_runs_over_a_store_that_hands_out_guards() {
+        let side = 16;
+        let lending = grid(side);
+        let guarding = Paged {
+            held: grid(side),
+            asked: Cell::new(0),
+        };
+
+        let mut over_lending = MldQuery::new();
+        let mut over_guarding = MldQuery::new();
+        let mut pairs = 0;
+        for source in (0..side * side).step_by(7) {
+            for target in (0..side * side).step_by(11) {
+                over_lending.clear();
+                over_guarding.clear();
+                let reached = over_lending.run(&lending, source, &[target]);
+                assert_eq!(reached, over_guarding.run(&guarding, source, &[target]));
+                assert_eq!(
+                    over_lending.distance(target),
+                    over_guarding.distance(target),
+                    "from {source} to {target}"
+                );
+                pairs += 1;
+            }
+        }
+        assert!(pairs > 100, "the sweep is worth running");
+        assert!(
+            guarding.asked.get() > 0,
+            "the guarding store was never asked for a table"
+        );
+    }
+}

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -127,6 +127,17 @@ impl PackedPartition {
         self.levels
     }
 
+    /// Where each level's cell id begins in a word, finest level first, with
+    /// the width of a whole word in the last entry.
+    ///
+    /// This is the layout of a key, and a format that stores keys has to store
+    /// it beside them: how many bits a level was given depends on how many
+    /// cells it turned out to have.
+    #[must_use]
+    pub fn level_layout(&self) -> &[u32] {
+        &self.begins_at
+    }
+
     /// how many nodes it was built over
     #[must_use]
     pub fn number_of_nodes(&self) -> usize {

--- a/src/renumber/bin/command_line.rs
+++ b/src/renumber/bin/command_line.rs
@@ -39,6 +39,17 @@ pub struct Arguments {
     /// read back.
     #[clap(long, action)]
     pub out_ordering: String,
+
+    /// Which order to number in.
+    ///
+    /// `border-first` puts the border nodes of the coarsest cells at the front
+    /// of the whole graph, which is what a search in memory wants.
+    /// `cell-path` keeps every cell, and so every subtree, in one run of
+    /// numbers, which is what a store that hands out a subtree at a time
+    /// wants. Measured over europe.ptv the second costs a fifth of the median
+    /// query, all of it on the long routes.
+    #[clap(long, value_enum, default_value_t = Order::BorderFirst)]
+    pub numbering: Order,
 }
 
 impl Display for Arguments {
@@ -51,5 +62,20 @@ impl Display for Arguments {
         writeln!(f, "out directory: {}", self.out_directory)?;
         writeln!(f, "out coordinates: {}", self.out_coordinates)?;
         writeln!(f, "out ordering: {}", self.out_ordering)
+    }
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Order {
+    BorderFirst,
+    CellPath,
+}
+
+impl From<Order> for toolbox_rs::node_ordering::Numbering {
+    fn from(order: Order) -> Self {
+        match order {
+            Order::BorderFirst => Self::BorderFirst,
+            Order::CellPath => Self::CellPath,
+        }
     }
 }

--- a/src/renumber/bin/main.rs
+++ b/src/renumber/bin/main.rs
@@ -69,7 +69,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let started = Instant::now();
-    let ordering = NodeOrdering::of(&graph, &PackedPartition::of(&directory));
+    let ordering = NodeOrdering::in_order(
+        &graph,
+        &PackedPartition::of(&directory),
+        args.numbering.into(),
+    );
     info!(
         "numbered {} nodes in {:.1} s, {} of them ({:.1}%) on the border of a cell",
         ordering.len(),


### PR DESCRIPTION
Second of five, on #606.

## What changes

### `CellTree`

`LevelDirectory` holds the assembly's answer in the form the assembly left it:
the cell of each node and the parent of each cell. That answers about a node
and nothing else — it cannot say what a cell holds without walking every node,
how many of those are on its border without walking every arc, or where it is
on the ground at all. A store that hands out one cell at a time needs all
three before it reads anything.

    CellTree::of(&LevelDirectory, &PackedPartition, &G, &[FPCoordinate])
    CellTree::children_of / parent_of / facts / bounds
    CellTree::key_of(level, cell) -> CellKey
    CellTree::range_of(level, cell) -> (u128, u128)
    CellTree::unpacked_bytes(level) / nodes_begin(level, cell)

A key is the path from the root to a cell, packed the way `PackedPartition`
packs a node's. Sorting keys walks the tree, and a cell's subtree is exactly
one range of keys — checked exhaustively against every node of every cell of
every level.

Also `PackedPartition::level_layout`, which is the bit layout of a key and has
to be stored beside keys, and `BoundingBox` serializes.

### The overlay trait

    trait CellTable { border_nodes, row, column, place_of }
    trait Overlay {
        type Graph: Graph<u32>;
        type Table<'a>: CellTable;
        graph, partition, border_levels, levels, cells_on_level, distances_of
    }

The searches named `Customization`, which is the overlay a server holds: every
table kept and handed out as a reference, nothing being able to move
underneath it. A store that pages cannot do that — its tables live in a cache
free to evict one, so handing a table out has to hold it open while the search
reads it, which is a guard with a lifetime the store decides.

`Customization` implements it with `Table<'a> = &'a CellDistances`, which is
what it was already doing. `MldSearch::run` and `BidirectionalMldSearch::run`
are generic and neither names `Customization` outside its own tests. Nothing
about the algorithm moved.

A test builds a second store whose `Table` is a guard rather than a reference,
runs the same search over both and compares every answer. If a guard fits, a
store that reads and decompresses fits.

Deliberately **not** on the trait: anything that builds. A store reading a
packed file cannot customize a cell; a customization that works one out on
demand does so behind `distances_of` and the search cannot tell.

## Measurements

europe.ptv, cell-path numbering, six levels, key 76 bits wide:

| level | cells | bits | on border | share |
|---|---|---|---|---|
| 0 | 497,965 | 19 | 3,029,336 | 16.8% |
| 1 | 98,375 | 17 | 1,112,165 | 6.2% |
| 2 | 24,384 | 15 | 480,999 | 2.7% |
| 3 | 2,440 | 12 | 123,960 | 0.7% |
| 4 | 245 | 8 | 30,419 | 0.2% |
| 5 | 26 | 5 | 6,521 | 0.0% |

The tree builds in 0.76s and is 19.5 MiB written, which a device holds before
it can look anything up. The border counts agree exactly with what the
customization arrives at by another route.

The trait costs nothing: `ranks time` medians over 4,800 pairs were 63.0 and
63.9µs on two rounds before and are 63.3 and 60.9 after; bidirectional-mld is
54.1 and 57.0.

## A bug the cross-check caught

Asking each node about its own **outgoing** arcs misses every node that can
only be entered from another cell, which a directed road network has plenty
of — 261,684 nodes of the finest level, nearly a tenth of its border. Both
ends of an arc are counted now and a test holds it. The counts matching
customization's is the only reason it was found.

`sound` passes on the cell-path renumbered instance: level 0 over 22,920,778
pairs and level 2 over 11,968,001, both against plain Dijkstra on the graph.