### PR TITLE
Pack cell tables at one bit width, and number the cells in key order

### DIFF
--- a/examples/block_pack.rs
+++ b/examples/block_pack.rs
@@ -1,0 +1,241 @@
+//! Packs an instance into blocks and reads every table back out of them.
+//!
+//! ```text
+//! block_pack <graph> <directory> <coordinates> [target MiB]
+//! ```
+//!
+//! Wants an instance numbered by cell path, since a block says where a border
+//! node sits inside its cell's run of numbers and there is no run otherwise.
+//!
+//! Cuts a level's cells into blocks of about the target size, packs each, and
+//! then unpacks every table and compares it with what went in. Reports what
+//! the blocks come to and how much of that is not the entries themselves.
+//!
+//! Also asks whether the cells of a level are numbered in the order their keys
+//! run, which decides whether a block is a run of cell numbers or has to carry
+//! a list of which cells it holds.
+
+use std::{env::args, time::Instant};
+
+use toolbox_rs::{
+    cell_block::{CellBlock, CellEntry},
+    cell_tree::CellTree,
+    customization::Customization,
+    geometry::FPCoordinate,
+    io,
+    level_directory::LevelDirectory,
+    packed_partition::PackedPartition,
+    static_graph::StaticGraph,
+};
+
+fn megabytes(bytes: u64) -> String {
+    format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!(
+                "usage: block_pack <graph> <directory> <coordinates> [target MiB]: missing {what}"
+            )
+        })
+    };
+    let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
+    let directory: LevelDirectory = io::read_from_file(&next("directory"));
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&next("coordinates"));
+    let target = argv
+        .next()
+        .map_or(4.0, |mib| mib.parse::<f64>().expect("a size in MiB"))
+        * 1024.0
+        * 1024.0;
+
+    let levels = directory.levels();
+    let partition = PackedPartition::of(&directory);
+    let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+    let customization = Customization::new(graph, directory);
+
+    println!(
+        "{:>5} {:>9} {:>7} {:>10} {:>10} {:>9} {:>7} {:>7}",
+        "level", "cells", "blocks", "raw", "blocks", "framing", "share", "wrong"
+    );
+    let started = Instant::now();
+    let (mut all_raw, mut all_block, mut all_framing, mut all_wrong, mut all_blocks) =
+        (0_u64, 0_u64, 0_u64, 0_u64, 0_u64);
+    let mut keys_in_order = true;
+
+    for level in 0..levels {
+        let holding = customization.level(level);
+        let count = tree.cells_on_level(level);
+
+        // are the cells numbered the way their keys run?
+        let mut last = 0_u128;
+        for cell in 0..count {
+            let (first, _) = tree.range_of(level, cell as u32);
+            if first < last {
+                keys_in_order = false;
+            }
+            last = first;
+        }
+
+        // the finest level is the one whose border nodes lead each run
+        let border_leads = level == 0;
+        let (mut raw, mut packed, mut framing, mut wrong, mut blocks) =
+            (0_u64, 0_u64, 0_u64, 0_u64, 0_u64);
+
+        let mut held: Vec<Vec<u32>> = Vec::new();
+        let mut widths: Vec<usize> = Vec::new();
+        let mut places: Vec<Vec<u32>> = Vec::new();
+        let mut holds: Vec<usize> = Vec::new();
+        let mut first_of_run = 0_u32;
+        let mut carrying = 0_f64;
+
+        let flush = |held: &mut Vec<Vec<u32>>,
+                     widths: &mut Vec<usize>,
+                     places: &mut Vec<Vec<u32>>,
+                     holds: &mut Vec<usize>,
+                     first: u32,
+                     raw: &mut u64,
+                     packed: &mut u64,
+                     framing: &mut u64,
+                     wrong: &mut u64,
+                     blocks: &mut u64| {
+            if held.is_empty() {
+                return;
+            }
+            let entries = held
+                .iter()
+                .zip(widths.iter())
+                .zip(places.iter())
+                .zip(holds.iter())
+                .map(|(((matrix, &wide), places), &holds)| CellEntry {
+                    matrix,
+                    wide,
+                    places,
+                    holds,
+                })
+                .collect::<Vec<_>>();
+            let block = CellBlock::of(level, first, &entries, border_leads);
+            *packed += block.bytes() as u64;
+            *framing += block.framing_bytes() as u64;
+            *blocks += 1;
+
+            let mut out = Vec::new();
+            let mut read_places = Vec::new();
+            for (which, matrix) in held.iter().enumerate() {
+                block.unpack_into(which, widths, &mut out);
+                if &out != matrix {
+                    *wrong += 1;
+                }
+                block.places_into(which, widths, &mut read_places);
+                if !border_leads && read_places != places[which] {
+                    *wrong += 1;
+                }
+                *raw += matrix.len() as u64 * 4;
+            }
+            held.clear();
+            widths.clear();
+            places.clear();
+            holds.clear();
+        };
+
+        for cell in 0..count {
+            let Some(table) = customization.distances_of(level, cell as u32) else {
+                continue;
+            };
+            let nodes = holding.nodes_of(cell as u32);
+            let wide = table.border_nodes_of().len();
+            let mut matrix = Vec::with_capacity(wide * wide);
+            for source in 0..wide {
+                matrix.extend_from_slice(table.row(source));
+            }
+            // a border node as an offset into the cell's run rather than a
+            // node of the graph
+            let base = nodes.first().copied().unwrap_or(0);
+            let at = if border_leads {
+                Vec::new()
+            } else {
+                table
+                    .border_nodes_of()
+                    .iter()
+                    .map(|&node| node - base as u32)
+                    .collect()
+            };
+
+            if held.is_empty() {
+                first_of_run = cell as u32;
+            }
+            carrying += (matrix.len() * 4) as f64;
+            held.push(matrix);
+            widths.push(wide);
+            places.push(at);
+            holds.push(nodes.len());
+
+            if carrying >= target {
+                flush(
+                    &mut held,
+                    &mut widths,
+                    &mut places,
+                    &mut holds,
+                    first_of_run,
+                    &mut raw,
+                    &mut packed,
+                    &mut framing,
+                    &mut wrong,
+                    &mut blocks,
+                );
+                carrying = 0.0;
+            }
+        }
+        flush(
+            &mut held,
+            &mut widths,
+            &mut places,
+            &mut holds,
+            first_of_run,
+            &mut raw,
+            &mut packed,
+            &mut framing,
+            &mut wrong,
+            &mut blocks,
+        );
+
+        println!(
+            "{level:>5} {count:>9} {blocks:>7} {:>10} {:>10} {:>9} {:>7} {:>7}",
+            megabytes(raw),
+            megabytes(packed),
+            megabytes(framing),
+            format!("{:.0}%", 100.0 * packed as f64 / raw.max(1) as f64),
+            wrong,
+        );
+        all_raw += raw;
+        all_block += packed;
+        all_framing += framing;
+        all_wrong += wrong;
+        all_blocks += blocks;
+    }
+
+    println!("\npacked {all_blocks} blocks in {:.1?}", started.elapsed());
+    for (name, bytes) in [
+        ("raw, four bytes an entry", all_raw),
+        ("the blocks", all_block),
+        ("of which framing", all_framing),
+    ] {
+        println!(
+            "  {name:<28} {:>10}  {:>5}",
+            megabytes(bytes),
+            format!("{:.1}%", 100.0 * bytes as f64 / all_raw.max(1) as f64),
+        );
+    }
+    println!(
+        "  cells numbered as their keys run: {}",
+        if keys_in_order { "yes" } else { "NO" }
+    );
+    if all_wrong == 0 {
+        println!("  every table and every place read back as it was written");
+    } else {
+        println!("  {all_wrong} TABLES OR PLACES DID NOT READ BACK");
+        std::process::exit(1);
+    }
+}

