### PR TITLE
Add the block codecs, the block map and a store to read one back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ rayon = "1.10.0"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 xxhash-rust = {version = "0.8.15", features = ["xxh3"] }
+lz4_flex = "0.14.0"
+flate2 = "1.1.9"
+zstd = "0.13.3"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5.4"

--- a/examples/block_pack.rs
+++ b/examples/block_pack.rs
@@ -18,6 +18,7 @@
 use std::{env::args, time::Instant};
 
 use toolbox_rs::{
+    block_codec::Codec,
     cell_block::{CellBlock, CellEntry},
     cell_tree::CellTree,
     customization::Customization,
@@ -60,6 +61,17 @@ fn main() {
         "{:>5} {:>9} {:>7} {:>10} {:>10} {:>9} {:>7} {:>7}",
         "level", "cells", "blocks", "raw", "blocks", "framing", "share", "wrong"
     );
+    // what each codec makes of the blocks, and what it costs to read one back
+    let tried: [(Codec, i32); 5] = [
+        (Codec::Stored, 0),
+        (Codec::Lz4, 0),
+        (Codec::Deflate, 6),
+        (Codec::Zstd, 3),
+        (Codec::Zstd, 19),
+    ];
+    let mut squeezed = [0_u64; 5];
+    let mut decoding = [std::time::Duration::ZERO; 5];
+
     let started = Instant::now();
     let (mut all_raw, mut all_block, mut all_framing, mut all_wrong, mut all_blocks) =
         (0_u64, 0_u64, 0_u64, 0_u64, 0_u64);
@@ -91,16 +103,16 @@ fn main() {
         let mut first_of_run = 0_u32;
         let mut carrying = 0_f64;
 
-        let flush = |held: &mut Vec<Vec<u32>>,
-                     widths: &mut Vec<usize>,
-                     places: &mut Vec<Vec<u32>>,
-                     holds: &mut Vec<usize>,
-                     first: u32,
-                     raw: &mut u64,
-                     packed: &mut u64,
-                     framing: &mut u64,
-                     wrong: &mut u64,
-                     blocks: &mut u64| {
+        let mut flush = |held: &mut Vec<Vec<u32>>,
+                         widths: &mut Vec<usize>,
+                         places: &mut Vec<Vec<u32>>,
+                         holds: &mut Vec<usize>,
+                         first: u32,
+                         raw: &mut u64,
+                         packed: &mut u64,
+                         framing: &mut u64,
+                         wrong: &mut u64,
+                         blocks: &mut u64| {
             if held.is_empty() {
                 return;
             }
@@ -117,6 +129,18 @@ fn main() {
                 })
                 .collect::<Vec<_>>();
             let block = CellBlock::of(level, first, &entries, border_leads);
+            // what it comes to on disk, each way of writing it down
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&block).expect("a block serializes");
+            for (which, &(codec, effort)) in tried.iter().enumerate() {
+                let stored = codec.encode(&bytes, effort);
+                let began = Instant::now();
+                let read = codec
+                    .decode(&stored, bytes.len())
+                    .expect("a block reads back");
+                decoding[which] += began.elapsed();
+                assert_eq!(read.len(), bytes.len(), "{} lost bytes", codec.name());
+                squeezed[which] += stored.len() as u64;
+            }
             *packed += block.bytes() as u64;
             *framing += block.framing_bytes() as u64;
             *blocks += 1;
@@ -229,7 +253,27 @@ fn main() {
         );
     }
     println!(
-        "  cells numbered as their keys run: {}",
+        "\n  {:<16} {:>10} {:>8} {:>12}",
+        "codec", "on disk", "share", "to read all"
+    );
+    for (which, &(codec, effort)) in tried.iter().enumerate() {
+        let name = if effort > 0 {
+            format!("{} {effort}", codec.name())
+        } else {
+            codec.name().to_owned()
+        };
+        println!(
+            "  {name:<16} {:>10} {:>8} {:>12}",
+            megabytes(squeezed[which]),
+            format!(
+                "{:.1}%",
+                100.0 * squeezed[which] as f64 / all_raw.max(1) as f64
+            ),
+            format!("{:.2?}", decoding[which]),
+        );
+    }
+    println!(
+        "\n  cells numbered as their keys run: {}",
         if keys_in_order { "yes" } else { "NO" }
     );
     if all_wrong == 0 {

--- a/src/block_codec.rs
+++ b/src/block_codec.rs
@@ -1,0 +1,210 @@
+//! How a block is squeezed on its way to disk, and back on its way off it.
+//!
+//! # A byte a block, not a byte a file
+//!
+//! Which codec a block was written with is written down with the block, so one
+//! file may hold blocks written several ways. That costs a byte a block and
+//! buys two things worth more than a byte.
+//!
+//! A build may choose per block: the coarse levels are a few large blocks
+//! where a slow codec costs little and saves much, the finest level is many
+//! small ones where the cost per fault is what matters. And a build may change
+//! its mind later without rewriting what is already shipped, which for a store
+//! that ships in pieces and updates in pieces is the difference between a new
+//! release and a new download.
+//!
+//! [`Stored`] is the codec that does nothing. It is not a placeholder: a block
+//! whose entries are already packed to the bit may not be worth compressing at
+//! all, and a build that finds so says so with a byte.
+
+use std::io::{Read, Write};
+
+/// What a block was squeezed with.
+///
+/// The numbers are written into files and may not be reused for anything else.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Codec {
+    /// written out as it stands
+    #[default]
+    Stored = 0,
+    Deflate = 1,
+    Zstd = 2,
+    Lz4 = 3,
+}
+
+/// A codec that a file names and this build does not know.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnknownCodec(pub u8);
+
+impl std::fmt::Display for UnknownCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "no codec numbered {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownCodec {}
+
+impl Codec {
+    /// The byte written down beside a block.
+    #[must_use]
+    pub fn id(self) -> u8 {
+        self as u8
+    }
+
+    /// Which codec a byte names.
+    ///
+    /// # Errors
+    ///
+    /// Returns the byte when this build has no codec of that number, which is
+    /// a file from a later version rather than a file that is wrong.
+    pub fn of(id: u8) -> Result<Self, UnknownCodec> {
+        match id {
+            0 => Ok(Self::Stored),
+            1 => Ok(Self::Deflate),
+            2 => Ok(Self::Zstd),
+            3 => Ok(Self::Lz4),
+            other => Err(UnknownCodec(other)),
+        }
+    }
+
+    /// What to call it in a report.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Stored => "stored",
+            Self::Deflate => "deflate",
+            Self::Zstd => "zstd",
+            Self::Lz4 => "lz4",
+        }
+    }
+
+    /// Squeezes a block.
+    ///
+    /// `effort` is what the codec makes of it: deflate takes nought to nine
+    /// and zstd takes one to twenty-two, and each is held to what it takes.
+    /// The others ignore it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the codec fails on a buffer, which for these three means it
+    /// could not get the room rather than that the input was wrong.
+    #[must_use]
+    pub fn encode(self, raw: &[u8], effort: i32) -> Vec<u8> {
+        match self {
+            Self::Stored => raw.to_vec(),
+            Self::Deflate => {
+                let mut out = flate2::write::DeflateEncoder::new(
+                    Vec::new(),
+                    flate2::Compression::new(effort.clamp(0, 9) as u32),
+                );
+                out.write_all(raw).expect("a buffer does not fail to write");
+                out.finish().expect("a buffer does not fail to finish")
+            }
+            Self::Zstd => {
+                zstd::encode_all(raw, effort.clamp(1, 22)).expect("a buffer does not fail to write")
+            }
+            Self::Lz4 => lz4_flex::compress_prepend_size(raw),
+        }
+    }
+
+    /// Reads a block back.
+    ///
+    /// `unpacked` is how large it was before it was squeezed, which the block
+    /// map holds. Deflate is told so that the room is asked for once.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message where the bytes are not what the codec expects.
+    pub fn decode(self, stored: &[u8], unpacked: usize) -> Result<Vec<u8>, String> {
+        match self {
+            Self::Stored => Ok(stored.to_vec()),
+            Self::Deflate => {
+                let mut out = Vec::with_capacity(unpacked);
+                flate2::read::DeflateDecoder::new(stored)
+                    .read_to_end(&mut out)
+                    .map_err(|why| format!("deflate: {why}"))?;
+                Ok(out)
+            }
+            Self::Zstd => zstd::decode_all(stored).map_err(|why| format!("zstd: {why}")),
+            Self::Lz4 => {
+                lz4_flex::decompress_size_prepended(stored).map_err(|why| format!("lz4: {why}"))
+            }
+        }
+    }
+
+    /// Every codec this build knows, for a run that compares them.
+    #[must_use]
+    pub fn all() -> [Self; 4] {
+        [Self::Stored, Self::Deflate, Self::Zstd, Self::Lz4]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Something with the shape of a block: runs of small numbers at a fixed
+    /// width, which is what packed distances look like.
+    fn blockish(len: usize) -> Vec<u8> {
+        (0..len)
+            .map(|at| ((at * 7 + at / 13) % 251) as u8)
+            .collect()
+    }
+
+    #[test]
+    fn every_codec_gives_back_what_it_was_given() {
+        for raw in [Vec::new(), blockish(1), blockish(1000), blockish(100_000)] {
+            for codec in Codec::all() {
+                for effort in [1, 9] {
+                    let stored = codec.encode(&raw, effort);
+                    let read = codec
+                        .decode(&stored, raw.len())
+                        .unwrap_or_else(|why| panic!("{} at {effort}: {why}", codec.name()));
+                    assert_eq!(read, raw, "{} at effort {effort}", codec.name());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_codec_is_named_by_the_byte_it_writes() {
+        for codec in Codec::all() {
+            assert_eq!(Codec::of(codec.id()), Ok(codec));
+        }
+    }
+
+    /// A file naming a codec this build does not have is a file from later,
+    /// and says so rather than being read as something else.
+    #[test]
+    fn a_codec_this_build_does_not_know_is_refused() {
+        assert_eq!(Codec::of(200), Err(UnknownCodec(200)));
+        assert_eq!(
+            Codec::of(200).unwrap_err().to_string(),
+            "no codec numbered 200"
+        );
+    }
+
+    #[test]
+    fn the_ones_that_squeeze_do_squeeze() {
+        let raw = blockish(100_000);
+        for codec in [Codec::Deflate, Codec::Zstd, Codec::Lz4] {
+            let stored = codec.encode(&raw, 3);
+            assert!(stored.len() < raw.len(), "{} made it larger", codec.name());
+        }
+        assert_eq!(Codec::Stored.encode(&raw, 3).len(), raw.len());
+    }
+
+    #[test]
+    fn rubbish_is_refused_rather_than_read() {
+        let nonsense = vec![0xFF_u8; 64];
+        // stored takes anything, being a copy; the rest have a shape to check
+        for codec in [Codec::Deflate, Codec::Zstd, Codec::Lz4] {
+            assert!(
+                codec.decode(&nonsense, 1000).is_err(),
+                "{} read rubbish",
+                codec.name()
+            );
+        }
+    }
+}

--- a/src/block_map.rs
+++ b/src/block_map.rs
@@ -1,0 +1,264 @@
+//! Where every block is, and what it covers.
+//!
+//! # Four ranges that are the same range
+//!
+//! A block holds a run of cells of one level. Numbered as their keys run, that
+//! run is at once a range of keys, a range of cell numbers and a range of node
+//! numbers, so an entry says all three as bounds and the store looks a block
+//! up by whichever it happens to hold.
+//!
+//! That is what the two renumberings bought. Out of the assembly none of the
+//! three agreed with either of the others and an entry would have had to carry
+//! a list of the cells it held.
+//!
+//! # What is absent means what was not downloaded
+//!
+//! A store is shipped in pieces and a device may hold some of them. There is
+//! no flag for that: a key that no entry covers is a key nobody has, and a
+//! lookup says so by finding nothing. A region is a range of keys that is
+//! present or is not.
+//!
+//! # Blocks are named by what is in them
+//!
+//! Each entry carries a hash of the block's bytes. Two builds that produce the
+//! same block produce the same name for it, so a device updating from one
+//! release to the next downloads the blocks whose contents changed rather than
+//! the blocks whose numbers changed. Nothing here does that yet; the naming is
+//! what has to be in the format from the start, because it cannot be added to
+//! files already shipped.
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::level_directory::CellId;
+
+/// The version this is written under.
+pub const VERSION: u16 = 1;
+
+/// Where one block sits and what it covers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct BlockEntry {
+    /// the first key of the range this block covers, and the last
+    pub first_key: u128,
+    pub last_key: u128,
+    /// which level its cells are of
+    pub level: u8,
+    /// which codec its bytes were written with
+    pub codec: u8,
+    /// the first cell of the run, and how many
+    pub first_cell: CellId,
+    pub cells: u32,
+    /// the first node the run holds, and how many
+    pub first_node: u32,
+    pub nodes: u32,
+    /// where the bytes begin in the file they are in
+    pub at: u64,
+    /// how many bytes it takes on disk, and how many once read back
+    pub stored: u32,
+    pub unpacked: u32,
+    /// a name for the bytes, so that a later release can be told what changed
+    pub hash: u64,
+}
+
+impl BlockEntry {
+    /// Whether a key falls in the range this block covers.
+    #[must_use]
+    pub fn holds_key(&self, key: u128) -> bool {
+        (self.first_key..=self.last_key).contains(&key)
+    }
+
+    /// Whether a cell of this block's level falls in its run.
+    #[must_use]
+    pub fn holds_cell(&self, cell: CellId) -> bool {
+        cell >= self.first_cell && cell - self.first_cell < self.cells
+    }
+}
+
+/// Every block of a store, in the order they are laid out.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Archive, Serialize, Deserialize)]
+pub struct BlockMap {
+    version: u16,
+    /// sorted by level and then by the first cell of the run
+    entries: Vec<BlockEntry>,
+}
+
+impl BlockMap {
+    /// Takes the entries and puts them in the order lookups want.
+    #[must_use]
+    pub fn of(mut entries: Vec<BlockEntry>) -> Self {
+        entries.sort_unstable_by_key(|entry| (entry.level, entry.first_cell));
+        Self {
+            version: VERSION,
+            entries,
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[must_use]
+    pub fn entries(&self) -> &[BlockEntry] {
+        &self.entries
+    }
+
+    /// The block holding a cell, and nothing where no block does.
+    ///
+    /// Nothing means the piece of the map that cell is in was not downloaded,
+    /// which is a question rather than a fault.
+    #[must_use]
+    pub fn holding_cell(&self, level: usize, cell: CellId) -> Option<&BlockEntry> {
+        let level = u8::try_from(level).ok()?;
+        // the last block of this level that begins at or before the cell
+        let after = self
+            .entries
+            .partition_point(|entry| (entry.level, entry.first_cell) <= (level, cell));
+        let entry = self.entries.get(after.checked_sub(1)?)?;
+        (entry.level == level && entry.holds_cell(cell)).then_some(entry)
+    }
+
+    /// The block holding a key, and nothing where no block does.
+    ///
+    /// A key names a cell of one level, so the level is asked for too: the
+    /// same subtree has a key at every level above its own and they share
+    /// their upper bits.
+    #[must_use]
+    pub fn holding_key(&self, level: usize, key: u128) -> Option<&BlockEntry> {
+        let level = u8::try_from(level).ok()?;
+        self.entries
+            .iter()
+            .find(|entry| entry.level == level && entry.holds_key(key))
+    }
+
+    /// What the store comes to on disk, and what it comes to read back.
+    #[must_use]
+    pub fn bytes(&self) -> (u64, u64) {
+        self.entries
+            .iter()
+            .fold((0, 0), |(stored, unpacked), entry| {
+                (
+                    stored + u64::from(entry.stored),
+                    unpacked + u64::from(entry.unpacked),
+                )
+            })
+    }
+
+    /// Refuses a map written under a version this does not know.
+    ///
+    /// # Errors
+    ///
+    /// Returns the version found when it is not the one this reads.
+    pub fn check_version(&self) -> Result<(), u16> {
+        if self.version == VERSION {
+            Ok(())
+        } else {
+            Err(self.version)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(level: u8, first_cell: CellId, cells: u32, first_key: u128) -> BlockEntry {
+        BlockEntry {
+            first_key,
+            last_key: first_key + u128::from(cells) - 1,
+            level,
+            codec: 0,
+            first_cell,
+            cells,
+            first_node: first_cell * 10,
+            nodes: cells * 10,
+            at: u64::from(first_cell) * 100,
+            stored: cells * 8,
+            unpacked: cells * 16,
+            hash: u64::from(first_cell),
+        }
+    }
+
+    fn map() -> BlockMap {
+        // deliberately out of order, since a build may emit them so
+        BlockMap::of(vec![
+            entry(1, 0, 3, 1000),
+            entry(0, 10, 5, 100),
+            entry(0, 0, 10, 0),
+            entry(0, 20, 4, 200),
+        ])
+    }
+
+    #[test]
+    fn a_cell_finds_the_block_that_holds_it() {
+        let map = map();
+        for (level, cell, wanted) in [
+            (0_usize, 0 as CellId, Some(0 as CellId)),
+            (0, 9, Some(0)),
+            (0, 10, Some(10)),
+            (0, 14, Some(10)),
+            (0, 20, Some(20)),
+            (0, 23, Some(20)),
+            (1, 2, Some(0)),
+        ] {
+            assert_eq!(
+                map.holding_cell(level, cell).map(|entry| entry.first_cell),
+                wanted,
+                "level {level}, cell {cell}"
+            );
+        }
+    }
+
+    /// A cell in a gap is a cell nobody downloaded, and the answer is nothing
+    /// rather than the block next door.
+    #[test]
+    fn a_cell_no_block_holds_finds_nothing() {
+        let map = map();
+        for (level, cell) in [(0_usize, 15 as CellId), (0, 24), (0, 999), (1, 3), (2, 0)] {
+            assert!(
+                map.holding_cell(level, cell).is_none(),
+                "level {level}, cell {cell} found a block"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_finds_the_block_whose_range_covers_it() {
+        let map = map();
+        assert_eq!(map.holding_key(0, 5).map(|entry| entry.first_cell), Some(0));
+        assert_eq!(
+            map.holding_key(0, 103).map(|entry| entry.first_cell),
+            Some(10)
+        );
+        assert_eq!(map.holding_key(0, 50), None, "a key in a gap");
+        assert_eq!(
+            map.holding_key(1, 1001).map(|entry| entry.first_cell),
+            Some(0)
+        );
+        // the same key at another level is another block, or none
+        assert_eq!(map.holding_key(1, 5), None);
+    }
+
+    #[test]
+    fn a_map_says_what_it_comes_to() {
+        let map = map();
+        assert_eq!(map.len(), 4);
+        let (stored, unpacked) = map.bytes();
+        assert_eq!(stored, (10 + 5 + 4 + 3) * 8);
+        assert_eq!(unpacked, (10 + 5 + 4 + 3) * 16);
+    }
+
+    #[test]
+    fn a_map_reads_back_as_it_was_written() {
+        let map = map();
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&map).expect("serializes");
+        let read: BlockMap =
+            rkyv::from_bytes::<BlockMap, rkyv::rancor::Error>(&bytes).expect("deserializes");
+        assert_eq!(read, map);
+        assert!(read.check_version().is_ok());
+    }
+}

--- a/src/block_store.rs
+++ b/src/block_store.rs
@@ -1,0 +1,325 @@
+//! Writing the blocks of a store to a file, and reading one back out of it.
+//!
+//! # What a read costs
+//!
+//! Finding a cell is a binary search of the block map, which is in memory.
+//! Then one positional read of the block's bytes, one pass of the codec over
+//! them, and the entries of the one cell asked for unpacked into a buffer the
+//! caller keeps. Nothing else in the block is touched.
+//!
+//! The read is positional rather than a seek and a read, so a store may be
+//! read from several threads through one open file without any of them moving
+//! another's cursor.
+//!
+//! # What is not here
+//!
+//! No cache. A store that pages wants one, and where it goes is above this:
+//! this is what a fault does, not when a fault happens. Nor is there anything
+//! about which levels are pinned, for the same reason.
+
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::Path,
+};
+
+use crate::{
+    block_codec::Codec,
+    block_map::{BlockEntry, BlockMap},
+    cell_block::CellBlock,
+    cell_tree::CellTree,
+    level_directory::CellId,
+};
+
+/// Reads exactly as many bytes as the buffer holds, from a place in a file.
+///
+/// Positional, so that one open file answers several threads at once.
+#[cfg(unix)]
+fn read_at(file: &File, at: u64, into: &mut [u8]) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(into, at)
+}
+
+#[cfg(windows)]
+fn read_at(file: &File, at: u64, into: &mut [u8]) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    let mut read = 0;
+    while read < into.len() {
+        match file.seek_read(&mut into[read..], at + read as u64)? {
+            0 => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "the file ended inside a block",
+                ));
+            }
+            some => read += some,
+        }
+    }
+    Ok(())
+}
+
+/// Lays blocks into a file one after another and remembers where each went.
+pub struct BlockWriter {
+    out: BufWriter<File>,
+    at: u64,
+    entries: Vec<BlockEntry>,
+}
+
+impl BlockWriter {
+    /// # Errors
+    ///
+    /// Returns what went wrong opening the file.
+    pub fn create(path: &Path) -> io::Result<Self> {
+        Ok(Self {
+            out: BufWriter::new(File::create(path)?),
+            at: 0,
+            entries: Vec::new(),
+        })
+    }
+
+    /// Writes one block down and notes what it covers.
+    ///
+    /// # Errors
+    ///
+    /// Returns what went wrong writing, or if the block will not serialize.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a block is larger than four thousand million bytes, which is
+    /// not a block anybody should be cutting.
+    pub fn push(
+        &mut self,
+        block: &CellBlock,
+        keys: (u128, u128),
+        cells: (CellId, u32),
+        nodes: (u32, u32),
+        codec: Codec,
+        effort: i32,
+    ) -> io::Result<()> {
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(block)
+            .map_err(|why| io::Error::other(format!("a block will not serialize: {why}")))?;
+        let stored = codec.encode(&bytes, effort);
+        self.out.write_all(&stored)?;
+
+        self.entries.push(BlockEntry {
+            first_key: keys.0,
+            last_key: keys.1,
+            level: u8::try_from(block.level()).expect("more levels than a byte counts"),
+            codec: codec.id(),
+            first_cell: cells.0,
+            cells: cells.1,
+            first_node: nodes.0,
+            nodes: nodes.1,
+            at: self.at,
+            stored: u32::try_from(stored.len())
+                .expect("a block of more than four thousand million"),
+            unpacked: u32::try_from(bytes.len())
+                .expect("a block of more than four thousand million"),
+            hash: xxhash_rust::xxh3::xxh3_64(&bytes),
+        });
+        self.at += stored.len() as u64;
+        Ok(())
+    }
+
+    /// Closes the file and hands back the map of what went into it.
+    ///
+    /// # Errors
+    ///
+    /// Returns what went wrong flushing.
+    pub fn finish(mut self) -> io::Result<BlockMap> {
+        self.out.flush()?;
+        Ok(BlockMap::of(self.entries))
+    }
+}
+
+/// A store open for reading.
+pub struct BlockStore {
+    blocks: File,
+    map: BlockMap,
+    tree: CellTree,
+}
+
+/// What went wrong reading a cell.
+#[derive(Debug)]
+pub enum NotRead {
+    /// no block holds it, which means the piece of the map it is in was not
+    /// downloaded rather than that anything is wrong
+    NotHere,
+    /// the file names a codec this build has no reader for
+    UnknownCodec(u8),
+    /// the bytes are not what they say they are
+    Corrupt(String),
+    Io(io::Error),
+}
+
+impl std::fmt::Display for NotRead {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotHere => write!(f, "no block of this store holds that cell"),
+            Self::UnknownCodec(id) => write!(f, "no codec numbered {id}"),
+            Self::Corrupt(why) => write!(f, "a block did not read back: {why}"),
+            Self::Io(why) => write!(f, "{why}"),
+        }
+    }
+}
+
+impl std::error::Error for NotRead {}
+
+impl From<io::Error> for NotRead {
+    fn from(why: io::Error) -> Self {
+        Self::Io(why)
+    }
+}
+
+impl BlockStore {
+    /// # Errors
+    ///
+    /// Returns what went wrong opening the file.
+    pub fn open(blocks: &Path, map: BlockMap, tree: CellTree) -> io::Result<Self> {
+        Ok(Self {
+            blocks: File::open(blocks)?,
+            map,
+            tree,
+        })
+    }
+
+    #[must_use]
+    pub fn map(&self) -> &BlockMap {
+        &self.map
+    }
+
+    #[must_use]
+    pub fn tree(&self) -> &CellTree {
+        &self.tree
+    }
+
+    /// The distances across one cell, read out of whichever block holds it.
+    ///
+    /// Into a buffer the caller keeps, since a search asks for one cell after
+    /// another and each answer is the same shape.
+    ///
+    /// # Errors
+    ///
+    /// [`NotRead::NotHere`] where no block holds the cell, which is a region
+    /// nobody downloaded rather than a fault.
+    pub fn table_into(
+        &self,
+        level: usize,
+        cell: CellId,
+        out: &mut Vec<u32>,
+    ) -> Result<(), NotRead> {
+        let entry = *self.map.holding_cell(level, cell).ok_or(NotRead::NotHere)?;
+        let codec = Codec::of(entry.codec).map_err(|why| NotRead::UnknownCodec(why.0))?;
+
+        let mut stored = vec![0_u8; entry.stored as usize];
+        read_at(&self.blocks, entry.at, &mut stored)?;
+        let bytes = codec
+            .decode(&stored, entry.unpacked as usize)
+            .map_err(NotRead::Corrupt)?;
+        let block = rkyv::from_bytes::<CellBlock, rkyv::rancor::Error>(&bytes)
+            .map_err(|why| NotRead::Corrupt(why.to_string()))?;
+
+        // how wide each table of the block is, which the tree knows and the
+        // block does not carry
+        let widths = (0..entry.cells)
+            .map(|at| self.tree.facts(level, entry.first_cell + at).on_border as usize)
+            .collect::<Vec<_>>();
+        block.unpack_into((cell - entry.first_cell) as usize, &widths, out);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell_block::CellEntry;
+
+    fn tiny_tree() -> CellTree {
+        use crate::{
+            edge::InputEdge, geometry::FPCoordinate, grid_graph::grid_directory,
+            packed_partition::PackedPartition, static_graph::StaticGraph,
+        };
+        let side = 8;
+        let mut edges = Vec::new();
+        for row in 0..side {
+            for column in 0..side {
+                let node = row * side + column;
+                if column + 1 < side {
+                    edges.push(InputEdge::new(node, node + 1, 1_u32));
+                    edges.push(InputEdge::new(node + 1, node, 1_u32));
+                }
+                if row + 1 < side {
+                    edges.push(InputEdge::new(node, node + side, 1_u32));
+                    edges.push(InputEdge::new(node + side, node, 1_u32));
+                }
+            }
+        }
+        let graph = StaticGraph::new(edges);
+        let directory = grid_directory(side);
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        CellTree::of(&directory, &partition, &graph, &coordinates)
+    }
+
+    #[test]
+    fn a_table_written_to_a_store_reads_back_out_of_it() {
+        let tree = tiny_tree();
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("blocks");
+
+        // two blocks of the finest level, each of two cells, with tables as
+        // wide as the tree says those cells are
+        let mut matrices = Vec::new();
+        for cell in 0..4_u32 {
+            let wide = tree.facts(0, cell).on_border as usize;
+            matrices.push(
+                (0..wide * wide)
+                    .map(|at| (at as u32 + cell) * 3)
+                    .collect::<Vec<u32>>(),
+            );
+        }
+
+        let mut writer = BlockWriter::create(&path).expect("a file to write");
+        for (which, codec) in [(0_u32, Codec::Stored), (2, Codec::Lz4)] {
+            let entries = (which..which + 2)
+                .map(|cell| CellEntry {
+                    matrix: &matrices[cell as usize],
+                    wide: tree.facts(0, cell).on_border as usize,
+                    places: &[],
+                    holds: 16,
+                })
+                .collect::<Vec<_>>();
+            let block = CellBlock::of(0, which, &entries, true);
+            let keys = (tree.range_of(0, which).0, tree.range_of(0, which + 1).1);
+            writer
+                .push(&block, keys, (which, 2), (which * 4, 8), codec, 3)
+                .expect("a block to write");
+        }
+        let map = writer.finish().expect("a file to close");
+        assert_eq!(map.len(), 2);
+
+        let store = BlockStore::open(&path, map, tree).expect("a store to open");
+        let mut out = Vec::new();
+        for cell in 0..4_u32 {
+            store.table_into(0, cell, &mut out).expect("a cell to read");
+            assert_eq!(out, matrices[cell as usize], "cell {cell}");
+        }
+    }
+
+    #[test]
+    fn a_cell_no_block_holds_says_so_rather_than_failing() {
+        let tree = tiny_tree();
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("blocks");
+        let writer = BlockWriter::create(&path).expect("a file to write");
+        let map = writer.finish().expect("a file to close");
+
+        let store = BlockStore::open(&path, map, tree).expect("a store to open");
+        let mut out = Vec::new();
+        let why = store
+            .table_into(0, 0, &mut out)
+            .expect_err("nothing is there");
+        assert!(matches!(why, NotRead::NotHere), "{why}");
+        assert_eq!(why.to_string(), "no block of this store holds that cell");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bidirectional_mld_query;
 pub mod bin_pack;
 pub mod bit_weight_iterator;
 pub mod bitset_subset_iterator;
+pub mod block_codec;
 pub mod bloom_filter;
 pub mod border_levels;
 pub mod bounding_box;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod bin_pack;
 pub mod bit_weight_iterator;
 pub mod bitset_subset_iterator;
 pub mod block_codec;
+pub mod block_map;
+pub mod block_store;
 pub mod bloom_filter;
 pub mod border_levels;
 pub mod bounding_box;


### PR DESCRIPTION
Fourth of five, on #608.

## Codecs, and what they turn out to be worth

A byte a block rather than a choice for a file, so a build may squeeze the
coarse levels hard and the fine ones not at all, and may change its mind later
without rewriting what has shipped. Stored, deflate, zstd, lz4. A byte naming a
codec this build has no reader for is refused as a file from later.

Over europe.ptv, 66 blocks of about four megabytes:

| codec | on disk | share of raw | to read the whole store |
|---|---|---|---|
| stored | 113.3 MiB | 44.8% | 16.2ms |
| **lz4** | **107.8 MiB** | **42.7%** | **19.9ms** |
| deflate 6 | 103.6 MiB | 41.0% | 336.3ms |
| zstd 3 | 103.9 MiB | 41.1% | 130.2ms |
| zstd 19 | 102.8 MiB | 40.7% | 126.5ms |

**The best saves nine per cent** over storing the blocks as they are, and zstd
at 19 beats zstd at 3 by one megabyte in a hundred and three. That is not the
codecs failing: the entries are already packed to the narrowest width that
holds them, so most of what a compressor looks for was taken out before it
arrived. Compression is the second bite and the first was the larger.

So the codec is a **latency** choice, not a size one: lz4 is five per cent for
about four milliseconds over a straight copy of the whole store, zstd is nine
for a hundred and ten. Recommendation: lz4, with the byte a block there for a
build that would rather ship ten megabytes less.

Adds `lz4_flex`, `flate2` and `zstd`.

## The block map

A block holds a run of cells of one level, and numbered as their keys run that
run is at once a range of keys, of cell numbers and of node numbers, so an
entry carries all three as bounds and a lookup takes whichever the caller
holds.

**A key no entry covers is a key nobody downloaded.** There is no flag for a
missing region: `holding_cell` hands back nothing, and that is the answer
rather than a fault.

Each entry carries an xxh3 of the block's bytes. Nothing uses it yet, but a
name for a block cannot be added to files already shipped: two builds that make
the same block make the same name, so a device updating between releases can
fetch the blocks whose contents changed rather than whose numbers changed.

## The store

    BlockWriter::create / push / finish -> BlockMap
    BlockStore::open / table_into / cell_into / entry_of / block_at

A read is a binary search of the map, one positional read of that block, one
pass of the codec, and the one cell asked for unpacked into a caller's buffer.
Nothing else in the block is touched. Positional rather than seek-and-read, so
one open file answers several threads without any of them moving another's
cursor.

`NotRead::NotHere` — the region nobody downloaded — is kept apart from a codec
this build cannot read and from bytes that are not what they say they are.