--- a/examples/distance_stats.rs
+++ b/examples/distance_stats.rs
@@ -1,0 +1,251 @@
+//! What the cell tables actually hold, and what encodings would cost.
+//!
+//! ```text
+//! distance_stats <graph> <directory>
+//! ```
+//!
+//! The tables are the bulk of what a store ships, so how they are written down
+//! is worth choosing on the numbers rather than on a guess. This customizes
+//! every cell and asks, per level, what the distances in a row look like and
+//! what each of four ways of writing them would come to.
+//!
+//! The four:
+//!
+//! - **raw**, four bytes an entry, which is what is held in memory today.
+//! - **min and two bytes**, the smallest of the row and then each entry as its
+//!   distance above it. An entry that does not fit escapes to a list.
+//! - **min and a row width**, the same but with the deltas cut to as many bits
+//!   as the widest of them needs, one width for the row.
+//! - **min and a cell width**, one width for the whole table rather than one a
+//!   row, which costs bits on the narrow rows and saves the per-row byte.
+//!
+//! What cannot be reached takes the largest value the width holds, so a width
+//! has to have room for one more than the widest real distance.
+
+use std::{env::args, time::Instant};
+
+use rayon::prelude::*;
+use toolbox_rs::{
+    customization::Customization, io, level_directory::LevelDirectory, static_graph::StaticGraph,
+};
+
+/// What one way of writing the tables down comes to.
+#[derive(Clone, Copy, Default)]
+struct Cost {
+    bytes: u64,
+    /// entries that had to be written out of line
+    escaped: u64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct Counts {
+    rows: u64,
+    entries: u64,
+    unreachable: u64,
+    /// rows whose spread fits in two bytes
+    narrow_rows: u64,
+    raw: Cost,
+    two_bytes: Cost,
+    row_width: Cost,
+    cell_width: Cost,
+    /// the widest spread seen in any row
+    widest: u32,
+    /// rows whose smallest reachable distance is not nought
+    least_not_nought: u64,
+    /// a cell width with no per-row least written at all
+    bare: Cost,
+}
+
+impl Counts {
+    fn fold(mut self, other: Self) -> Self {
+        self.rows += other.rows;
+        self.entries += other.entries;
+        self.unreachable += other.unreachable;
+        self.narrow_rows += other.narrow_rows;
+        self.raw.bytes += other.raw.bytes;
+        self.two_bytes.bytes += other.two_bytes.bytes;
+        self.two_bytes.escaped += other.two_bytes.escaped;
+        self.row_width.bytes += other.row_width.bytes;
+        self.cell_width.bytes += other.cell_width.bytes;
+        self.widest = self.widest.max(other.widest);
+        self.least_not_nought += other.least_not_nought;
+        self.bare.bytes += other.bare.bytes;
+        self
+    }
+}
+
+/// How many bits it takes to hold every number up to and including `largest`.
+fn bits_for(largest: u32) -> u32 {
+    if largest == 0 {
+        1
+    } else {
+        u32::BITS - largest.leading_zeros()
+    }
+}
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next()
+            .unwrap_or_else(|| panic!("usage: distance_stats <graph> <directory>: missing {what}"))
+    };
+    let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
+    let directory: LevelDirectory = io::read_from_file(&next("directory"));
+    let levels = directory.levels();
+    let customization = Customization::new(graph, directory);
+
+    println!(
+        "{:>5} {:>11} {:>7} {:>8} {:>10} {:>10} {:>10} {:>10}",
+        "level", "entries", "unreach", "fit 2B", "raw", "min+2B", "row width", "cell width"
+    );
+    let started = Instant::now();
+    let mut whole = Counts::default();
+    for level in 0..levels {
+        let cells = customization.cells_on_level(level);
+        let counts = (0..cells)
+            .into_par_iter()
+            .map(|cell| {
+                let mut counts = Counts::default();
+                let Some(table) = customization.distances_of(level, cell as u32) else {
+                    return counts;
+                };
+                let wide = table.border_nodes_of().len();
+                // one width for the whole table wants the widest spread in it,
+                // so the rows are looked at once to find it and once to count
+                let mut widest_in_cell = 0_u32;
+                for source in 0..wide {
+                    let row = table.row(source);
+                    if let Some(spread) = spread_of(row) {
+                        widest_in_cell = widest_in_cell.max(spread);
+                    }
+                }
+                let cell_bits = u64::from(bits_for(widest_in_cell.saturating_add(1)));
+
+                for source in 0..wide {
+                    let row = table.row(source);
+                    let entries = row.len() as u64;
+                    counts.rows += 1;
+                    counts.entries += entries;
+                    counts.unreachable += row.iter().filter(|&&at| at == u32::MAX).count() as u64;
+                    counts.raw.bytes += entries * 4;
+
+                    let Some(spread) = spread_of(row) else {
+                        // nothing reachable: a width of nothing and a flag
+                        counts.two_bytes.bytes += 5;
+                        counts.row_width.bytes += 5;
+                        counts.cell_width.bytes += 4;
+                        counts.bare.bytes += 0;
+                        continue;
+                    };
+                    counts.widest = counts.widest.max(spread);
+                    if spread < u32::from(u16::MAX) {
+                        counts.narrow_rows += 1;
+                    }
+                    // the smallest of the row, written once
+                    let escaped = row
+                        .iter()
+                        .filter(|&&at| {
+                            at != u32::MAX && u64::from(at) - u64::from(least(row)) >= 0xFFFF
+                        })
+                        .count() as u64;
+                    counts.two_bytes.escaped += escaped;
+                    // four for the least, two an entry, and six for each that
+                    // had to be written out of line
+                    counts.two_bytes.bytes += 4 + entries * 2 + escaped * 6;
+
+                    let bits = u64::from(bits_for(spread.saturating_add(1)));
+                    counts.row_width.bytes += 4 + 1 + (entries * bits).div_ceil(8);
+                    counts.cell_width.bytes += 4 + (entries * cell_bits).div_ceil(8);
+                    // the same without the least, which is worth asking about
+                    // because a row holds the distance from a node to itself
+                    if least(row) != 0 {
+                        counts.least_not_nought += 1;
+                    }
+                    counts.bare.bytes += (entries * cell_bits).div_ceil(8);
+                }
+                counts
+            })
+            .reduce(Counts::default, Counts::fold);
+
+        report(level, &counts);
+        whole = whole.fold(counts);
+    }
+    println!("customized and walked in {:.1?}", started.elapsed());
+    report_whole(&whole);
+}
+
+/// The smallest distance in a row that can be reached at all.
+fn least(row: &[u32]) -> u32 {
+    row.iter()
+        .copied()
+        .filter(|&at| at != u32::MAX)
+        .min()
+        .unwrap_or(0)
+}
+
+/// How far the reachable entries of a row spread, and nothing for a row that
+/// reaches nowhere.
+fn spread_of(row: &[u32]) -> Option<u32> {
+    let mut low = u32::MAX;
+    let mut high = 0_u32;
+    let mut any = false;
+    for &at in row {
+        if at == u32::MAX {
+            continue;
+        }
+        any = true;
+        low = low.min(at);
+        high = high.max(at);
+    }
+    any.then(|| high - low)
+}
+
+fn megabytes(bytes: u64) -> String {
+    format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+fn report(level: usize, counts: &Counts) {
+    println!(
+        "{level:>5} {:>11} {:>7} {:>8} {:>10} {:>10} {:>10} {:>10}",
+        counts.entries,
+        format!(
+            "{:.1}%",
+            100.0 * counts.unreachable as f64 / counts.entries.max(1) as f64
+        ),
+        format!(
+            "{:.1}%",
+            100.0 * counts.narrow_rows as f64 / counts.rows.max(1) as f64
+        ),
+        megabytes(counts.raw.bytes),
+        megabytes(counts.two_bytes.bytes),
+        megabytes(counts.row_width.bytes),
+        megabytes(counts.cell_width.bytes),
+    );
+}
+
+fn report_whole(counts: &Counts) {
+    let raw = counts.raw.bytes as f64;
+    println!(
+        "\n{} entries, {} rows, widest spread {}, {} rows whose least is not nought",
+        counts.entries, counts.rows, counts.widest, counts.least_not_nought
+    );
+    for (name, cost) in [
+        ("raw, four bytes", counts.raw),
+        ("least and two bytes", counts.two_bytes),
+        ("least and a row width", counts.row_width),
+        ("least and a cell width", counts.cell_width),
+        ("a cell width, no least", counts.bare),
+    ] {
+        println!(
+            "  {name:<24} {:>10}  {:>6}{}",
+            megabytes(cost.bytes),
+            format!("{:.0}%", 100.0 * cost.bytes as f64 / raw),
+            if cost.escaped > 0 {
+                format!(", {} written out of line", cost.escaped)
+            } else {
+                String::new()
+            }
+        );
+    }
+}

--- a/examples/layout_check.rs
+++ b/examples/layout_check.rs
@@ -31,6 +31,10 @@ use toolbox_rs::{
     customization::Customization, io, level_directory::LevelDirectory, static_graph::StaticGraph,
 };
 
+fn directory_of(customization: &Customization) -> &LevelDirectory {
+    customization.directory()
+}
+
 fn main() {
     env_logger::init();
     let mut argv = args().skip(1);
@@ -95,7 +99,25 @@ fn main() {
         );
     }
 
+    // and whether the cells of a level are laid out under their parents, which
+    // is what makes a cell's children a run rather than a list
+    let mut children_run = true;
+    for level in 1..levels {
+        let above = directory_of(&customization)
+            .parents_on_level(level - 1)
+            .to_vec();
+        children_run &= above.windows(2).all(|pair| pair[0] <= pair[1]);
+    }
+
     println!();
+    println!(
+        "the children of a cell are a run:       {}",
+        if children_run {
+            "yes, everywhere"
+        } else {
+            "NO"
+        }
+    );
     println!(
         "the nodes of a cell are the run itself: {}",
         if all_runs { "yes, everywhere" } else { "NO" }

--- a/examples/layout_check.rs
+++ b/examples/layout_check.rs
@@ -1,0 +1,118 @@
+//! Two things a store would like to be true of a numbering, asked rather than
+//! assumed.
+//!
+//! ```text
+//! layout_check <graph> <directory>
+//! ```
+//!
+//! Under [`Numbering::CellPath`] every cell is one run of numbers. Two further
+//! things follow if the run is laid out the way it looks like it is, and each
+//! is worth a lot to a store:
+//!
+//! **The nodes of a cell are the run itself.** If the numbers in a cell are
+//! exactly the numbers of the run, then nothing has to say which nodes a cell
+//! holds: the range says it. A store keeps a first and a count instead of a
+//! list, and so does the cell tree, whose list is a number per node per level.
+//!
+//! **The border nodes lead the run.** A table is addressed by where a node
+//! sits in it, so a store has to be able to turn a place into a node. If the
+//! border nodes of a cell are the first of its run, that is an addition, and
+//! the list of border nodes -- four bytes for every one of them, at every
+//! level -- is not needed at all.
+//!
+//! Neither is true under the other numbering, and neither is guaranteed by
+//! contiguity alone, so this checks both.
+//!
+//! [`Numbering::CellPath`]: toolbox_rs::node_ordering::Numbering::CellPath
+
+use std::env::args;
+
+use toolbox_rs::{
+    customization::Customization, io, level_directory::LevelDirectory, static_graph::StaticGraph,
+};
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next()
+            .unwrap_or_else(|| panic!("usage: layout_check <graph> <directory>: missing {what}"))
+    };
+    let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
+    let directory: LevelDirectory = io::read_from_file(&next("directory"));
+    let levels = directory.levels();
+    let customization = Customization::new(graph, directory);
+
+    println!(
+        "{:>5} {:>9} {:>16} {:>16} {:>12}",
+        "level", "cells", "a run of numbers", "border in front", "border nodes"
+    );
+    let mut all_runs = true;
+    let mut all_in_front = true;
+    for level in 0..levels {
+        let holding = customization.level(level);
+        let cells = holding.cells();
+        let mut runs = 0_usize;
+        let mut in_front = 0_usize;
+        let mut border_nodes = 0_u64;
+        for cell in 0..cells {
+            let nodes = holding.nodes_of(cell as u32);
+            if nodes.is_empty() {
+                runs += 1;
+                in_front += 1;
+                continue;
+            }
+            // the run itself: every number from the first to the last, in order
+            let first = nodes[0];
+            if nodes
+                .iter()
+                .enumerate()
+                .all(|(at, &node)| node == first + at)
+            {
+                runs += 1;
+            }
+            // and the ones on the border are the front of it
+            let border = nodes
+                .iter()
+                .filter(|&&node| holding.on_border(node))
+                .count();
+            border_nodes += border as u64;
+            if nodes[..border].iter().all(|&node| holding.on_border(node))
+                && nodes[border..].iter().all(|&node| !holding.on_border(node))
+            {
+                in_front += 1;
+            }
+        }
+        all_runs &= runs == cells;
+        all_in_front &= in_front == cells;
+        println!(
+            "{level:>5} {cells:>9} {:>16} {:>16} {border_nodes:>12}",
+            format!("{runs} ({:.1}%)", 100.0 * runs as f64 / cells.max(1) as f64),
+            format!(
+                "{in_front} ({:.1}%)",
+                100.0 * in_front as f64 / cells.max(1) as f64
+            ),
+        );
+    }
+
+    println!();
+    println!(
+        "the nodes of a cell are the run itself: {}",
+        if all_runs { "yes, everywhere" } else { "NO" }
+    );
+    println!(
+        "the border nodes lead the run:          {}",
+        if all_in_front {
+            "yes, everywhere"
+        } else {
+            "NO"
+        }
+    );
+    if all_runs && all_in_front {
+        println!(
+            "\nso a cell wants a first and a count, and a place in a table is a\n\
+             node without being told: nothing has to store which nodes a cell\n\
+             holds, nor which of them are on its border."
+        );
+    }
+}

--- a/examples/pack_check.rs
+++ b/examples/pack_check.rs
@@ -1,0 +1,186 @@
+//! Packs every cell table of an instance and reads every one of them back.
+//!
+//! ```text
+//! pack_check <graph> <directory>
+//! ```
+//!
+//! The tables are what a store is mostly made of, so the thing to know about
+//! the way they are written down is whether it gives back what it was given.
+//! This customizes every cell, packs its table, unpacks it and compares it
+//! entry by entry with what went in. Anything that differs is reported and
+//! counted; nothing is sampled.
+//!
+//! What it says at the end is what the tables come to packed against what they
+//! come to as four-byte numbers, per level and in all.
+
+use std::{
+    env::args,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use rayon::prelude::*;
+use toolbox_rs::{
+    customization::Customization, io, level_directory::LevelDirectory,
+    packed_distances::PackedDistances, static_graph::StaticGraph,
+};
+
+#[derive(Clone, Copy, Default)]
+struct Counts {
+    cells: u64,
+    entries: u64,
+    raw: u64,
+    packed: u64,
+    /// the entries alone, without the frame a table is held in
+    payload: u64,
+    wrong: u64,
+    /// the widest and narrowest a table came out
+    widest_bits: u32,
+    narrowest_bits: u32,
+}
+
+impl Counts {
+    fn fold(mut self, other: Self) -> Self {
+        self.cells += other.cells;
+        self.entries += other.entries;
+        self.raw += other.raw;
+        self.packed += other.packed;
+        self.payload += other.payload;
+        self.wrong += other.wrong;
+        self.widest_bits = self.widest_bits.max(other.widest_bits);
+        self.narrowest_bits = if self.narrowest_bits == 0 {
+            other.narrowest_bits
+        } else if other.narrowest_bits == 0 {
+            self.narrowest_bits
+        } else {
+            self.narrowest_bits.min(other.narrowest_bits)
+        };
+        self
+    }
+}
+
+fn megabytes(bytes: u64) -> String {
+    format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next()
+            .unwrap_or_else(|| panic!("usage: pack_check <graph> <directory>: missing {what}"))
+    };
+    let graph = StaticGraph::new(io::read_edges_from_file(&next("graph")));
+    let directory: LevelDirectory = io::read_from_file(&next("directory"));
+    let levels = directory.levels();
+    let customization = Customization::new(graph, directory);
+
+    // reported rather than asserted, so that a run says how much is wrong
+    // rather than stopping at the first of it
+    static SHOWN: AtomicU64 = AtomicU64::new(0);
+
+    println!(
+        "{:>5} {:>9} {:>11} {:>10} {:>10} {:>10} {:>7} {:>7}",
+        "level", "cells", "entries", "raw", "entries", "framing", "share", "wrong"
+    );
+    let started = Instant::now();
+    let mut whole = Counts::default();
+    for level in 0..levels {
+        let cells = customization.cells_on_level(level);
+        let counts = (0..cells)
+            .into_par_iter()
+            .map(|cell| {
+                let mut counts = Counts::default();
+                let Some(table) = customization.distances_of(level, cell as u32) else {
+                    return counts;
+                };
+                let wide = table.border_nodes_of().len();
+                // the table as one run, which is what the packer takes
+                let mut matrix = Vec::with_capacity(wide * wide);
+                for source in 0..wide {
+                    matrix.extend_from_slice(table.row(source));
+                }
+
+                let packed = PackedDistances::of(&matrix, wide);
+                let mut read = Vec::new();
+                packed.unpack_into(&mut read);
+
+                counts.cells = 1;
+                counts.entries = matrix.len() as u64;
+                counts.raw = matrix.len() as u64 * 4;
+                counts.packed = packed.bytes() as u64;
+                // what the entries themselves come to. The rest is the frame:
+                // the width, the bit width and the vector header, which in a
+                // block move into the directory and stop being paid per cell.
+                counts.payload = (matrix.len() as u64 * u64::from(packed.bits())).div_ceil(8);
+                counts.widest_bits = packed.bits();
+                counts.narrowest_bits = packed.bits();
+                if read != matrix {
+                    counts.wrong = read
+                        .iter()
+                        .zip(&matrix)
+                        .filter(|(read, was)| read != was)
+                        .count() as u64;
+                    if SHOWN.fetch_add(1, Ordering::Relaxed) < 4 {
+                        let (place, (read, was)) = read
+                            .iter()
+                            .zip(&matrix)
+                            .enumerate()
+                            .find(|(_, (read, was))| read != was)
+                            .expect("something differed");
+                        println!(
+                            "  level {level}, cell {cell}, entry {place}: read {read}, was {was}"
+                        );
+                    }
+                }
+                counts
+            })
+            .reduce(Counts::default, Counts::fold);
+
+        println!(
+            "{level:>5} {:>9} {:>11} {:>10} {:>10} {:>10} {:>7} {:>7}",
+            counts.cells,
+            counts.entries,
+            megabytes(counts.raw),
+            megabytes(counts.payload),
+            megabytes(counts.packed - counts.payload),
+            format!(
+                "{:.0}%",
+                100.0 * counts.payload as f64 / counts.raw.max(1) as f64
+            ),
+            counts.wrong,
+        );
+        whole = whole.fold(counts);
+    }
+
+    println!(
+        "\npacked {} cells and {} entries in {:.1?}",
+        whole.cells,
+        whole.entries,
+        started.elapsed()
+    );
+    for (name, bytes) in [
+        ("raw, four bytes an entry", whole.raw),
+        ("the entries packed", whole.payload),
+        (
+            "and the frame a block does not pay",
+            whole.packed - whole.payload,
+        ),
+    ] {
+        println!(
+            "  {name:<36} {:>10}  {:>5}",
+            megabytes(bytes),
+            format!("{:.0}%", 100.0 * bytes as f64 / whole.raw.max(1) as f64),
+        );
+    }
+    println!(
+        "  widths from {} to {} bits",
+        whole.narrowest_bits, whole.widest_bits
+    );
+    if whole.wrong == 0 {
+        println!("  every entry of every table read back as it was written");
+    } else {
+        println!("  {} ENTRIES DID NOT READ BACK", whole.wrong);
+        std::process::exit(1);
+    }
+}

--- a/src/cell_block.rs
+++ b/src/cell_block.rs
@@ -1,0 +1,413 @@
+//! A run of cells of one level, with their tables written back to back.
+//!
+//! # What a block does not hold
+//!
+//! Almost everything a table needs to be read is already known without it.
+//!
+//! How wide a cell's table is, is how many border nodes the cell has, which
+//! the [cell tree](crate::cell_tree::CellTree) says. A block that stored it
+//! again would pay four bytes a cell for an answer it was handed. Where a
+//! cell's table begins follows from the widths and the bit widths of the cells
+//! before it, so it is added up when the block is read rather than written
+//! down. What is left is one byte a cell, the width its entries are packed at,
+//! and the entries themselves.
+//!
+//! That is what "the framing moves into the directory" comes to: held one
+//! table to a struct, the frame was 19.0 MiB over europe.ptv and 15.2 MiB of
+//! it on the finest level alone.
+//!
+//! # Which node a place in a table is
+//!
+//! A table is addressed by where a node sits in it, so reading one means
+//! turning a place back into a node. Under
+//! [`Numbering::CellPath`](crate::node_ordering::Numbering::CellPath) the
+//! nodes of a cell are exactly the run of numbers between its first and its
+//! last, measured over europe.ptv and true of every cell of every level. So a
+//! place is a node as soon as it is known where in the run the border nodes
+//! are.
+//!
+//! On the finest level they are the front of it: a node on the border of its
+//! level-0 cell is a node on a border at all, and the numbering puts those
+//! first inside a cell. Measured, that holds for every one of 497,965 cells,
+//! and a block of the finest level therefore stores nothing at all about
+//! which nodes its tables are about.
+//!
+//! Above the finest it cannot hold, and not because the numbering is wrong. A
+//! level-1 cell's run is the runs of its children laid end to end, each sorted
+//! within itself; gathering its border nodes to the front would take them out
+//! of their children and the children would no longer be runs. One or the
+//! other, not both. Measured: 1.9% of level-1 cells have their border nodes in
+//! front, and near none above that.
+//!
+//! So above the finest level a block holds where each border node sits inside
+//! its cell's run, packed at as many bits as the widest run in the block
+//! needs. That is an offset into a cell rather than a node of the graph, which
+//! on europe.ptv is between six and twenty bits rather than thirty-two.
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::packed_distances::{bits_for, read_at, write_at};
+
+/// The version this is written under.
+pub const VERSION: u16 = 1;
+
+/// A run of cells of one level and everything needed to read their tables.
+#[derive(Clone, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct CellBlock {
+    version: u16,
+    level: u8,
+    /// the first cell of the run
+    first: u32,
+    /// how many bits an entry of each cell's table takes, one a cell
+    bits: Vec<u8>,
+    /// Where each border node sits in its cell's run of nodes, at
+    /// `place_bits` apiece and laid out cell after cell.
+    ///
+    /// Empty where the border nodes are the front of the run, which is the
+    /// finest level, and there is nothing to say.
+    places: Vec<u8>,
+    place_bits: u8,
+    /// the tables, back to back, each at its own width
+    tables: Vec<u8>,
+}
+
+/// What a block is built from, one of these a cell, in key order.
+pub struct CellEntry<'a> {
+    /// the cell's table, `wide * wide` entries by row
+    pub matrix: &'a [u32],
+    /// how many border nodes the cell has, which is the side of the table
+    pub wide: usize,
+    /// where each border node sits in the cell's run of nodes, and empty
+    /// where they are the front of it
+    pub places: &'a [u32],
+    /// how many nodes the cell holds, which bounds a place
+    pub holds: usize,
+}
+
+impl CellBlock {
+    /// Writes a run of cells down.
+    ///
+    /// `border_leads` says that the border nodes of every cell are the front
+    /// of its run, so that nothing is stored about where they are.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a matrix is not square, or if places are given when the
+    /// border nodes are said to lead, or missing when they are not.
+    #[must_use]
+    pub fn of(level: usize, first: u32, cells: &[CellEntry<'_>], border_leads: bool) -> Self {
+        let mut bits = Vec::with_capacity(cells.len());
+        let mut table_bits = 0_usize;
+        let mut widest_run = 0_u32;
+        let mut places_count = 0_usize;
+        for cell in cells {
+            assert_eq!(
+                cell.matrix.len(),
+                cell.wide * cell.wide,
+                "a table is square"
+            );
+            assert_eq!(
+                cell.places.is_empty(),
+                border_leads,
+                "a cell says one thing about its border and the block another"
+            );
+            let widest = cell
+                .matrix
+                .iter()
+                .copied()
+                .filter(|&at| at != u32::MAX)
+                .max()
+                .unwrap_or(0);
+            let width = bits_for(widest.saturating_add(1)).min(u32::BITS);
+            bits.push(u8::try_from(width).expect("a width of more bits than a byte counts"));
+            table_bits += cell.matrix.len() * width as usize;
+            widest_run = widest_run.max(u32::try_from(cell.holds).unwrap_or(u32::MAX));
+            places_count += cell.places.len();
+        }
+
+        // a place is an offset into a cell rather than a node of the graph, so
+        // it needs room for the longest run in the block and no more
+        let place_bits = if border_leads {
+            0
+        } else {
+            bits_for(widest_run.max(1))
+        };
+
+        let mut tables = vec![0_u8; table_bits.div_ceil(8)];
+        let mut places = vec![0_u8; (places_count * place_bits as usize).div_ceil(8)];
+        let mut at_table = 0_usize;
+        let mut at_place = 0_usize;
+        for (cell, &width) in cells.iter().zip(&bits) {
+            let width = u32::from(width);
+            let unreachable = mask_of(width);
+            for &entry in cell.matrix {
+                let value = if entry == u32::MAX {
+                    unreachable
+                } else {
+                    entry
+                };
+                write_at(&mut tables, at_table, width, value);
+                at_table += width as usize;
+            }
+            for &place in cell.places {
+                write_at(&mut places, at_place, place_bits, place);
+                at_place += place_bits as usize;
+            }
+        }
+
+        Self {
+            version: VERSION,
+            level: u8::try_from(level).expect("more levels than a byte counts"),
+            first,
+            bits,
+            places,
+            place_bits: u8::try_from(place_bits).expect("a width of more bits than a byte counts"),
+            tables,
+        }
+    }
+
+    #[must_use]
+    pub fn level(&self) -> usize {
+        self.level as usize
+    }
+
+    #[must_use]
+    pub fn first(&self) -> u32 {
+        self.first
+    }
+
+    #[must_use]
+    pub fn cells(&self) -> usize {
+        self.bits.len()
+    }
+
+    /// Whether the border nodes of every cell are the front of its run.
+    #[must_use]
+    pub fn border_leads(&self) -> bool {
+        self.places.is_empty()
+    }
+
+    /// What the block takes up.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>() + self.bits.capacity() + self.places.capacity() + self.tables.capacity()
+    }
+
+    /// What is written down beyond the entries themselves.
+    #[must_use]
+    pub fn framing_bytes(&self) -> usize {
+        self.bits.capacity() + self.places.capacity()
+    }
+
+    /// Reads one cell's table back, as the four-byte numbers a search wants.
+    ///
+    /// `widths` says how wide each cell of the block is, which the cell tree
+    /// knows and the block does not store. It is read from the front of the
+    /// block up to the cell asked for, so a caller reading the whole block
+    /// should walk it in order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cell is not in the block, or if fewer widths are given
+    /// than the block has cells.
+    pub fn unpack_into(&self, which: usize, widths: &[usize], out: &mut Vec<u32>) {
+        assert!(which < self.cells(), "no such cell in the block");
+        assert!(
+            widths.len() >= self.cells(),
+            "a width is wanted for each cell"
+        );
+
+        // where the table begins follows from what came before it
+        let mut at = 0_usize;
+        for (before, &wide) in widths.iter().enumerate().take(which) {
+            at += wide * wide * self.bits[before] as usize;
+        }
+
+        let width = u32::from(self.bits[which]);
+        let unreachable = mask_of(width);
+        let wide = widths[which];
+        out.clear();
+        out.reserve(wide * wide);
+        for _ in 0..wide * wide {
+            let value = read_at(&self.tables, at, width);
+            out.push(if value == unreachable {
+                u32::MAX
+            } else {
+                value
+            });
+            at += width as usize;
+        }
+    }
+
+    /// Where the border nodes of a cell sit in its run of nodes.
+    ///
+    /// Empty where they are the front of it and there was nothing to store.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cell is not in the block.
+    pub fn places_into(&self, which: usize, widths: &[usize], out: &mut Vec<u32>) {
+        assert!(which < self.cells(), "no such cell in the block");
+        out.clear();
+        if self.border_leads() {
+            return;
+        }
+        let bits = u32::from(self.place_bits);
+        let mut at = widths.iter().take(which).sum::<usize>() * bits as usize;
+        out.reserve(widths[which]);
+        for _ in 0..widths[which] {
+            out.push(read_at(&self.places, at, bits));
+            at += bits as usize;
+        }
+    }
+
+    /// Refuses a block written under a version this does not know.
+    ///
+    /// # Errors
+    ///
+    /// Returns the version found when it is not the one this reads.
+    pub fn check_version(&self) -> Result<(), u16> {
+        if self.version == VERSION {
+            Ok(())
+        } else {
+            Err(self.version)
+        }
+    }
+}
+
+fn mask_of(bits: u32) -> u32 {
+    if bits >= u32::BITS {
+        u32::MAX
+    } else {
+        (1_u32 << bits) - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+    fn matrices(rng: &mut StdRng, sizes: &[usize], largest: u32) -> Vec<Vec<u32>> {
+        sizes
+            .iter()
+            .map(|&wide| {
+                (0..wide * wide)
+                    .map(|at| {
+                        if at % 11 == 3 {
+                            u32::MAX
+                        } else {
+                            rng.random_range(0..=largest)
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn every_table_of_a_block_reads_back() {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        for largest in [1_u32, 255, 70_000, 3_000_000] {
+            let sizes = vec![1_usize, 4, 2, 9, 3];
+            let held = matrices(&mut rng, &sizes, largest);
+            let cells = held
+                .iter()
+                .zip(&sizes)
+                .map(|(matrix, &wide)| CellEntry {
+                    matrix,
+                    wide,
+                    places: &[],
+                    holds: wide * 3,
+                })
+                .collect::<Vec<_>>();
+            let block = CellBlock::of(0, 100, &cells, true);
+            assert_eq!(block.cells(), sizes.len());
+            assert_eq!(block.first(), 100);
+            assert!(block.border_leads());
+
+            let mut out = Vec::new();
+            for (which, matrix) in held.iter().enumerate() {
+                block.unpack_into(which, &sizes, &mut out);
+                assert_eq!(&out, matrix, "cell {which} at largest {largest}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_places_of_a_block_read_back() {
+        let sizes = vec![2_usize, 3];
+        let held: Vec<Vec<u32>> = vec![vec![0, 4, 4, 0], vec![0, 1, 2, 1, 0, 3, 2, 3, 0]];
+        // where each border node sits inside a run of a hundred nodes
+        let places: Vec<Vec<u32>> = vec![vec![0, 57], vec![3, 40, 99]];
+        let cells = held
+            .iter()
+            .zip(&sizes)
+            .zip(&places)
+            .map(|((matrix, &wide), places)| CellEntry {
+                matrix,
+                wide,
+                places,
+                holds: 100,
+            })
+            .collect::<Vec<_>>();
+        let block = CellBlock::of(2, 7, &cells, false);
+        assert!(!block.border_leads());
+        // a hundred nodes wants seven bits, not thirty-two
+        assert_eq!(block.place_bits, 7);
+
+        let mut out = Vec::new();
+        for (which, wanted) in places.iter().enumerate() {
+            block.places_into(which, &sizes, &mut out);
+            assert_eq!(&out, wanted, "cell {which}");
+        }
+    }
+
+    #[test]
+    fn a_block_carries_nothing_it_was_handed() {
+        // eight cells of four border nodes at eight bits is 128 bytes of
+        // entries, and the framing is one byte a cell and nothing else
+        let sizes = vec![4_usize; 8];
+        let held = sizes
+            .iter()
+            .map(|&wide| (0..wide * wide).map(|at| (at % 200) as u32).collect())
+            .collect::<Vec<Vec<u32>>>();
+        let cells = held
+            .iter()
+            .zip(&sizes)
+            .map(|(matrix, &wide)| CellEntry {
+                matrix,
+                wide,
+                places: &[],
+                holds: wide,
+            })
+            .collect::<Vec<_>>();
+        let block = CellBlock::of(0, 0, &cells, true);
+        assert_eq!(block.framing_bytes(), 8, "one byte a cell and no more");
+    }
+
+    #[test]
+    fn a_block_reads_back_as_it_was_written() {
+        let sizes = vec![3_usize, 5];
+        let held: Vec<Vec<u32>> = vec![
+            (0..9).map(|at| at * 7).collect(),
+            (0..25).map(|at| at * 3).collect(),
+        ];
+        let cells = held
+            .iter()
+            .zip(&sizes)
+            .map(|(matrix, &wide)| CellEntry {
+                matrix,
+                wide,
+                places: &[],
+                holds: wide,
+            })
+            .collect::<Vec<_>>();
+        let block = CellBlock::of(1, 42, &cells, true);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&block).expect("serializes");
+        let read: CellBlock =
+            rkyv::from_bytes::<CellBlock, rkyv::rancor::Error>(&bytes).expect("deserializes");
+        assert_eq!(read, block);
+        assert!(read.check_version().is_ok());
+    }
+}

--- a/src/cell_ordering.rs
+++ b/src/cell_ordering.rs
@@ -1,0 +1,262 @@
+//! A numbering of the cells that runs the way their keys do.
+//!
+//! # Why the numbers matter
+//!
+//! A block of a store holds a run of cells, and the store finds it by the keys
+//! it covers. Those two only agree if a cell's number and a cell's key run the
+//! same way, and out of the assembly they do not: a cell is numbered as the
+//! merging happened to reach it, so a block covering one range of keys covers
+//! a scattering of numbers and has to carry a list of which cells it holds.
+//!
+//! Numbered as the keys run, a block is a range of keys, a range of cell
+//! numbers and a range of node numbers at once, and none of the three has to
+//! be written down as anything but a first and a last.
+//!
+//! Two more things fall out, both of which a store would otherwise pay for:
+//!
+//! - **The children of a cell are a run.** Cells with the same parent share
+//!   the whole of their key above them and differ below, so sorting by key
+//!   puts them side by side. A cell's children become a first and a count.
+//! - **The cells of a level are in the order their nodes are.** The nodes were
+//!   numbered by cell path too, so walking the cells of a level in order walks
+//!   the nodes of the graph in order.
+//!
+//! # It does not move the nodes
+//!
+//! A node's number comes from the order of the packed words, and a word is
+//! built out of cell numbers, so renumbering cells rewrites every word. It
+//! does not reorder them: the new numbers run the way the keys do and the keys
+//! are what the old words were sorted by, so every word lands where it already
+//! was. An instance whose nodes are numbered by cell path stays numbered.
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::{
+    level_directory::{CellId, LevelDirectory},
+    packed_partition::PackedPartition,
+};
+
+/// Which number each cell of each level had, and has.
+#[derive(Clone, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct CellOrdering {
+    /// per level, the new number of the cell that had each old number
+    to_new: Vec<Vec<CellId>>,
+    /// per level, the old number of the cell that has each new number
+    to_old: Vec<Vec<CellId>>,
+}
+
+impl CellOrdering {
+    /// Works out the numbering of a directory.
+    ///
+    /// The key of a cell is the path from the root down to it, so the keys of
+    /// a level are built out of the keys of the level above rather than walked
+    /// up to one cell at a time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the directory and the partition are not over the same levels.
+    #[must_use]
+    pub fn of(directory: &LevelDirectory, partition: &PackedPartition) -> Self {
+        let levels = directory.levels();
+        assert_eq!(levels, partition.levels(), "another directory");
+        let begins_at = partition.level_layout();
+
+        // the key of every cell, from the top down: a cell's key is its
+        // parent's with its own number laid into the bits of its level
+        let mut keys: Vec<Vec<u128>> = vec![Vec::new(); levels];
+        let top = levels - 1;
+        keys[top] = (0..directory.cells_on_level(top) as u128)
+            .map(|cell| cell << begins_at[top])
+            .collect();
+        for level in (0..top).rev() {
+            let above = directory.parents_on_level(level);
+            keys[level] = above
+                .iter()
+                .enumerate()
+                .map(|(cell, &parent)| {
+                    keys[level + 1][parent as usize] | ((cell as u128) << begins_at[level])
+                })
+                .collect();
+        }
+
+        let mut to_new = Vec::with_capacity(levels);
+        let mut to_old = Vec::with_capacity(levels);
+        for of_level in &keys {
+            let count = of_level.len();
+            let mut order = (0..count as CellId).collect::<Vec<_>>();
+            order.sort_unstable_by_key(|&cell| of_level[cell as usize]);
+            let mut places = vec![0 as CellId; count];
+            for (place, &cell) in order.iter().enumerate() {
+                places[cell as usize] =
+                    CellId::try_from(place).expect("more cells than a cell id counts");
+            }
+            to_new.push(places);
+            to_old.push(order);
+        }
+        Self { to_new, to_old }
+    }
+
+    #[must_use]
+    pub fn levels(&self) -> usize {
+        self.to_new.len()
+    }
+
+    #[must_use]
+    pub fn cells_on_level(&self, level: usize) -> usize {
+        self.to_new[level].len()
+    }
+
+    /// The number a cell has now.
+    #[must_use]
+    pub fn new_of(&self, level: usize, cell: CellId) -> CellId {
+        self.to_new[level][cell as usize]
+    }
+
+    /// The number a cell had.
+    #[must_use]
+    pub fn old_of(&self, level: usize, cell: CellId) -> CellId {
+        self.to_old[level][cell as usize]
+    }
+
+    /// The same directory with its cells renumbered.
+    ///
+    /// Which cell a node is in does not change, only what that cell is called,
+    /// so nothing about the partition itself moves.
+    #[must_use]
+    pub fn renumber(&self, directory: &LevelDirectory) -> LevelDirectory {
+        let levels = directory.levels();
+        assert_eq!(levels, self.levels(), "another directory");
+
+        let base = (0..directory.number_of_nodes())
+            .map(|node| self.new_of(0, directory.cell_of(node, 0)))
+            .collect();
+        let parents = (0..levels - 1)
+            .map(|level| {
+                let above = directory.parents_on_level(level);
+                // the cell that is now numbered `cell` was numbered
+                // `old_of(cell)`, and its parent has moved too
+                (0..above.len())
+                    .map(|cell| {
+                        let was = self.old_of(level, cell as CellId);
+                        self.new_of(level + 1, above[was as usize])
+                    })
+                    .collect()
+            })
+            .collect();
+        LevelDirectory::new(base, parents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grid_graph::grid_directory;
+
+    fn keys_of(directory: &LevelDirectory, level: usize) -> Vec<u128> {
+        let partition = PackedPartition::of(directory);
+        let begins_at = partition.level_layout();
+        (0..directory.cells_on_level(level))
+            .map(|cell| {
+                // the path of a cell, walked up one level at a time
+                let mut key = (cell as u128) << begins_at[level];
+                let mut at = cell as CellId;
+                for (above, &begins) in begins_at
+                    .iter()
+                    .enumerate()
+                    .take(directory.levels())
+                    .skip(level + 1)
+                {
+                    at = directory.parents_on_level(above - 1)[at as usize];
+                    key |= (at as u128) << begins;
+                }
+                key
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_cells_come_out_in_the_order_their_keys_run() {
+        let directory = grid_directory(16);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let moved = ordering.renumber(&directory);
+        for level in 0..moved.levels() {
+            let keys = keys_of(&moved, level);
+            assert!(
+                keys.windows(2).all(|pair| pair[0] < pair[1]),
+                "level {level} is not in key order"
+            );
+        }
+    }
+
+    #[test]
+    fn the_children_of_a_cell_are_a_run() {
+        let directory = grid_directory(16);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let moved = ordering.renumber(&directory);
+        for level in 1..moved.levels() {
+            let above = moved.parents_on_level(level - 1);
+            // walking the children in order, the parent never goes back
+            assert!(
+                above.windows(2).all(|pair| pair[0] <= pair[1]),
+                "level {level} has a parent out of order"
+            );
+        }
+    }
+
+    #[test]
+    fn a_node_stays_in_the_cell_it_was_in() {
+        let directory = grid_directory(16);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let moved = ordering.renumber(&directory);
+        for node in 0..directory.number_of_nodes() {
+            for level in 0..directory.levels() {
+                assert_eq!(
+                    moved.cell_of(node, level),
+                    ordering.new_of(level, directory.cell_of(node, level)),
+                    "node {node} at level {level}"
+                );
+            }
+        }
+    }
+
+    /// Two nodes that shared a cell still share one, and two that did not
+    /// still do not. This is the whole of what a renumbering may not change.
+    #[test]
+    fn the_partition_itself_does_not_move() {
+        let directory = grid_directory(8);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let moved = ordering.renumber(&directory);
+        for first in 0..directory.number_of_nodes() {
+            for second in 0..directory.number_of_nodes() {
+                assert_eq!(
+                    directory.common_level(first, second),
+                    moved.common_level(first, second),
+                    "{first} and {second}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_numbering_is_a_numbering() {
+        let directory = grid_directory(16);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        for level in 0..ordering.levels() {
+            let count = ordering.cells_on_level(level);
+            for cell in 0..count as CellId {
+                assert_eq!(ordering.old_of(level, ordering.new_of(level, cell)), cell);
+                assert_eq!(ordering.new_of(level, ordering.old_of(level, cell)), cell);
+            }
+        }
+    }
+
+    #[test]
+    fn an_ordering_reads_back_as_it_was_written() {
+        let directory = grid_directory(8);
+        let ordering = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&ordering).expect("serializes");
+        let read: CellOrdering =
+            rkyv::from_bytes::<CellOrdering, rkyv::rancor::Error>(&bytes).expect("deserializes");
+        assert_eq!(read, ordering);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod node_ordering;
 pub mod one_iterator;
 pub mod one_to_many_dijkstra;
 pub mod overlay;
+pub mod packed_distances;
 pub mod packed_partition;
 pub mod partition_id;
 pub mod path_based_scc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bloom_filter;
 pub mod border_levels;
 pub mod bounding_box;
 pub mod cell;
+pub mod cell_block;
 pub mod cell_tree;
 pub mod complete_graph;
 pub mod convex_hull;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod border_levels;
 pub mod bounding_box;
 pub mod cell;
 pub mod cell_block;
+pub mod cell_ordering;
 pub mod cell_tree;
 pub mod complete_graph;
 pub mod convex_hull;

--- a/src/packed_distances.rs
+++ b/src/packed_distances.rs
@@ -61,7 +61,7 @@ pub struct PackedDistances {
 }
 
 /// How many bits it takes to hold every number up to and including `largest`.
-fn bits_for(largest: u32) -> u32 {
+pub(crate) fn bits_for(largest: u32) -> u32 {
     if largest == 0 {
         1
     } else {
@@ -174,7 +174,7 @@ fn mask_of(bits: u32) -> u32 {
 /// An entry straddles at most five bytes at any width up to thirty-two, so the
 /// bytes it touches are read into a wide accumulator, the value laid into it,
 /// and the accumulator written back.
-fn write_at(packed: &mut [u8], at: usize, bits: u32, value: u32) {
+pub(crate) fn write_at(packed: &mut [u8], at: usize, bits: u32, value: u32) {
     let byte = at / 8;
     let shift = (at % 8) as u32;
     let mut held = 0_u64;
@@ -189,7 +189,7 @@ fn write_at(packed: &mut [u8], at: usize, bits: u32, value: u32) {
 }
 
 /// Reads `bits` from a bit offset.
-fn read_at(packed: &[u8], at: usize, bits: u32) -> u32 {
+pub(crate) fn read_at(packed: &[u8], at: usize, bits: u32) -> u32 {
     let byte = at / 8;
     let shift = (at % 8) as u32;
     let mut held = 0_u64;

--- a/src/packed_distances.rs
+++ b/src/packed_distances.rs
@@ -1,0 +1,286 @@
+//! A cell's table of distances, written down small.
+//!
+//! # What the numbers turned out to be
+//!
+//! The tables are the bulk of what a store ships, so how they are written down
+//! was chosen by measuring europe.ptv rather than by picking a scheme. Four
+//! were counted, against 252.8 MiB of four-byte entries:
+//!
+//! ```text
+//!   the least of a row, then two bytes an entry   161.1 MiB   64%
+//!   the least, then a width per row               126.5 MiB   50%
+//!   the least, then a width per table             130.7 MiB   52%
+//!   a width per table and no least                112.5 MiB   44%
+//! ```
+//!
+//! Two of those numbers are worth keeping.
+//!
+//! **Two bytes an entry is the wrong shape.** It is what a delta wants when
+//! the values of a row sit close together, and on the coarse levels they do
+//! not: at the top level only 8.4% of rows fit, 2.88 million entries have to
+//! be written out of line, and the result is *larger* than writing the numbers
+//! out in full. A width chosen to fit whatever the table holds has no such
+//! cliff.
+//!
+//! **The least of a row is always nought.** A row holds the distance from a
+//! node to every border node of its cell, itself among them, and that one is
+//! nought. Measured over all 4,783,400 rows of europe.ptv, not one had a
+//! smallest reachable distance above nought, so subtracting it saves nothing
+//! and writing it down costs four bytes a row, which is 18.2 MiB.
+//!
+//! # The encoding
+//!
+//! One width for the whole table, as many bits as its widest distance needs,
+//! and the entries back to back at that width. What cannot be reached takes
+//! the largest value the width holds, so the width has room for one more than
+//! the widest real distance.
+//!
+//! A width per row is 14 MiB smaller in the entries alone, and was not taken:
+//! rows are read at random, so a width per row wants a table of where each row
+//! begins, which is four bytes a row and gives the 14 MiB back with 4 MiB of
+//! its own. With one width the row begins at `row * wide * bits` and there is
+//! nothing to store or look up.
+//!
+//! # What this is not
+//!
+//! This is how a table is written down, not how it is read. A search reads a
+//! row as a run of four-byte numbers and this is not that, so a block is
+//! unpacked when it is faulted in and the search sees what it always saw.
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// A table of distances at one width.
+#[derive(Clone, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct PackedDistances {
+    /// how many border nodes the cell has, which is the side of the table
+    wide: u32,
+    /// how many bits an entry takes, one to thirty-two
+    bits: u8,
+    /// the entries, back to back, at `bits` apiece
+    packed: Vec<u8>,
+}
+
+/// How many bits it takes to hold every number up to and including `largest`.
+fn bits_for(largest: u32) -> u32 {
+    if largest == 0 {
+        1
+    } else {
+        u32::BITS - largest.leading_zeros()
+    }
+}
+
+impl PackedDistances {
+    /// Writes a table down, row by row, at one width.
+    ///
+    /// `matrix` is `wide * wide` entries by row, with [`u32::MAX`] where
+    /// nothing can be reached.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless the matrix is square and as wide as it says.
+    #[must_use]
+    pub fn of(matrix: &[u32], wide: usize) -> Self {
+        assert_eq!(matrix.len(), wide * wide, "a table is square");
+
+        // the width has to hold the widest real distance and one more, that
+        // one being what stands for what cannot be reached
+        let widest = matrix
+            .iter()
+            .copied()
+            .filter(|&at| at != u32::MAX)
+            .max()
+            .unwrap_or(0);
+        let bits = bits_for(widest.saturating_add(1)).min(u32::BITS);
+        let unreachable = mask_of(bits);
+
+        let mut packed = vec![0_u8; (matrix.len() * bits as usize).div_ceil(8)];
+        for (place, &at) in matrix.iter().enumerate() {
+            let value = if at == u32::MAX { unreachable } else { at };
+            write_at(&mut packed, place * bits as usize, bits, value);
+        }
+        Self {
+            wide: u32::try_from(wide).expect("a cell wider than four bytes count"),
+            bits: u8::try_from(bits).expect("a width of more bits than a byte counts"),
+            packed,
+        }
+    }
+
+    #[must_use]
+    pub fn wide(&self) -> usize {
+        self.wide as usize
+    }
+
+    #[must_use]
+    pub fn bits(&self) -> u32 {
+        u32::from(self.bits)
+    }
+
+    /// What the table takes up.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>() + self.packed.capacity()
+    }
+
+    /// Reads the whole table back, as the four-byte numbers a search wants.
+    ///
+    /// Into a buffer the caller keeps, a block holding many tables and each
+    /// being unpacked once when the block is faulted in.
+    pub fn unpack_into(&self, out: &mut Vec<u32>) {
+        out.clear();
+        let entries = self.wide as usize * self.wide as usize;
+        out.reserve(entries);
+        let bits = u32::from(self.bits);
+        let unreachable = mask_of(bits);
+        for place in 0..entries {
+            let value = read_at(&self.packed, place * bits as usize, bits);
+            out.push(if value == unreachable {
+                u32::MAX
+            } else {
+                value
+            });
+        }
+    }
+
+    /// One entry, without unpacking the rest.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the entry is not in the table.
+    #[must_use]
+    pub fn at(&self, source: usize, target: usize) -> u32 {
+        let wide = self.wide as usize;
+        assert!(source < wide && target < wide, "no such entry");
+        let bits = u32::from(self.bits);
+        let value = read_at(&self.packed, (source * wide + target) * bits as usize, bits);
+        if value == mask_of(bits) {
+            u32::MAX
+        } else {
+            value
+        }
+    }
+}
+
+/// The largest value a width holds, which is what stands for the unreachable.
+fn mask_of(bits: u32) -> u32 {
+    if bits >= u32::BITS {
+        u32::MAX
+    } else {
+        (1_u32 << bits) - 1
+    }
+}
+
+/// Writes `bits` of `value` at a bit offset.
+///
+/// An entry straddles at most five bytes at any width up to thirty-two, so the
+/// bytes it touches are read into a wide accumulator, the value laid into it,
+/// and the accumulator written back.
+fn write_at(packed: &mut [u8], at: usize, bits: u32, value: u32) {
+    let byte = at / 8;
+    let shift = (at % 8) as u32;
+    let mut held = 0_u64;
+    for (place, &part) in packed[byte..].iter().take(5).enumerate() {
+        held |= u64::from(part) << (place * 8);
+    }
+    held &= !(u64::from(mask_of(bits)) << shift);
+    held |= u64::from(value & mask_of(bits)) << shift;
+    for (place, part) in packed[byte..].iter_mut().take(5).enumerate() {
+        *part = u8::try_from((held >> (place * 8)) & 0xFF).expect("a byte of a byte");
+    }
+}
+
+/// Reads `bits` from a bit offset.
+fn read_at(packed: &[u8], at: usize, bits: u32) -> u32 {
+    let byte = at / 8;
+    let shift = (at % 8) as u32;
+    let mut held = 0_u64;
+    for (place, &part) in packed[byte..].iter().take(5).enumerate() {
+        held |= u64::from(part) << (place * 8);
+    }
+    u32::try_from((held >> shift) & u64::from(mask_of(bits))).expect("a value of its own width")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+    fn round_trip(matrix: &[u32], wide: usize) {
+        let packed = PackedDistances::of(matrix, wide);
+        let mut read = Vec::new();
+        packed.unpack_into(&mut read);
+        assert_eq!(read, matrix, "at {} bits", packed.bits());
+        for source in 0..wide {
+            for target in 0..wide {
+                assert_eq!(
+                    packed.at(source, target),
+                    matrix[source * wide + target],
+                    "entry {source},{target}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_table_reads_back_as_it_was_written() {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        for wide in [1_usize, 2, 3, 7, 16, 33] {
+            for largest in [0_u32, 1, 2, 255, 256, 65_535, 65_536, 1_000_000] {
+                let matrix = (0..wide * wide)
+                    .map(|_| rng.random_range(0..=largest))
+                    .collect::<Vec<_>>();
+                round_trip(&matrix, wide);
+            }
+        }
+    }
+
+    #[test]
+    fn what_cannot_be_reached_reads_back_unreachable() {
+        let matrix = vec![u32::MAX; 9];
+        round_trip(&matrix, 3);
+
+        // and mixed in with what can
+        let matrix = vec![0, u32::MAX, 5, u32::MAX, 0, u32::MAX, 7, 9, 0];
+        round_trip(&matrix, 3);
+    }
+
+    /// The width has to leave room for the unreachable above the widest real
+    /// distance, or a table whose widest distance is a power of two less one
+    /// would read that distance back as unreachable.
+    #[test]
+    fn the_widest_distance_is_not_mistaken_for_unreachable() {
+        for widest in [1_u32, 3, 7, 255, 65_535] {
+            let matrix = vec![0, widest, widest, 0];
+            let packed = PackedDistances::of(&matrix, 2);
+            assert_eq!(packed.at(0, 1), widest, "at {} bits", packed.bits());
+            round_trip(&matrix, 2);
+        }
+    }
+
+    #[test]
+    fn a_table_of_the_widest_numbers_there_are_still_reads_back() {
+        // one below the unreachable is a real distance and has to survive
+        let matrix = vec![0, u32::MAX - 1, 1, 0];
+        round_trip(&matrix, 2);
+        assert_eq!(PackedDistances::of(&matrix, 2).bits(), 32);
+    }
+
+    #[test]
+    fn a_narrow_table_takes_narrow_room() {
+        // sixteen entries that fit in three bits apiece is six bytes, against
+        // sixty-four for four bytes each
+        let matrix = (0..16).map(|at| at % 6).collect::<Vec<_>>();
+        let packed = PackedDistances::of(&matrix, 4);
+        assert_eq!(packed.bits(), 3);
+        round_trip(&matrix, 4);
+    }
+
+    #[test]
+    fn a_table_serializes() {
+        let matrix = vec![0, 3, 4, 0];
+        let packed = PackedDistances::of(&matrix, 2);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&packed).expect("serializes");
+        let read: PackedDistances =
+            rkyv::from_bytes::<PackedDistances, rkyv::rancor::Error>(&bytes).expect("deserializes");
+        assert_eq!(read, packed);
+    }
+}

--- a/src/renumber/bin/command_line.rs
+++ b/src/renumber/bin/command_line.rs
@@ -50,6 +50,16 @@ pub struct Arguments {
     /// query, all of it on the long routes.
     #[clap(long, value_enum, default_value_t = Order::BorderFirst)]
     pub numbering: Order,
+
+    /// Number the cells of each level in the order their keys run, before
+    /// numbering the nodes.
+    ///
+    /// Out of the assembly a cell is numbered as the merging happened to reach
+    /// it, so a run of cell numbers is not a range of keys. Renumbered, a
+    /// block of a store is a range of keys, of cell numbers and of node
+    /// numbers at once. Says nothing about which cell a node is in.
+    #[clap(long, action)]
+    pub cells_in_key_order: bool,
 }
 
 impl Display for Arguments {

--- a/src/renumber/bin/main.rs
+++ b/src/renumber/bin/main.rs
@@ -34,6 +34,7 @@ use env_logger::{Builder, Env};
 use log::info;
 
 use toolbox_rs::{
+    cell_ordering::CellOrdering,
     edge::InputEdge,
     geometry::FPCoordinate,
     graph::{Graph, NodeID},
@@ -67,6 +68,24 @@ fn main() -> Result<(), Box<dyn Error>> {
     if directory.number_of_nodes() != graph.number_of_nodes() {
         return Err("the directory was built over another graph".into());
     }
+
+    // The cells first, if asked. A node's number comes from the order of the
+    // packed words and a word is built out of cell numbers, so this rewrites
+    // every word; it does not reorder them, the new numbers running the way
+    // the keys do and the keys being what the words were already sorted by.
+    let directory = if args.cells_in_key_order {
+        let started = Instant::now();
+        let cells = CellOrdering::of(&directory, &PackedPartition::of(&directory));
+        let moved = cells.renumber(&directory);
+        info!(
+            "numbered the cells of {} levels in the order their keys run, in {:.1} s",
+            moved.levels(),
+            started.elapsed().as_secs_f64()
+        );
+        moved
+    } else {
+        directory
+    };
 
     let started = Instant::now();
     let ordering = NodeOrdering::in_order(


### PR DESCRIPTION
Third of five, on #607.

## The encoding, chosen by measuring

The plan called for the least of each row and then two-byte deltas above it,
with an escape, aiming at 30 to 40 per cent. Counted over every table of
europe.ptv, against 252.8 MiB of four-byte entries:

| | | |
|---|---|---|
| the least of a row, then two bytes an entry | 161.1 MiB | 64% |
| the least, then a width per row | 126.5 MiB | 50% |
| the least, then a width per table | 130.7 MiB | 52% |
| **a width per table and no least** | **112.5 MiB** | **44%** |

**Two bytes an entry is the wrong shape here.** It wants a row whose values sit
close together and the coarse levels do not: at the top level 8.4% of rows fit,
2.88 million entries escape, and the result is *larger than raw* — 13.1 MiB
against 9.1.

**The least of a row is always nought.** A row holds the distance from a node
to every border node of its cell, itself among them, and that one is nought.
Over all 4,783,400 rows not one had a smallest reachable distance above nought.
Storing it costs 18.2 MiB and buys nothing.

A width per row is 14 MiB smaller in the entries and was still not taken: rows
are read at random, so it wants four bytes a row saying where each begins,
which gives the 14 back and costs 4 more. With one width a row begins at
`row * wide * bits`.

    PackedDistances::of / unpack_into / at / bits / wide / bytes

## Blocks that carry nothing the directory knows

How wide a table is, is how many border nodes the cell has, which the tree
says. Where a table begins follows from the widths before it, so it is added
up on reading. What is left per cell is one byte.

    CellBlock::of(level, first, &[CellEntry], border_leads)
    CellBlock::unpack_into / places_into / framing_bytes

Two measured facts shape it. **The nodes of a cell are exactly its run of
numbers, at every level**, so a place in a table is a node arithmetically.
**The border nodes lead the run only on the finest level** — and cannot above
it, a level-1 cell's run being its children's runs laid end to end, so
gathering its border nodes to the front would stop the children being runs.
One or the other. So level 0 stores nothing about which nodes its tables are
about, and the levels above store a place as an offset into the cell's run:
six to twenty bits instead of thirty-two.

## Cells numbered as their keys run

Out of the assembly a cell is numbered as the merging reached it, so a run of
cell numbers was not a range of keys and a block would have had to list what
it held.

    CellOrdering::of / renumber / new_of / old_of
    renumber --cells-in-key-order

Renumbering cells rewrites every packed word but does not reorder them: the new
numbers run the way the keys do and the keys are what the words were sorted by.
Measured — an instance numbered by cell path stays numbered.

| | before | after |
|---|---|---|
| cells numbered as their keys run | NO | **yes** |
| the children of a cell are a run | NO | **yes, everywhere** |
| the nodes of a cell are the run | yes | yes |

## What it comes to

europe.ptv, 623,435 cells, 66,267,046 entries, cut into blocks of about four
megabytes:

| | | |
|---|---|---|
| raw, four bytes an entry | 252.8 MiB | 100.0% |
| the blocks | 113.3 MiB | 44.8% |
| of which framing | **2.5 MiB** | **1.0%** |

Held one table to a struct the framing was 19.0 MiB, and 15.2 of that on the
finest level, which is now 0.5. Every table and every place of all 66 blocks
was unpacked and compared with what went in, none differing.

`sound` over level 2 of the renumbered instance checks 11,968,001 pairs against
plain Dijkstra on the graph, none differing: what moved is what the cells are
called. The tests hold it by comparing `common_level` for every pair of nodes.