### PR TITLE
Read the cells off a file, hold the coarse levels, and cache the rest

### DIFF
--- a/docs/disk-storage-results.md
+++ b/docs/disk-storage-results.md
@@ -166,6 +166,58 @@ two coarsest levels were the ones worth holding before and after. The numbers
 did not: the paged store was reported at five to seven times the in-memory
 query and is under two.
 
+## How much memory to give it
+
+`paged_query` was run over 600 pairs (every eighth of the 4,800, so the rank
+spread is kept) at budgets from 1 to 256 MiB, 64 KiB blocks, `pinned_share`
+0.5. `scripts/budget_plot.R` draws it from the summary `TOOLBOX_SUMMARY`
+writes, in query time against budget, with the multiple of the in-memory query
+on the opposite axis.
+
+| budget | held | for cache | median | 95th | reads/query | hit rate |
+|--------|------|-----------|--------|------|-------------|----------|
+| 1 MiB | — | 1.0 MiB | 6.03× | 16,300× | 43.9 | 46.7% |
+| 2 MiB | — | 2.0 MiB | 4.58× | 16,700× | 42.0 | 56.6% |
+| 4 MiB | — | 4.0 MiB | 4.25× | 11,100× | 35.8 | 73.5% |
+| 8 MiB | — | 8.0 MiB | 4.41× | 2,200× | 20.0 | 89.6% |
+| 16 MiB | — | 16.0 MiB | 3.85× | 225× | 10.0 | 94.5% |
+| 32 MiB | — | 32.0 MiB | 3.57× | 125× | 8.3 | 95.0% |
+| 64 MiB | L5+ | 45.7 MiB | 2.99× | 92.8× | 5.9 | 93.8% |
+| 80 MiB | L5+ | 61.7 MiB | 2.77× | 88.1× | 4.9 | 94.7% |
+| 96 MiB | L5+ | 77.7 MiB | 2.42× | 85.7× | 3.8 | 95.9% |
+| **112 MiB** | L5+ | 93.7 MiB | **1.27×** | 83.8× | **0.50** | 99.5% |
+| 128 MiB | L4+ | 69.8 MiB | 1.32× | 81.3× | 0.48 | 99.1% |
+| 192 MiB | L4+ | 133.8 MiB | 1.48× | 80.5× | 0.48 | 99.1% |
+| 256 MiB | L3+ | 136.8 MiB | 1.27× | 81.7× | 0.41 | 98.1% |
+
+The curve is a cliff, not a slope. From 1 to 96 MiB the median only walks from
+6.0× to 2.4×, because a query's cells are scattered across the levels and a
+cache that cannot hold the working set evicts what the next query wants. At
+112 MiB the working set fits: reads fall from 3.8 a query to 0.5 and the
+median lands at 1.27×. Above that nothing more is bought — 256 MiB is 1.27×,
+the same, and the spread between 112, 128, 192 and 256 is run-to-run noise.
+
+**112 MiB is the size to pick**, and 128 MiB if a round number is wanted. Below
+the cliff the choice hardly matters: 32 MiB and 4 MiB are both about 4× and
+neither is close to the knee.
+
+Two things the medians hide:
+
+- **The tail is where a small budget hurts.** At 1 MiB the 95th is 1.22
+  *seconds* against 75µs in memory. It is under 10ms from 32 MiB up, and the
+  95th flattens at ~85× well before the median does — the 95th is the block
+  reads a long query cannot avoid, and 16 MiB already removes most of them.
+- **Holding levels is not what wins.** 112 MiB holds only level 5 (18.3 MiB)
+  and is as fast as 128 MiB, which holds levels 4 and 5 (58.2 MiB) and has
+  *less* cache for it. Cache size is the parameter; the held levels ride along.
+  A second sweep with `pinned_share` 0 confirmed it: at every budget where a
+  level was actually held, the cache-only run was within noise.
+
+The saturation point depends on how many distinct queries share the cache. The
+same sweep over 120 pairs put the cliff at 128 MiB and reported 1.04× there,
+because a fifth of the queries have a fifth of the working set. A server
+answering a wider spread than 600 pairs should expect the cliff further right.
+
 ## What has not been measured
 
 - **Cold page cache.** Every one of these runs read a file the operating

--- a/docs/disk-storage-results.md
+++ b/docs/disk-storage-results.md
@@ -1,0 +1,140 @@
+# Disk-based MLD storage: what the measurements say
+
+All on europe.ptv: 18,010,173 nodes, 42,188,664 arcs, 6 levels, the boundary
+directory, cells numbered in key order and nodes by cell path. 623,435 cells,
+66,267,046 table entries. Four physical cores.
+
+Every number here is measured, and every table read back out of a store was
+compared with what went into it. Where a measurement contradicted the plan the
+measurement is what is written down.
+
+## The store
+
+| | | |
+|---|---|---|
+| tables as four-byte entries | 252.8 MiB | 100% |
+| packed at one width per table | 111.0 MiB | 44% |
+| framing beside them | 2.5 MiB | 1% |
+| a block file, lz4 | **107.8 MiB** | **43%** |
+| the cell tree, shipped whole | 19.5 MiB | |
+
+## Encoding: one width per table, no row minimum
+
+Four schemes counted over every table:
+
+| | | |
+|---|---|---|
+| the least of a row, then two bytes an entry | 161.1 MiB | 64% |
+| the least, then a width per row | 126.5 MiB | 50% |
+| the least, then a width per table | 130.7 MiB | 52% |
+| **a width per table and no least** | **112.5 MiB** | **44%** |
+
+Two findings, both against the plan:
+
+**Two-byte deltas are the wrong shape for this data.** They want a row whose
+values sit close together, and the coarse levels do not: at the top level only
+8.4% of rows fit, 2.88 million entries escape, and the result is *larger than
+raw* — 13.1 MiB against 9.1.
+
+**The least of a row is always nought.** A row holds the distance from a node
+to every border node of its cell, itself among them, and that one is nought.
+Over all 4,783,400 rows not one had a smallest reachable distance above nought.
+Storing it costs 18.2 MiB and buys nothing.
+
+A width per row is 14 MiB smaller in the entries and was still not taken: rows
+are read at random, so it wants four bytes a row saying where each begins,
+which gives the 14 back and costs 4 more.
+
+## Codecs: worth 9 per cent, so a latency choice
+
+| codec | on disk | share of raw | to read the whole store |
+|---|---|---|---|
+| stored | 113.3 MiB | 44.8% | 16.2ms |
+| **lz4** | **107.8 MiB** | **42.7%** | **19.9ms** |
+| deflate 6 | 103.6 MiB | 41.0% | 336.3ms |
+| zstd 3 | 103.9 MiB | 41.1% | 130.2ms |
+| zstd 19 | 102.8 MiB | 40.7% | 126.5ms |
+
+The best saves nine per cent over storing the blocks as they are, and zstd at
+19 beats zstd at 3 by one megabyte in a hundred and three. That is not the
+codecs failing: the entries are already packed to the narrowest width that
+holds them, so most of what a compressor looks for was taken out before it
+arrived. Compression is the second bite and the first was the larger.
+
+**Recommendation: lz4.** Five per cent for about four milliseconds over a
+straight copy of the whole store, against nine per cent for a hundred and ten.
+The codec byte a block is what lets a build that would rather ship ten
+megabytes less use zstd for the levels where a fault is rare.
+
+## Block size: 64 KiB, not 4 MiB
+
+At a budget of 150 MiB, medians over 4,800 pairs:
+
+| block target | blocks | on disk | median | p95 | reads a query |
+|---|---|---|---|---|---|
+| 4096 KiB | 66 | 107.8 MiB | 2118µs | 9061µs | 1.9 |
+| 512 KiB | 491 | 108.0 MiB | 635µs | 7069µs | 2.2 |
+| **64 KiB** | **3,633** | **108.2 MiB** | **437µs** | **6829µs** | 2.5 |
+| 16 KiB | 13,217 | 108.8 MiB | 507µs | 6957µs | 3.0 |
+| 4 KiB | 45,088 | 110.3 MiB | 752µs | 7321µs | 4.2 |
+
+The plan's four megabytes is **4.8 times worse than the best** and its smallest
+suggested size, one megabyte, is still two to three times worse. A 4 MiB block
+is read, decoded and parsed to hand back one table of a few hundred bytes.
+
+Below 64 KiB it turns: reads a query climb faster than each read gets cheaper,
+and the file grows, since a smaller block gives lz4 less to work with — 108.2
+MiB at 64 KiB against 110.3 at 4 KiB.
+
+**Recommendation: 64 KiB**, and the curve is shallow between 64 and 512, so a
+build with a reason to prefer fewer, larger blocks loses little at 512.
+
+## Memory budget: which levels to hold
+
+Levels cost, unpacked, from the coarsest down: 18.3, 40.0, 61.0, 93.1, 125.0
+and 186.4 MiB, so from the top 18.3, 58.2, 119.2, 212.4, 337.4 and 523.8.
+
+At 4 MiB blocks, 4,800 pairs, half the budget available to hold levels:
+
+| budget | held | held bytes | cache | open | median | p95 | reads a query | hit rate |
+|---|---|---|---|---|---|---|---|---|
+| 75 MiB | L5 | 18.3 MiB | 56.7 MiB | 5.6s | 3397µs | 12229µs | 3.8 | 95.3% |
+| 150 MiB | L4+ | 58.2 MiB | 91.8 MiB | 5.4s | 2173µs | 8632µs | 1.9 | 96.9% |
+| 300 MiB | L3+ | 119.2 MiB | 180.8 MiB | 5.5s | 2192µs | 8688µs | 1.6 | 93.8% |
+| 700 MiB | L1+ | 337.4 MiB | 362.6 MiB | 5.8s | 953µs | 6873µs | 0.5 | 82.2% |
+
+**Every answer at every budget matched the same search over the cells in
+memory**, 4,800 pairs each.
+
+Holding the two coarsest levels is most of what there is to gain: 75 to 150
+MiB halves the median, and 150 to 300 changes nothing worth naming. Going to
+700 halves it again, but that is 337 MiB of held tables to save a millisecond,
+and by then the hit rate has *fallen* to 82% because the cache is holding fine
+tables that a query touches once.
+
+Opening a store is about 5.5s at any budget, nearly all of it reading and
+unpacking the levels to be held.
+
+## Against the same query in memory
+
+The in-memory search is 63µs at the median under the border-first numbering
+and 76µs under cell-path. The paged store is **437µs at 64 KiB blocks and a
+150 MiB budget**, so between five and seven times slower.
+
+That is the price of the whole exercise and it is worth stating plainly: a
+device holding a hundred and eight megabytes answers in about four hundred
+microseconds where a server holding one and a half gigabytes answers in
+seventy.
+
+## What has not been measured
+
+- **Cold page cache.** Every one of these runs read a file the operating
+  system already had. A device faulting from flash will be slower, and the
+  block-size curve will move: the smaller the block, the more the fixed cost of
+  a read matters.
+- **Regions.** Nothing here is sparse; the whole of Europe was present.
+- **The pinned section is not mmapped.** Held levels are read and unpacked at
+  open, which is the 5.5s. Mapping them would trade that for a slower first
+  touch.
+- **zstd with a trained dictionary**, which the plan wanted for the small-frame
+  case. With 64 KiB blocks there is a case for it that there was not at 4 MiB.

--- a/docs/disk-storage-results.md
+++ b/docs/disk-storage-results.md
@@ -72,13 +72,13 @@ At a budget of 150 MiB, medians over 4,800 pairs:
 
 | block target | blocks | on disk | median | p95 | reads a query |
 |---|---|---|---|---|---|
-| 4096 KiB | 66 | 107.8 MiB | 2118µs | 9061µs | 1.9 |
-| 512 KiB | 491 | 108.0 MiB | 635µs | 7069µs | 2.2 |
-| **64 KiB** | **3,633** | **108.2 MiB** | **437µs** | **6829µs** | 2.5 |
-| 16 KiB | 13,217 | 108.8 MiB | 507µs | 6957µs | 3.0 |
-| 4 KiB | 45,088 | 110.3 MiB | 752µs | 7321µs | 4.2 |
+| 4096 KiB | 66 | 107.8 MiB | 1197µs | 7055µs | 1.3 |
+| 512 KiB | 491 | 108.0 MiB | 262µs | 5957µs | 1.6 |
+| **64 KiB** | **3,633** | **108.2 MiB** | **130µs** | **5669µs** | 1.7 |
+| 16 KiB | 13,217 | 108.8 MiB | 196µs | 6182µs | 2.0 |
+| 4 KiB | 45,088 | 110.3 MiB | 320µs | 6314µs | 2.7 |
 
-The plan's four megabytes is **4.8 times worse than the best** and its smallest
+The plan's four megabytes is **9.2 times worse than the best**, and its smallest
 suggested size, one megabyte, is still two to three times worse. A 4 MiB block
 is read, decoded and parsed to hand back one table of a few hundred bytes.
 
@@ -86,45 +86,85 @@ Below 64 KiB it turns: reads a query climb faster than each read gets cheaper,
 and the file grows, since a smaller block gives lz4 less to work with — 108.2
 MiB at 64 KiB against 110.3 at 4 KiB.
 
-**Recommendation: 64 KiB**, and the curve is shallow between 64 and 512, so a
-build with a reason to prefer fewer, larger blocks loses little at 512.
+**Recommendation: 64 KiB.** The curve is shallow between 64 and 512, so a build
+with a reason to prefer fewer, larger blocks loses little at 512, and steep
+above that.
 
 ## Memory budget: which levels to hold
 
 Levels cost, unpacked, from the coarsest down: 18.3, 40.0, 61.0, 93.1, 125.0
 and 186.4 MiB, so from the top 18.3, 58.2, 119.2, 212.4, 337.4 and 523.8.
 
-At 4 MiB blocks, 4,800 pairs, half the budget available to hold levels:
+At 64 KiB blocks, 4,800 pairs, half the budget available to hold levels:
 
 | budget | held | held bytes | cache | open | median | p95 | reads a query | hit rate |
 |---|---|---|---|---|---|---|---|---|
-| 75 MiB | L5 | 18.3 MiB | 56.7 MiB | 5.6s | 3397µs | 12229µs | 3.8 | 95.3% |
-| 150 MiB | L4+ | 58.2 MiB | 91.8 MiB | 5.4s | 2173µs | 8632µs | 1.9 | 96.9% |
-| 300 MiB | L3+ | 119.2 MiB | 180.8 MiB | 5.5s | 2192µs | 8688µs | 1.6 | 93.8% |
-| 700 MiB | L1+ | 337.4 MiB | 362.6 MiB | 5.8s | 953µs | 6873µs | 0.5 | 82.2% |
+| 75 MiB | L5 | 18.3 MiB | 56.7 MiB | 5.6s | 211µs | 6171µs | 5.2 | 94.9% |
+| **150 MiB** | **L4+** | **58.2 MiB** | **91.8 MiB** | 5.4s | **130µs** | 5680µs | 1.7 | 97.1% |
+| 300 MiB | L3+ | 119.2 MiB | 180.8 MiB | 5.4s | 124µs | 5598µs | 1.5 | 93.9% |
+| 700 MiB | L1+ | 337.4 MiB | 362.6 MiB | 5.5s | 95µs | 5508µs | 0.6 | 83.7% |
 
-**Every answer at every budget matched the same search over the cells in
-memory**, 4,800 pairs each.
-
-Holding the two coarsest levels is most of what there is to gain: 75 to 150
-MiB halves the median, and 150 to 300 changes nothing worth naming. Going to
-700 halves it again, but that is 337 MiB of held tables to save a millisecond,
-and by then the hit rate has *fallen* to 82% because the cache is holding fine
-tables that a query touches once.
+**Holding the two coarsest levels is nearly all of what there is to gain.** 75
+to 150 MiB cuts the median by 38% and reads a query from 5.2 to 1.7; 150 to 300
+buys 5%. Going to 700 buys another 27%, but for 337 MiB of held tables, and by
+then the hit rate has *fallen* to 84% because the cache is holding fine tables
+a query touches once.
 
 Opening a store is about 5.5s at any budget, nearly all of it reading and
 unpacking the levels to be held.
 
 ## Against the same query in memory
 
-The in-memory search is 63µs at the median under the border-first numbering
-and 76µs under cell-path. The paged store is **437µs at 64 KiB blocks and a
-150 MiB budget**, so between five and seven times slower.
+Both engines over the same 4,800 pairs, 64 KiB blocks, a 150 MiB budget, the
+cells in memory fully customized first. Medians by Dijkstra rank:
 
-That is the price of the whole exercise and it is worth stating plainly: a
-device holding a hundred and eight megabytes answers in about four hundred
-microseconds where a server holding one and a half gigabytes answers in
-seventy.
+| rank | in memory | paged | |
+|---|---|---|---|
+| 2^4 | 3.1µs | 3.3µs | 1.07× |
+| 2^6 | 7.5µs | 7.8µs | 1.05× |
+| 2^8 | 16.1µs | 34.0µs | 2.12× |
+| 2^10 | 32.7µs | 71.1µs | **2.17×** |
+| 2^12 | 64.5µs | 115.2µs | 1.79× |
+| 2^14 | 140.2µs | 211.3µs | 1.51× |
+| 2^16 | 289.7µs | 391.0µs | 1.35× |
+| 2^18 | 584.1µs | 715.5µs | 1.23× |
+| 2^20 | 1331.8µs | 1401.9µs | 1.05× |
+| 2^22 | 2981.6µs | 2933.4µs | 0.98× |
+| 2^24 | 7008.6µs | 6305.3µs | 0.90× |
+| **all** | **75.2µs** | **137.1µs** | **1.82×** |
+
+**A store of 108 MiB answers within a factor of two of a customization holding
+about a gigabyte and a half.**
+
+The curve has a shape worth reading. Below rank 2^7 there is almost nothing in
+it: a short search stays in the cells around its ends, which are cached after
+the first touch. It peaks at 2^10, where a search has started reaching cells it
+has not seen and has not yet reached the levels that are held outright. Above
+2^19 it closes, and at the very top the paged store is *faster* — the held
+levels are one run of memory apiece, where the customization reaches through a
+vector of boxes per cell.
+
+**Every one of the 4,800 answers equals the same query run on the original,
+un-renumbered instance**, through two renumberings, the packing, lz4 and the
+cache.
+
+## A measurement that was wrong, and is corrected here
+
+Everything above was first measured with the wrong pairs. The pair file holds
+node ids of the instance they were drawn on, and the store is built on a
+renumbered one, so the ids named different nodes: of 4,800 pairs, **none** gave
+the same distance on both instances, and the rank beside each belonged to
+somebody else.
+
+It was caught by a number that did not fit — the in-memory engine measured
+341µs where the same engine on the same pairs measures 75µs — and confirmed by
+comparing the two instances' answers pair by pair. The pairs are now put
+through the numbering that `renumber` wrote.
+
+The conclusions held: 64 KiB was the best block size before and after, and the
+two coarsest levels were the ones worth holding before and after. The numbers
+did not: the paged store was reported at five to seven times the in-memory
+query and is under two.
 
 ## What has not been measured
 
@@ -137,4 +177,4 @@ seventy.
   open, which is the 5.5s. Mapping them would trade that for a slower first
   touch.
 - **zstd with a trained dictionary**, which the plan wanted for the small-frame
-  case. With 64 KiB blocks there is a case for it that there was not at 4 MiB.
+  case. At 64 KiB blocks there is a case for it that there was not at 4 MiB.

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -1,0 +1,276 @@
+//! What a query costs when the cells are on a disk rather than in memory.
+//!
+//! ```text
+//! paged_query <graph> <directory> <coordinates> <pairs.csv> <blocks> [MiB ...]
+//! ```
+//!
+//! Wants an instance whose cells are numbered in key order and whose nodes are
+//! numbered by cell path, which is what `renumber --numbering cell-path
+//! --cells-in-key-order` writes.
+//!
+//! Builds the store if the blocks file is not there, then for each budget
+//! opens it afresh, runs every pair, and says what it cost. Every answer is
+//! compared with the same search over the cells in memory, so the run says
+//! whether the store is right as well as how fast it is.
+
+use std::{
+    env::args,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::Path,
+    time::Instant,
+};
+
+use toolbox_rs::{
+    block_codec::Codec,
+    block_map::BlockMap,
+    block_store::{BlockStore, BlockWriter},
+    border_levels::BorderLevels,
+    cell_block::{CellBlock, CellEntry},
+    cell_tree::CellTree,
+    customization::Customization,
+    geometry::FPCoordinate,
+    graph::NodeID,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    mld_query::MldQuery,
+    packed_partition::PackedPartition,
+    paged_overlay::{Budget, PagedOverlay},
+    static_graph::StaticGraph,
+};
+
+const MIB: usize = 1024 * 1024;
+
+fn megabytes(bytes: u64) -> String {
+    format!("{:.1} MiB", bytes as f64 / MIB as f64)
+}
+
+/// Writes every cell of a customization into a store, a level at a time.
+fn pack(
+    customization: &Customization,
+    tree: &CellTree,
+    path: &Path,
+    target: usize,
+) -> std::io::Result<BlockMap> {
+    let mut writer = BlockWriter::create(path)?;
+    for level in 0..tree.levels() {
+        let border_leads = level == 0;
+        let count = tree.cells_on_level(level);
+        let mut at = 0;
+        while at < count {
+            // as many cells as fit the target, and never fewer than one
+            let (mut upto, mut carrying) = (at, 0_usize);
+            while upto < count && (carrying < target || upto == at) {
+                let wide = tree.facts(level, upto as CellId).on_border as usize;
+                carrying += wide * wide * 4;
+                upto += 1;
+            }
+
+            let mut matrices = Vec::new();
+            let mut widths = Vec::new();
+            let mut places = Vec::new();
+            let mut holds = Vec::new();
+            for cell in at..upto {
+                let cell = cell as CellId;
+                let held = customization.distances_of(level, cell);
+                let wide = held.map_or(0, |table| table.border_nodes_of().len());
+                let mut matrix = Vec::with_capacity(wide * wide);
+                if let Some(table) = held {
+                    for source in 0..wide {
+                        matrix.extend_from_slice(table.row(source));
+                    }
+                }
+                let begins = tree.nodes_begin(level, cell);
+                places.push(if border_leads {
+                    Vec::new()
+                } else {
+                    held.map_or_else(Vec::new, |table| {
+                        table
+                            .border_nodes_of()
+                            .iter()
+                            .map(|&node| node - begins)
+                            .collect()
+                    })
+                });
+                matrices.push(matrix);
+                widths.push(wide);
+                holds.push(tree.facts(level, cell).nodes as usize);
+            }
+
+            let entries = matrices
+                .iter()
+                .zip(&widths)
+                .zip(&places)
+                .zip(&holds)
+                .map(|(((matrix, &wide), places), &holds)| CellEntry {
+                    matrix,
+                    wide,
+                    places,
+                    holds,
+                })
+                .collect::<Vec<_>>();
+            let block = CellBlock::of(level, at as CellId, &entries, border_leads);
+            let last = (upto - 1) as CellId;
+            let keys = (
+                tree.range_of(level, at as CellId).0,
+                tree.range_of(level, last).1,
+            );
+            let first_node = tree.nodes_begin(level, at as CellId);
+            let nodes = (
+                first_node,
+                tree.nodes_begin(level, last) + tree.facts(level, last).nodes - first_node,
+            );
+            writer.push(
+                &block,
+                keys,
+                (at as CellId, (upto - at) as u32),
+                nodes,
+                Codec::Lz4,
+                3,
+            )?;
+            at = upto;
+        }
+    }
+    writer.finish()
+}
+
+fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
+    let mut pairs = Vec::new();
+    for line in BufReader::new(File::open(path).expect("the pairs"))
+        .lines()
+        .skip(1)
+    {
+        let line = line.expect("a line");
+        let mut fields = line.split(',');
+        if let (Some(Ok(source)), Some(Ok(target))) =
+            (fields.next().map(str::parse), fields.next().map(str::parse))
+        {
+            pairs.push((source, target));
+        }
+    }
+    pairs
+}
+
+fn main() {
+    env_logger::init();
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!("usage: paged_query <graph> <directory> <coordinates> <pairs> <blocks> [MiB ...]: missing {what}")
+        })
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let coordinates_path = next("coordinates");
+    let pairs_path = next("pairs");
+    let blocks_path = next("blocks");
+    let budgets = argv
+        .map(|mib| mib.parse::<usize>().expect("a size in MiB") * MIB)
+        .collect::<Vec<_>>();
+    let budgets = if budgets.is_empty() {
+        vec![75 * MIB, 150 * MIB, 300 * MIB, 700 * MIB]
+    } else {
+        budgets
+    };
+
+    let edges = io::read_edges_from_file(&graph_path);
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&coordinates_path);
+    let graph = StaticGraph::new(edges.clone());
+    let partition = PackedPartition::of(&directory);
+    let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+    let pairs = pairs_of(&pairs_path);
+    println!("{} pairs, {} levels", pairs.len(), tree.levels());
+
+    let in_memory = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
+    let path = Path::new(&blocks_path);
+    if !path.exists() {
+        let started = Instant::now();
+        // everything is customized before anything is written
+        for level in 0..tree.levels() {
+            for cell in 0..tree.cells_on_level(level) {
+                let _ = in_memory.distances_of(level, cell as CellId);
+            }
+        }
+        // how large a block is cut, in kibibytes of raw entries
+        let target = std::env::var("TOOLBOX_BLOCK_KIB")
+            .ok()
+            .and_then(|kib| kib.parse::<usize>().ok())
+            .unwrap_or(4096)
+            * 1024;
+        let map = pack(&in_memory, &tree, path, target).expect("a store to write");
+        let (stored, unpacked) = map.bytes();
+        println!(
+            "wrote {} blocks in {:.1?}: {} on disk, {} unpacked",
+            map.len(),
+            started.elapsed(),
+            megabytes(stored),
+            megabytes(unpacked)
+        );
+        io::write_to_file(&format!("{blocks_path}.map"), &map);
+        io::write_to_file(&format!("{blocks_path}.tree"), &tree);
+    }
+    let map: BlockMap = io::read_from_file(&format!("{blocks_path}.map"));
+    let held_tree: CellTree = io::read_from_file(&format!("{blocks_path}.tree"));
+
+    println!(
+        "\n{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}",
+        "budget", "held", "of which", "for cache", "open", "median", "p95", "reads/q", "hit rate"
+    );
+    for &bytes in &budgets {
+        let budget = Budget::of(bytes);
+        let store = BlockStore::open(path, map.clone(), held_tree.clone()).expect("a store");
+        let opening = Instant::now();
+        let paged = PagedOverlay::within(
+            store,
+            StaticGraph::new(edges.clone()),
+            PackedPartition::of(&directory),
+            BorderLevels::of(&graph, &partition),
+            budget,
+        );
+        let open = opening.elapsed();
+        let (pinned, cache) = budget.split(&held_tree);
+
+        let mut over_file = MldQuery::new();
+        let mut over_memory = MldQuery::new();
+        let mut took = Vec::with_capacity(pairs.len());
+        let mut wrong = 0_u64;
+        let before = paged.faults();
+        for &(source, target) in &pairs {
+            over_file.clear();
+            let started = Instant::now();
+            over_file.run(&paged, source, &[target]);
+            took.push(started.elapsed().as_nanos() as u64);
+            over_memory.clear();
+            over_memory.run(&in_memory, source, &[target]);
+            if over_file.distance(target) != over_memory.distance(target) {
+                wrong += 1;
+            }
+        }
+        took.sort_unstable();
+        let faults = paged.faults();
+        let reads = faults.reads - before.reads;
+        let asked = faults.hits + faults.misses - before.hits - before.misses;
+
+        println!(
+            "{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}{}",
+            format!("{} MiB", bytes / MIB),
+            format!("L{}+", paged.pinned_from()),
+            megabytes(pinned),
+            megabytes(cache as u64),
+            format!("{open:.1?}"),
+            format!("{:.0}us", took[took.len() / 2] as f64 / 1000.0),
+            format!("{:.0}us", took[took.len() * 95 / 100] as f64 / 1000.0),
+            format!("{:.1}", reads as f64 / pairs.len() as f64),
+            format!(
+                "{:.1}%",
+                100.0 * (faults.hits - before.hits) as f64 / asked.max(1) as f64
+            ),
+            if wrong == 0 {
+                String::new()
+            } else {
+                format!("  {wrong} WRONG")
+            },
+        );
+    }
+}

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -310,7 +310,7 @@ fn main() {
                 );
                 let _ = writeln!(
                     timings,
-                    "paged,{source},{target},{rank},{paged_nanos},{from_file}"
+                    "offline,{source},{target},{rank},{paged_nanos},{from_file}"
                 );
             }
         }

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -203,6 +203,15 @@ fn main() {
             pairs.len()
         ),
     }
+    // Every so many, rather than the first so many: the pairs come in runs of
+    // one rank, so taking a prefix would take a few ranks and none of the rest.
+    // A small budget thrashes, and thrashing over five thousand pairs takes
+    // longer than anybody waits.
+    if let Ok(stride) = std::env::var("TOOLBOX_PAIR_STRIDE") {
+        let stride: usize = stride.parse().expect("a stride");
+        pairs = pairs.into_iter().step_by(stride.max(1)).collect();
+        println!("every {stride} pairs kept, leaving {}", pairs.len());
+    }
     println!("{} pairs, {} levels", pairs.len(), tree.levels());
 
     let in_memory = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
@@ -252,8 +261,22 @@ fn main() {
         "\n{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}",
         "budget", "held", "of which", "for cache", "open", "median", "p95", "reads/q", "hit rate"
     );
+    // what share of a budget may be held outright, so a run can be made with
+    // the levels held and again with none of them, which is what says whether
+    // holding is worth the room it takes
+    let share = std::env::var("TOOLBOX_PIN_SHARE")
+        .ok()
+        .and_then(|share| share.parse::<f64>().ok())
+        .unwrap_or(0.5);
+    let mut summary = String::from(
+        "budget,share,pinned_from,pinned,cache,mld_median,offline_median,p95,slowdown,reads,hits\n",
+    );
+
     for &bytes in &budgets {
-        let budget = Budget::of(bytes);
+        let budget = Budget {
+            bytes,
+            pinned_share: share,
+        };
         let store = BlockStore::open(path, map.clone(), held_tree.clone()).expect("a store");
         let opening = Instant::now();
         let paged = PagedOverlay::within(
@@ -281,6 +304,7 @@ fn main() {
         }
 
         let mut took = Vec::with_capacity(pairs.len());
+        let mut memory_took = Vec::with_capacity(pairs.len());
         let mut wrong = 0_u64;
         let before = paged.faults();
         // both engines timed over the same pairs, in the shape rank_plot wants
@@ -296,6 +320,7 @@ fn main() {
             let started = Instant::now();
             over_memory.run(&in_memory, source, &[target]);
             let memory_nanos = started.elapsed().as_nanos();
+            memory_took.push(memory_nanos as u64);
 
             let (from_file, from_memory) =
                 (over_file.distance(target), over_memory.distance(target));
@@ -323,9 +348,29 @@ fn main() {
             println!("  wrote {name}");
         }
         took.sort_unstable();
+        memory_took.sort_unstable();
         let faults = paged.faults();
         let reads = faults.reads - before.reads;
         let asked = faults.hits + faults.misses - before.hits - before.misses;
+
+        // one row a budget, for whatever draws the picture
+        {
+            use std::fmt::Write;
+            let offline = took[took.len() / 2] as f64 / 1000.0;
+            let in_memory = memory_took[memory_took.len() / 2] as f64 / 1000.0;
+            // the tail too, since a median that looks survivable can sit over
+            // one that is not
+            let tail = took[took.len() * 95 / 100] as f64 / 1000.0;
+            let _ = writeln!(
+                summary,
+                "{},{share},{},{pinned},{cache},{in_memory:.1},{offline:.1},{tail:.1},{:.3},{:.2},{:.4}",
+                bytes / MIB,
+                paged.pinned_from(),
+                offline / in_memory,
+                reads as f64 / pairs.len() as f64,
+                (faults.hits - before.hits) as f64 / asked.max(1) as f64,
+            );
+        }
 
         println!(
             "{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}{}",
@@ -347,5 +392,10 @@ fn main() {
                 format!("  {wrong} WRONG")
             },
         );
+    }
+
+    if let Ok(path) = std::env::var("TOOLBOX_SUMMARY") {
+        std::fs::write(&path, summary).expect("somewhere to write the summary");
+        println!("wrote {path}");
     }
 }

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -34,6 +34,7 @@ use toolbox_rs::{
     io,
     level_directory::{CellId, LevelDirectory},
     mld_query::MldQuery,
+    node_ordering::NodeOrdering,
     packed_partition::PackedPartition,
     paged_overlay::{Budget, PagedOverlay},
     static_graph::StaticGraph,
@@ -134,7 +135,7 @@ fn pack(
     writer.finish()
 }
 
-fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
+fn pairs_of(path: &str) -> Vec<(NodeID, NodeID, usize)> {
     let mut pairs = Vec::new();
     for line in BufReader::new(File::open(path).expect("the pairs"))
         .lines()
@@ -142,10 +143,12 @@ fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
     {
         let line = line.expect("a line");
         let mut fields = line.split(',');
-        if let (Some(Ok(source)), Some(Ok(target))) =
-            (fields.next().map(str::parse), fields.next().map(str::parse))
-        {
-            pairs.push((source, target));
+        if let (Some(Ok(source)), Some(Ok(target)), Some(Ok(rank))) = (
+            fields.next().map(str::parse),
+            fields.next().map(str::parse),
+            fields.next().map(str::parse),
+        ) {
+            pairs.push((source, target, rank));
         }
     }
     pairs
@@ -167,6 +170,8 @@ fn main() {
     let budgets = argv
         .map(|mib| mib.parse::<usize>().expect("a size in MiB") * MIB)
         .collect::<Vec<_>>();
+    // where to write the timings, if anywhere
+    let writing = std::env::var("TOOLBOX_TIMINGS").ok();
     let budgets = if budgets.is_empty() {
         vec![75 * MIB, 150 * MIB, 300 * MIB, 700 * MIB]
     } else {
@@ -179,19 +184,49 @@ fn main() {
     let graph = StaticGraph::new(edges.clone());
     let partition = PackedPartition::of(&directory);
     let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
-    let pairs = pairs_of(&pairs_path);
+    let mut pairs = pairs_of(&pairs_path);
+    // The pairs are nodes of whatever instance they were drawn on, and this
+    // one has been renumbered, so they name different nodes until they are put
+    // through the numbering that renumber wrote. Without it every pair is a
+    // different pair and the rank beside it belongs to somebody else.
+    match std::env::var("TOOLBOX_ORDERING") {
+        Ok(path) => {
+            let ordering: NodeOrdering = io::read_from_file(&path);
+            for pair in &mut pairs {
+                pair.0 = ordering.new_of(pair.0);
+                pair.1 = ordering.new_of(pair.1);
+            }
+            println!("{} pairs put through the numbering in {path}", pairs.len());
+        }
+        Err(_) => println!(
+            "{} pairs taken as nodes of this instance; set TOOLBOX_ORDERING if they are not",
+            pairs.len()
+        ),
+    }
     println!("{} pairs, {} levels", pairs.len(), tree.levels());
 
     let in_memory = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
     let path = Path::new(&blocks_path);
+    // Everything is customized before anything is timed, whether or not the
+    // store has to be written. The customization works a cell out the first
+    // time it is wanted, so an instance that is not warmed does that work
+    // inside the timed loop and is measured doing it rather than querying --
+    // which is a server that has been running for a while against a device,
+    // and not the comparison anybody wants.
+    let started = Instant::now();
+    for level in 0..tree.levels() {
+        for cell in 0..tree.cells_on_level(level) {
+            let _ = in_memory.distances_of(level, cell as CellId);
+        }
+    }
+    println!(
+        "customized {} cells in memory in {:.1?}",
+        in_memory.customized_cells(),
+        started.elapsed()
+    );
+
     if !path.exists() {
         let started = Instant::now();
-        // everything is customized before anything is written
-        for level in 0..tree.levels() {
-            for cell in 0..tree.cells_on_level(level) {
-                let _ = in_memory.distances_of(level, cell as CellId);
-            }
-        }
         // how large a block is cut, in kibibytes of raw entries
         let target = std::env::var("TOOLBOX_BLOCK_KIB")
             .ok()
@@ -233,19 +268,59 @@ fn main() {
 
         let mut over_file = MldQuery::new();
         let mut over_memory = MldQuery::new();
+        // Both are warmed before either is timed. The customization works a
+        // cell out the first time it is wanted, so an unwarmed first query
+        // pays for forty-three thousand cells; the store reads its first
+        // blocks. Neither is what either engine costs once it is running.
+        let warmup = pairs.len().min(500);
+        for &(source, target, _) in pairs.iter().take(warmup) {
+            over_file.clear();
+            over_file.run(&paged, source, &[target]);
+            over_memory.clear();
+            over_memory.run(&in_memory, source, &[target]);
+        }
+
         let mut took = Vec::with_capacity(pairs.len());
         let mut wrong = 0_u64;
         let before = paged.faults();
-        for &(source, target) in &pairs {
+        // both engines timed over the same pairs, in the shape rank_plot wants
+        let mut timings = String::new();
+        for &(source, target, rank) in &pairs {
             over_file.clear();
             let started = Instant::now();
             over_file.run(&paged, source, &[target]);
-            took.push(started.elapsed().as_nanos() as u64);
+            let paged_nanos = started.elapsed().as_nanos();
+            took.push(paged_nanos as u64);
+
             over_memory.clear();
+            let started = Instant::now();
             over_memory.run(&in_memory, source, &[target]);
-            if over_file.distance(target) != over_memory.distance(target) {
+            let memory_nanos = started.elapsed().as_nanos();
+
+            let (from_file, from_memory) =
+                (over_file.distance(target), over_memory.distance(target));
+            if from_file != from_memory {
                 wrong += 1;
             }
+            if writing.is_some() {
+                use std::fmt::Write;
+                let _ = writeln!(
+                    timings,
+                    "mld,{source},{target},{rank},{memory_nanos},{from_memory}"
+                );
+                let _ = writeln!(
+                    timings,
+                    "paged,{source},{target},{rank},{paged_nanos},{from_file}"
+                );
+            }
+        }
+        if let Some(path) = &writing {
+            use std::io::Write;
+            let name = format!("{path}.{}mib.csv", bytes / MIB);
+            let mut out = File::create(&name).expect("somewhere to write the timings");
+            writeln!(out, "engine,source,target,rank,nanos,distance").expect("a header");
+            out.write_all(timings.as_bytes()).expect("the timings");
+            println!("  wrote {name}");
         }
         took.sort_unstable();
         let faults = paged.faults();

--- a/scripts/budget_plot.R
+++ b/scripts/budget_plot.R
@@ -1,0 +1,179 @@
+#!/usr/bin/env Rscript
+#
+# Draws what the offline store costs against the memory it is given.
+#
+#   Rscript scripts/budget_plot.R budgets.csv budgets.pdf
+#
+# The input is what the paged_query example writes with TOOLBOX_SUMMARY, one
+# row a budget:
+#
+#   budget,share,pinned_from,pinned,cache,mld_median,offline_median,p95,slowdown,reads,hits
+#
+# Three panels on a shared budget axis, because one number does not say it.
+# (a) is the median query, (b) the ninety-fifth, and the two are four decades
+# apart at the small budgets, so they get a panel each rather than one axis on
+# which neither can be read. (c) is how many blocks a query had to read, which
+# is what the two above are made of.
+#
+# Each query panel carries the time on the left and the multiple of the
+# in-memory query on the right, so the plot can be read either as a latency or
+# as a cost, and the in-memory query itself is the dashed line across it.
+#
+# The output is vector where the name ends in .pdf, since that is what a paper
+# wants, and a raster otherwise.
+#
+# Base graphics only, as with the plots beside it.
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1) {
+  stop("usage: budget_plot.R <budgets.csv> [out.pdf|out.png]")
+}
+input <- args[1]
+output <- if (length(args) >= 2) args[2] else "budgets.pdf"
+
+runs <- read.csv(input, stringsAsFactors = FALSE)
+for (column in c("budget", "mld_median", "offline_median", "p95", "reads")) {
+  if (!column %in% names(runs)) {
+    stop(sprintf("%s has no %s column", input, column))
+  }
+}
+runs <- runs[order(runs$budget), ]
+room <- log2(runs$budget)
+
+# the in-memory query the multiples are taken against; it is measured again at
+# every budget and barely moves, so one number stands for all of them
+reference <- mean(runs$mld_median)
+drift <- max(abs(runs$mld_median - reference)) / reference
+
+# times in whatever unit keeps them short, since a paper reads µs at one end of
+# this and seconds at the other
+in_time <- function(micros) {
+  ifelse(micros < 1000, sprintf("%gµs", signif(micros, 3)),
+    ifelse(micros < 1e6, sprintf("%gms", signif(micros / 1000, 3)),
+      sprintf("%gs", signif(micros / 1e6, 3))
+    )
+  )
+}
+# the 1-2-5 decades a reader takes a number off
+times_over <- function(values) {
+  decades <- 10^(floor(log10(min(values))):ceiling(log10(max(values))))
+  ticks <- sort(as.vector(outer(c(1, 2, 5), decades)))
+  ticks <- ticks[ticks >= min(values) * 0.85 & ticks <= max(values) * 1.15]
+  while (length(ticks) > 9) ticks <- ticks[seq(1, length(ticks), by = 2)]
+  ticks
+}
+as_multiple <- function(values) {
+  paste0(formatC(values, format = "fg", big.mark = ",", drop0trailing = TRUE), "×")
+}
+# the multiples a reader looks for, kept to the span the panel covers
+ratios_over <- function(span) {
+  decades <- log10(span[2] / span[1])
+  wanted <- if (decades > 2) {
+    # a wide span reads as a regular sequence and not as whatever round numbers
+    # happen to survive being thinned
+    sort(as.vector(outer(c(1, 3), 10^(-1:5))))
+  } else {
+    c(1, 1.25, 1.5, 2, 3, 4, 5, 7.5, 10, 15, 20, 30, 50, 75, 100)
+  }
+  ticks <- wanted[wanted >= span[1] * 0.99 & wanted <= span[2] * 1.01]
+  while (length(ticks) > 8) ticks <- ticks[seq(1, length(ticks), by = 2)]
+  ticks
+}
+
+# the budgets crowd where they are close together, so they go on two rows
+budget_axis <- function(labelled) {
+  odd <- seq(1, length(room), by = 2)
+  even <- seq(2, length(room), by = 2)
+  axis(1, at = room, labels = FALSE, lwd = 0, lwd.ticks = 1)
+  if (labelled) {
+    axis(1, at = room[odd], labels = sprintf("%g", runs$budget[odd]),
+         tick = FALSE, line = -0.5, cex.axis = 1)
+    axis(1, at = room[even], labels = sprintf("%g", runs$budget[even]),
+         tick = FALSE, line = 0.2, cex.axis = 1)
+  }
+}
+
+# one panel of query time, with the time on the left and the cost on the right
+time_panel <- function(values, colour, label, corner) {
+  ticks <- times_over(c(values, reference))
+  span <- range(c(ticks, values, reference)) * c(0.88, 1.35)
+  plot(NA,
+    xlim = range(room) + c(-0.4, 0.4), ylim = span,
+    log = "y", xaxt = "n", yaxt = "n", xlab = "", ylab = "", bty = "l"
+  )
+  abline(h = ticks, col = "#00000012", lwd = 1)
+  budget_axis(FALSE)
+  axis(2, at = ticks, labels = in_time(ticks), cex.axis = 1)
+  mtext(label, side = 2, line = 3.6, las = 0, cex = 0.78)
+  # the same panel read as a cost rather than a latency
+  right <- ratios_over(span / reference)
+  axis(4, at = right * reference, labels = as_multiple(right), cex.axis = 1)
+  # far enough out to clear the widest of the tick labels beside it
+  mtext("relative to in memory", side = 4,
+        line = 1.4 + 0.55 * max(nchar(as_multiple(right))), las = 0, cex = 0.78)
+  # the query this is all being compared against
+  abline(h = reference, lty = 2, lwd = 1.6, col = "#606060")
+  text(max(room) + 0.4, reference, adj = c(1, -0.5), cex = 0.85, col = "#606060",
+       labels = sprintf("in memory, %s", in_time(reference)))
+  # where the store begins holding whole levels rather than caching blocks
+  if ("pinned" %in% names(runs) && any(runs$pinned > 0)) {
+    abline(v = log2(min(runs$budget[runs$pinned > 0])), lty = 3, lwd = 1.6,
+           col = "#2f8f52")
+  }
+  lines(room, values, type = "b", pch = 19, lwd = 3.2, cex = 1.15, col = colour)
+  mtext(corner, side = 3, line = 0.2, at = min(room) - 0.4, adj = 0, cex = 0.85,
+        font = 2)
+}
+
+vector_out <- grepl("\\.pdf$", output, ignore.case = TRUE)
+if (vector_out) {
+  pdf(output, width = 7.2, height = 8.4, pointsize = 10)
+} else {
+  png(output, width = 7.2, height = 8.4, units = "in", res = 300, pointsize = 10)
+}
+layout(matrix(c(1, 2, 3), nrow = 3), heights = c(1, 1, 0.95))
+par(mar = c(1.6, 5.2, 1.8, 6.2), mgp = c(3, 0.7, 0), las = 1, lwd = 1.1)
+
+time_panel(runs$offline_median, "#20449c", "median query time", "(a)")
+if ("pinned" %in% names(runs) && any(runs$pinned > 0)) {
+  held <- min(runs$budget[runs$pinned > 0])
+  text(log2(held), 10^par("usr")[4], adj = c(1.06, 1.7), cex = 0.85,
+       col = "#2f8f52",
+       labels = sprintf("levels held outright from %g MiB", held))
+}
+
+par(mar = c(1.6, 5.2, 1.8, 6.2))
+time_panel(runs$p95, "#a83a20", "95th percentile query time", "(b)")
+
+# and what both are made of
+par(mar = c(4.4, 5.2, 1.8, 6.2))
+seen <- pmax(runs$reads, 0.05)
+counts <- c(0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200)
+counts <- counts[counts >= min(seen) * 0.8 & counts <= max(seen) * 1.3]
+plot(NA,
+  xlim = range(room) + c(-0.4, 0.4), ylim = range(c(seen, counts)) * c(0.8, 1.3),
+  log = "y", xaxt = "n", yaxt = "n", xlab = "", ylab = "", bty = "l"
+)
+abline(h = counts, col = "#00000012", lwd = 1)
+if ("pinned" %in% names(runs) && any(runs$pinned > 0)) {
+  abline(v = log2(min(runs$budget[runs$pinned > 0])), lty = 3, lwd = 1.6,
+         col = "#2f8f52")
+}
+lines(room, seen, type = "b", pch = 19, lwd = 3.2, cex = 1.15, col = "#6f3a9c")
+budget_axis(TRUE)
+axis(2, at = counts, labels = sprintf("%g", counts), cex.axis = 1)
+mtext("blocks read per query", side = 2, line = 3.6, las = 0, cex = 0.78)
+mtext("(c)", side = 3, line = 0.2, at = min(room) - 0.4, adj = 0, cex = 0.85,
+      font = 2)
+mtext("memory for the cell tables (MiB)", side = 1, line = 2.9, cex = 0.82)
+
+invisible(dev.off())
+slow <- runs$offline_median / reference
+cat(sprintf(
+  "wrote %s: %d budgets, %g to %g MiB, %.2fx down to %.2fx at the median\n",
+  output, nrow(runs), min(runs$budget), max(runs$budget), max(slow), min(slow)
+))
+cat(sprintf(
+  "in memory %.1fus, and no budget measured it more than %.1f%% off that\n",
+  reference, 100 * drift
+))

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -59,6 +59,25 @@ decades_over <- function(values) {
   values <- values[is.finite(values) & values > 0]
   10^(floor(log10(min(values))):ceiling(log10(max(values))))
 }
+
+# The lower panel is a ratio, and a ratio worth reading is usually within a
+# factor of a few, where decades give one tick and say nothing. These are the
+# multiples a reader looks for, kept to the ones the data reaches, and one is
+# always among them because one is where the two engines cost the same.
+ratios_over <- function(values) {
+  values <- values[is.finite(values) & values > 0]
+  wanted <- c(
+    0.1, 0.125, 0.15, 0.2, 0.25, 0.33, 0.5, 0.6, 0.7, 0.8, 0.9,
+    1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 20, 30, 50, 100
+  )
+  kept <- wanted[wanted >= min(values) * 0.98 & wanted <= max(values) * 1.02]
+  sort(unique(c(kept, 1)))
+}
+
+# 1.5 rather than 1.50, and with the sign a reader expects on a multiple
+as_multiple <- function(values) {
+  paste0(formatC(values, format = "fg", drop0trailing = TRUE), "\u00d7")
+}
 plainly <- function(values) formatC(values, format = "fg", drop0trailing = TRUE)
 
 # a bucket holding a handful of samples is drawn like the rest and marked, so
@@ -128,16 +147,23 @@ if (denominator %in% engines && length(engines) > 1) {
   ratios <- sapply(against, function(engine) medians[, engine] / medians[, denominator])
   ratios <- matrix(ratios, nrow = length(exponents), dimnames = list(NULL, against))
   ylim <- range(c(ratios, 1), na.rm = TRUE)
+  # named after the one engine being divided, where there is only one, so the
+  # axis says what is being read rather than "other"
+  measured <- if (length(against) == 1) name_of(against) else "other"
   plot(NA,
     xlim = range(exponents), ylim = ylim, log = "y", xaxt = "n", yaxt = "n",
-    xlab = "Dijkstra rank", ylab = sprintf("other / %s", name_of(denominator))
+    xlab = "Dijkstra rank",
+    ylab = sprintf("%s / %s", measured, name_of(denominator))
   )
+  axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+  ticks <- ratios_over(c(ratios, 1))
+  axis(2, at = ticks, labels = as_multiple(ticks))
+  # a line at each tick, so a point can be read across to the axis rather than
+  # guessed at between two decades
+  abline(h = ticks, col = "#00000014")
   for (engine in against) {
     lines(exponents, ratios[, engine], type = "b", pch = 19, col = colour_of[engine])
   }
-  axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
-  ticks <- decades_over(c(ratios, 1))
-  axis(2, at = ticks, labels = plainly(ticks))
   # at one the two cost the same; below it the cells are not paying for
   # themselves, and it should climb as more of them can be stepped over. A
   # curve that does not climb is the thing to look for: every level is sound to
@@ -148,9 +174,11 @@ if (denominator %in% engines && length(engines) > 1) {
   # it, so that nothing is written over the curves. They start low on the left
   # and end high on the right, so the top left corner is the empty one — the
   # bottom right has the line at one running through it.
+  # the largest the ratio gets and where, which is the best of a speedup and
+  # the worst of a slowdown; either way it is the number to look at
   best_of <- sapply(against, function(engine) {
     best <- which.max(ratios[, engine])
-    sprintf("%s / %s (best %.0fx at 2^%d)", name_of(engine), name_of(denominator),
+    sprintf("%s / %s (up to %.2f\u00d7 at 2^%d)", name_of(engine), name_of(denominator),
             ratios[best, engine], exponents[best])
   })
   legend("topleft", legend = best_of, col = colour_of[against],

--- a/src/block_store.rs
+++ b/src/block_store.rs
@@ -193,6 +193,61 @@ impl BlockStore {
         &self.tree
     }
 
+    /// A whole cell: its table, and which node each place of it is.
+    ///
+    /// The nodes are worked out rather than read. A place is an offset into
+    /// the cell's run of numbers, which the tree says where to find, and on
+    /// the finest level the border nodes are the front of the run so the
+    /// offsets are nought upward and are not stored at all.
+    ///
+    /// # Errors
+    ///
+    /// [`NotRead::NotHere`] where no block holds the cell.
+    pub fn cell_into(
+        &self,
+        level: usize,
+        cell: CellId,
+        table: &mut Vec<u32>,
+        nodes: &mut Vec<u32>,
+    ) -> Result<(), NotRead> {
+        let entry = *self.map.holding_cell(level, cell).ok_or(NotRead::NotHere)?;
+        let block = self.block_at(&entry)?;
+        let widths = self.widths_of(&entry, level);
+        let which = (cell - entry.first_cell) as usize;
+        block.unpack_into(which, &widths, table);
+
+        let begins = self.tree.nodes_begin(level, cell);
+        block.places_into(which, &widths, nodes);
+        if nodes.is_empty() {
+            // the border nodes lead the run, so the places are nought upward
+            nodes.extend((0..widths[which] as u32).map(|at| begins + at));
+        } else {
+            for node in nodes.iter_mut() {
+                *node += begins;
+            }
+        }
+        Ok(())
+    }
+
+    /// Reads and decodes the block an entry names.
+    fn block_at(&self, entry: &crate::block_map::BlockEntry) -> Result<CellBlock, NotRead> {
+        let codec = Codec::of(entry.codec).map_err(|why| NotRead::UnknownCodec(why.0))?;
+        let mut stored = vec![0_u8; entry.stored as usize];
+        read_at(&self.blocks, entry.at, &mut stored)?;
+        let bytes = codec
+            .decode(&stored, entry.unpacked as usize)
+            .map_err(NotRead::Corrupt)?;
+        rkyv::from_bytes::<CellBlock, rkyv::rancor::Error>(&bytes)
+            .map_err(|why| NotRead::Corrupt(why.to_string()))
+    }
+
+    /// How wide each table of a block is, which the tree knows.
+    fn widths_of(&self, entry: &crate::block_map::BlockEntry, level: usize) -> Vec<usize> {
+        (0..entry.cells)
+            .map(|at| self.tree.facts(level, entry.first_cell + at).on_border as usize)
+            .collect()
+    }
+
     /// The distances across one cell, read out of whichever block holds it.
     ///
     /// Into a buffer the caller keeps, since a search asks for one cell after
@@ -209,21 +264,8 @@ impl BlockStore {
         out: &mut Vec<u32>,
     ) -> Result<(), NotRead> {
         let entry = *self.map.holding_cell(level, cell).ok_or(NotRead::NotHere)?;
-        let codec = Codec::of(entry.codec).map_err(|why| NotRead::UnknownCodec(why.0))?;
-
-        let mut stored = vec![0_u8; entry.stored as usize];
-        read_at(&self.blocks, entry.at, &mut stored)?;
-        let bytes = codec
-            .decode(&stored, entry.unpacked as usize)
-            .map_err(NotRead::Corrupt)?;
-        let block = rkyv::from_bytes::<CellBlock, rkyv::rancor::Error>(&bytes)
-            .map_err(|why| NotRead::Corrupt(why.to_string()))?;
-
-        // how wide each table of the block is, which the tree knows and the
-        // block does not carry
-        let widths = (0..entry.cells)
-            .map(|at| self.tree.facts(level, entry.first_cell + at).on_border as usize)
-            .collect::<Vec<_>>();
+        let block = self.block_at(&entry)?;
+        let widths = self.widths_of(&entry, level);
         block.unpack_into((cell - entry.first_cell) as usize, &widths, out);
         Ok(())
     }

--- a/src/block_store.rs
+++ b/src/block_store.rs
@@ -229,8 +229,19 @@ impl BlockStore {
         Ok(())
     }
 
+    /// The entry naming the block a cell is in, and nothing where no block
+    /// holds it.
+    #[must_use]
+    pub fn entry_of(&self, level: usize, cell: CellId) -> Option<BlockEntry> {
+        self.map.holding_cell(level, cell).copied()
+    }
+
     /// Reads and decodes the block an entry names.
-    fn block_at(&self, entry: &crate::block_map::BlockEntry) -> Result<CellBlock, NotRead> {
+    ///
+    /// # Errors
+    ///
+    /// What the codec or the file said.
+    pub fn block_at(&self, entry: &crate::block_map::BlockEntry) -> Result<CellBlock, NotRead> {
         let codec = Codec::of(entry.codec).map_err(|why| NotRead::UnknownCodec(why.0))?;
         let mut stored = vec![0_u8; entry.stored as usize];
         read_at(&self.blocks, entry.at, &mut stored)?;
@@ -242,7 +253,8 @@ impl BlockStore {
     }
 
     /// How wide each table of a block is, which the tree knows.
-    fn widths_of(&self, entry: &crate::block_map::BlockEntry, level: usize) -> Vec<usize> {
+    #[must_use]
+    pub fn widths_of(&self, entry: &BlockEntry, level: usize) -> Vec<usize> {
         (0..entry.cells)
             .map(|at| self.tree.facts(level, entry.first_cell + at).on_border as usize)
             .collect()

--- a/src/cell_block.rs
+++ b/src/cell_block.rs
@@ -106,11 +106,20 @@ impl CellBlock {
                 cell.wide * cell.wide,
                 "a table is square"
             );
-            assert_eq!(
-                cell.places.is_empty(),
-                border_leads,
-                "a cell says one thing about its border and the block another"
-            );
+            // one place per border node, and none at all where the border
+            // nodes lead the run or where the cell has no border to speak of
+            if border_leads {
+                assert!(
+                    cell.places.is_empty(),
+                    "a block whose border nodes lead was given places anyway"
+                );
+            } else {
+                assert_eq!(
+                    cell.places.len(),
+                    cell.wide,
+                    "a place is wanted for each border node"
+                );
+            }
             let widest = cell
                 .matrix
                 .iter()

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -117,6 +117,14 @@ pub struct CellTree {
     /// per level, the box each of its cells lies in, and an invalid box for a
     /// cell holding no node with a coordinate
     bounds: Vec<Vec<BoundingBox>>,
+    /// Per level, where each cell's nodes begin, with one past the end last.
+    ///
+    /// The running total of what the cells hold, which is where their nodes
+    /// begin only when the nodes are numbered by cell path: then a cell is one
+    /// run and the runs follow one another in the order the cells are in. Under
+    /// any other numbering these are counts and nothing more, which is why
+    /// [`nodes_begin`](Self::nodes_begin) says what it assumes.
+    begins_node: Vec<Vec<u32>>,
 }
 
 impl CellTree {
@@ -240,8 +248,24 @@ impl CellTree {
             parents.push(above_of.to_vec());
         }
 
+        // where each cell's nodes begin, as a running total of what they hold
+        let begins_node = facts
+            .iter()
+            .map(|holding| {
+                let mut begins = Vec::with_capacity(holding.len() + 1);
+                let mut at = 0_u32;
+                begins.push(0);
+                for cell in holding {
+                    at += cell.nodes;
+                    begins.push(at);
+                }
+                begins
+            })
+            .collect();
+
         Self {
             version: VERSION,
+            begins_node,
             begins_at: partition.level_layout().to_vec(),
             starts,
             children,
@@ -297,6 +321,21 @@ impl CellTree {
         let from = starts[cell as usize] as usize;
         let to = starts[cell as usize + 1] as usize;
         &held[from..to]
+    }
+
+    /// Where a cell's nodes begin.
+    ///
+    /// True only of an instance numbered by cell path, where a cell is one run
+    /// of numbers and the runs follow the cells. Under any other numbering the
+    /// cell holds the same nodes but they are not this run, and a caller that
+    /// asks anyway will be told about nodes belonging to somebody else.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no such cell on that level.
+    #[must_use]
+    pub fn nodes_begin(&self, level: usize, cell: CellId) -> u32 {
+        self.begins_node[level][cell as usize]
     }
 
     /// The key of a cell: the path from the root down to it.

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -323,6 +323,24 @@ impl CellTree {
         &held[from..to]
     }
 
+    /// What a level's tables come to once read off a file and unpacked.
+    ///
+    /// A table is held as the entries, the same entries transposed for a
+    /// search running backwards, and the node each place of it is. That is
+    /// eight bytes an entry rather than the four a packed one takes, which is
+    /// the price of being read rather than searched: a store that pages is
+    /// bounded by what it holds unpacked, not by what it downloaded.
+    #[must_use]
+    pub fn unpacked_bytes(&self, level: usize) -> u64 {
+        self.facts[level]
+            .iter()
+            .map(|cell| {
+                let wide = u64::from(cell.on_border);
+                wide * wide * 8 + wide * 4
+            })
+            .sum()
+    }
+
     /// Where a cell's nodes begin.
     ///
     /// True only of an instance numbered by cell path, where a cell is one run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod one_to_many_dijkstra;
 pub mod overlay;
 pub mod packed_distances;
 pub mod packed_partition;
+pub mod paged_overlay;
 pub mod partition_id;
 pub mod path_based_scc;
 pub mod path_unpacking;

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -30,9 +30,17 @@
 use rayon::prelude::*;
 use std::sync::{Arc, Mutex};
 
+/// How many blocks are kept in hand while their cells are unpacked.
+///
+/// A block is wanted only while the cells around it are being read; a few is
+/// enough to keep a search walking cells side by side from reading the same
+/// block twice, and more would be room better given to the tables.
+const BLOCKS_IN_HAND: usize = 8;
+
 use crate::{
     block_store::{BlockStore, NotRead},
     border_levels::BorderLevels,
+    cell_block::CellBlock,
     cell_tree::CellTree,
     graph::NodeID,
     level_directory::CellId,
@@ -98,6 +106,10 @@ pub struct Faults {
     pub misses: u64,
     /// tables thrown away to make room
     pub evicted: u64,
+    /// blocks read off the file, which is what a fault really costs
+    pub reads: u64,
+    /// tables unpacked out of a block already in hand
+    pub unpacked: u64,
     /// what is held now, in bytes
     pub held: usize,
 }
@@ -186,6 +198,17 @@ pub struct PagedOverlay {
 struct Kept {
     tables: LRU<(u8, CellId), Arc<HeldTable>>,
     bytes: usize,
+    /// The blocks a table was last unpacked out of.
+    ///
+    /// A read is of a block and a table is of a cell, and a block holds many
+    /// cells. Without this, two cells of one block are two reads of that block
+    /// and two passes of the codec over it, which for a search walking cells
+    /// side by side is nearly every read it makes.
+    ///
+    /// Held apart from the tables and given a fixed few, since a block is
+    /// wanted only while the cells around it are being unpacked and a table is
+    /// wanted for as long as the search keeps coming back to it.
+    blocks: LRU<(u8, CellId), Arc<CellBlock>>,
     faults: Faults,
 }
 
@@ -211,6 +234,7 @@ impl PagedOverlay {
             kept: Mutex::new(Kept {
                 tables: LRU::new_with_capacity(1 << 16),
                 bytes: 0,
+                blocks: LRU::new_with_capacity(BLOCKS_IN_HAND),
                 faults: Faults::default(),
             }),
             budget,
@@ -354,9 +378,49 @@ impl PagedOverlay {
     /// A fault is a disk read and a pass of a codec, and holding the cache
     /// through it would stop every other thread.
     fn read(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead> {
+        let entry = self.store.entry_of(level, cell).ok_or(NotRead::NotHere)?;
+        let key = (
+            u8::try_from(level).map_err(|_| NotRead::NotHere)?,
+            entry.first_cell,
+        );
+
+        // the block this cell is in, off the file or out of the few in hand
+        let block = {
+            let mut kept = self.kept.lock().expect("the cache is poisoned");
+            kept.blocks.get(&key).cloned()
+        };
+        let block = match block {
+            Some(block) => {
+                self.kept
+                    .lock()
+                    .expect("the cache is poisoned")
+                    .faults
+                    .unpacked += 1;
+                block
+            }
+            None => {
+                let read = Arc::new(self.store.block_at(&entry)?);
+                let mut kept = self.kept.lock().expect("the cache is poisoned");
+                kept.faults.reads += 1;
+                kept.blocks.push(&key, read.clone());
+                read
+            }
+        };
+
+        let widths = self.store.widths_of(&entry, level);
+        let which = (cell - entry.first_cell) as usize;
         let mut matrix = Vec::new();
         let mut nodes = Vec::new();
-        self.store.cell_into(level, cell, &mut matrix, &mut nodes)?;
+        block.unpack_into(which, &widths, &mut matrix);
+        block.places_into(which, &widths, &mut nodes);
+        let begins = self.store.tree().nodes_begin(level, cell);
+        if nodes.is_empty() {
+            nodes.extend((0..widths[which] as u32).map(|at| begins + at));
+        } else {
+            for node in &mut nodes {
+                *node += begins;
+            }
+        }
         let wide = nodes.len();
         let mut transposed = vec![u32::MAX; matrix.len()];
         for source in 0..wide {

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -1,0 +1,481 @@
+//! The cells of a partition read off a file as a search asks for them.
+//!
+//! # The same search, the other way round
+//!
+//! [`Customization`](crate::customization::Customization) works a cell out the
+//! first time it is wanted and keeps it. This reads one off a disk the first
+//! time it is wanted and keeps it until the room runs out. Both are
+//! [`Overlay`], so the same search runs over either and cannot tell which it
+//! has: what differs is where a table comes from and how long it stays.
+//!
+//! # Why a table is counted and not lent
+//!
+//! A customization lends a table out, nothing being able to move underneath
+//! it. Here the room is bounded, so a table a search is reading is a table the
+//! cache would otherwise be free to throw away to make room for the next one.
+//! So a table is counted rather than lent: what comes back holds the table
+//! open, and the cache cannot drop it until the search has done with it.
+//!
+//! That also means two tables may be held at once without the cache being
+//! borrowed twice, which a search that walks two cells in one step needs.
+//!
+//! # What is held in bytes
+//!
+//! The cache is bounded by what the tables come to unpacked, not by how many
+//! there are. A table of the finest level is a few hundred bytes and one of
+//! the coarsest is most of a megabyte, so counting tables would mean a budget
+//! that meant nothing: the same number of them is two megabytes or six hundred
+//! depending on which ones a search happened to want.
+
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    block_store::{BlockStore, NotRead},
+    border_levels::BorderLevels,
+    graph::NodeID,
+    level_directory::CellId,
+    lru::LRU,
+    overlay::{CellTable, Overlay},
+    packed_partition::PackedPartition,
+    static_graph::StaticGraph,
+};
+
+/// One cell's table, as it is once read off the file.
+#[derive(Debug)]
+pub struct HeldTable {
+    /// the table, row by row
+    matrix: Vec<u32>,
+    /// the transpose, for a search running backwards
+    transposed: Vec<u32>,
+    /// which node each place of the table is
+    nodes: Vec<u32>,
+}
+
+impl HeldTable {
+    /// What it takes up, which is what the budget counts.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>()
+            + (self.matrix.capacity() + self.transposed.capacity() + self.nodes.capacity()) * 4
+    }
+}
+
+impl CellTable for Arc<HeldTable> {
+    #[inline]
+    fn border_nodes(&self) -> &[u32] {
+        &self.nodes
+    }
+
+    #[inline]
+    fn row(&self, source: usize) -> &[u32] {
+        let wide = self.nodes.len();
+        &self.matrix[source * wide..(source + 1) * wide]
+    }
+
+    #[inline]
+    fn column(&self, target: usize) -> &[u32] {
+        let wide = self.nodes.len();
+        &self.transposed[target * wide..(target + 1) * wide]
+    }
+
+    #[inline]
+    fn place_of(&self, node: NodeID) -> Option<usize> {
+        // the border nodes of a cell come out in increasing order, so this is
+        // a search of a sorted run rather than a map to keep beside it
+        let node = u32::try_from(node).ok()?;
+        self.nodes.binary_search(&node).ok()
+    }
+}
+
+/// What a store has been asked for and what it cost.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Faults {
+    /// tables the cache already had
+    pub hits: u64,
+    /// tables that had to be read off the file
+    pub misses: u64,
+    /// tables thrown away to make room
+    pub evicted: u64,
+    /// what is held now, in bytes
+    pub held: usize,
+}
+
+/// The cells of a partition, read off a file and kept while there is room.
+pub struct PagedOverlay {
+    store: BlockStore,
+    graph: StaticGraph<u32>,
+    partition: PackedPartition,
+    borders: BorderLevels,
+    kept: Mutex<Kept>,
+    budget: usize,
+}
+
+struct Kept {
+    tables: LRU<(u8, CellId), Arc<HeldTable>>,
+    bytes: usize,
+    faults: Faults,
+}
+
+impl PagedOverlay {
+    /// Opens a store to read cells from, holding `budget` bytes of them.
+    #[must_use]
+    pub fn new(
+        store: BlockStore,
+        graph: StaticGraph<u32>,
+        partition: PackedPartition,
+        borders: BorderLevels,
+        budget: usize,
+    ) -> Self {
+        Self {
+            store,
+            graph,
+            partition,
+            borders,
+            // room for the entries, which the budget in bytes bounds; the
+            // count is only what the map is made large enough for
+            kept: Mutex::new(Kept {
+                tables: LRU::new_with_capacity(1 << 16),
+                bytes: 0,
+                faults: Faults::default(),
+            }),
+            budget,
+        }
+    }
+
+    /// What has been asked of it so far.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another thread failed while holding the cache.
+    #[must_use]
+    pub fn faults(&self) -> Faults {
+        let kept = self.kept.lock().expect("the cache is poisoned");
+        Faults {
+            held: kept.bytes,
+            ..kept.faults
+        }
+    }
+
+    /// Throws everything away, which a run that measures a cold store wants.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another thread failed while holding the cache.
+    pub fn forget(&self) {
+        let mut kept = self.kept.lock().expect("the cache is poisoned");
+        kept.tables.clear();
+        kept.bytes = 0;
+    }
+
+    /// Reads a cell off the file, or hands back the one already held.
+    ///
+    /// # Errors
+    ///
+    /// What the store said, [`NotRead::NotHere`] being a region nobody
+    /// downloaded rather than a fault.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another thread failed while holding the cache.
+    pub fn table_of(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead> {
+        let key = (u8::try_from(level).map_err(|_| NotRead::NotHere)?, cell);
+        {
+            let mut kept = self.kept.lock().expect("the cache is poisoned");
+            if let Some(held) = kept.tables.get(&key) {
+                let held = held.clone();
+                kept.faults.hits += 1;
+                return Ok(held);
+            }
+        }
+
+        // read outside the lock: a fault is a disk read and a pass of a codec,
+        // and holding the cache through it would stop every other thread
+        let mut matrix = Vec::new();
+        let mut nodes = Vec::new();
+        self.store.cell_into(level, cell, &mut matrix, &mut nodes)?;
+        let wide = nodes.len();
+        let mut transposed = vec![u32::MAX; matrix.len()];
+        for source in 0..wide {
+            for target in 0..wide {
+                transposed[target * wide + source] = matrix[source * wide + target];
+            }
+        }
+        let held = Arc::new(HeldTable {
+            matrix,
+            transposed,
+            nodes,
+        });
+
+        let mut kept = self.kept.lock().expect("the cache is poisoned");
+        kept.faults.misses += 1;
+        kept.bytes += held.bytes();
+        if let Some((_, was)) = kept.tables.push(&key, held.clone()) {
+            kept.bytes -= was.bytes();
+        }
+        // and then down to the budget, oldest first
+        while kept.bytes > self.budget && kept.tables.len() > 1 {
+            let Some((_, was)) = kept.tables.pop_lru() else {
+                break;
+            };
+            kept.bytes -= was.bytes();
+            kept.faults.evicted += 1;
+        }
+        Ok(held)
+    }
+}
+
+impl Overlay for PagedOverlay {
+    type Graph = StaticGraph<u32>;
+    type Table<'a>
+        = Arc<HeldTable>
+    where
+        Self: 'a;
+
+    fn graph(&self) -> &Self::Graph {
+        &self.graph
+    }
+
+    fn partition(&self) -> &PackedPartition {
+        &self.partition
+    }
+
+    fn border_levels(&self) -> &BorderLevels {
+        &self.borders
+    }
+
+    fn levels(&self) -> usize {
+        self.store.tree().levels()
+    }
+
+    fn cells_on_level(&self, level: usize) -> usize {
+        self.store.tree().cells_on_level(level)
+    }
+
+    fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>> {
+        // A cell nobody downloaded reads as a cell with no table, which is
+        // what a cell with no border node reads as too. A search then does not
+        // step over it, and answers with whatever it can reach otherwise.
+        self.table_of(level, cell).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        block_codec::Codec,
+        block_store::BlockWriter,
+        cell_block::{CellBlock, CellEntry},
+        cell_ordering::CellOrdering,
+        cell_tree::CellTree,
+        customization::Customization,
+        edge::InputEdge,
+        geometry::FPCoordinate,
+        grid_graph::grid_directory,
+        level_directory::LevelDirectory,
+        mld_query::MldQuery,
+        node_ordering::{NodeOrdering, Numbering},
+    };
+
+    fn grid_edges(side: usize) -> Vec<InputEdge<u32>> {
+        let mut edges = Vec::new();
+        for row in 0..side {
+            for column in 0..side {
+                let node = row * side + column;
+                let weight = (1 + (row * 7 + column * 3) % 9) as u32;
+                if column + 1 < side {
+                    edges.push(InputEdge::new(node, node + 1, weight));
+                    edges.push(InputEdge::new(node + 1, node, weight));
+                }
+                if row + 1 < side {
+                    edges.push(InputEdge::new(node, node + side, weight + 1));
+                    edges.push(InputEdge::new(node + side, node, weight + 1));
+                }
+            }
+        }
+        edges
+    }
+
+    /// The whole pipeline: cells into key order, nodes into cell-path order,
+    /// then the instance the store is built from.
+    fn laid_out(side: usize) -> (Vec<InputEdge<u32>>, LevelDirectory) {
+        let edges = grid_edges(side);
+        let directory = grid_directory(side);
+        let directory =
+            CellOrdering::of(&directory, &PackedPartition::of(&directory)).renumber(&directory);
+        let graph = StaticGraph::new(edges.clone());
+        let ordering = NodeOrdering::in_order(
+            &graph,
+            &PackedPartition::of(&directory),
+            Numbering::CellPath,
+        );
+        (
+            ordering.renumber(&edges),
+            ordering.renumber_directory(&directory),
+        )
+    }
+
+    /// Writes every cell of a customization into a store.
+    fn pack(
+        customization: &Customization,
+        tree: &CellTree,
+        path: &std::path::Path,
+        cells_a_block: usize,
+    ) -> crate::block_map::BlockMap {
+        let mut writer = BlockWriter::create(path).expect("a file to write");
+        for level in 0..tree.levels() {
+            let border_leads = level == 0;
+            let mut at = 0;
+            while at < tree.cells_on_level(level) {
+                let upto = (at + cells_a_block).min(tree.cells_on_level(level));
+                let mut matrices = Vec::new();
+                let mut widths = Vec::new();
+                let mut places = Vec::new();
+                let mut holds = Vec::new();
+                for cell in at..upto {
+                    let cell = cell as CellId;
+                    // The topmost cell holds the whole graph, so no arc leaves
+                    // it and it has no border and no table. It goes into the
+                    // block as a table of nothing rather than being left out,
+                    // so that a block stays a run of cells.
+                    let held = customization.distances_of(level, cell);
+                    let wide = held.map_or(0, |table| table.border_nodes_of().len());
+                    let mut matrix = Vec::with_capacity(wide * wide);
+                    if let Some(table) = held {
+                        for source in 0..wide {
+                            matrix.extend_from_slice(table.row(source));
+                        }
+                    }
+                    let begins = tree.nodes_begin(level, cell);
+                    places.push(if border_leads {
+                        Vec::new()
+                    } else {
+                        held.map_or_else(Vec::new, |table| {
+                            table
+                                .border_nodes_of()
+                                .iter()
+                                .map(|&node| node - begins)
+                                .collect()
+                        })
+                    });
+                    matrices.push(matrix);
+                    widths.push(wide);
+                    holds.push(tree.facts(level, cell).nodes as usize);
+                }
+                let entries = matrices
+                    .iter()
+                    .zip(&widths)
+                    .zip(&places)
+                    .zip(&holds)
+                    .map(|(((matrix, &wide), places), &holds)| CellEntry {
+                        matrix,
+                        wide,
+                        places,
+                        holds,
+                    })
+                    .collect::<Vec<_>>();
+                let block = CellBlock::of(level, at as CellId, &entries, border_leads);
+                let keys = (
+                    tree.range_of(level, at as CellId).0,
+                    tree.range_of(level, (upto - 1) as CellId).1,
+                );
+                let nodes = (
+                    tree.nodes_begin(level, at as CellId),
+                    tree.nodes_begin(level, (upto - 1) as CellId)
+                        + tree.facts(level, (upto - 1) as CellId).nodes
+                        - tree.nodes_begin(level, at as CellId),
+                );
+                writer
+                    .push(
+                        &block,
+                        keys,
+                        (at as CellId, (upto - at) as u32),
+                        nodes,
+                        if level == 0 { Codec::Lz4 } else { Codec::Zstd },
+                        3,
+                    )
+                    .expect("a block to write");
+                at = upto;
+            }
+        }
+        writer.finish().expect("a file to close")
+    }
+
+    /// The one that matters: the same search, unchanged, over the cells in
+    /// memory and over the same cells read off a file, answering the same.
+    #[test]
+    fn a_search_over_a_file_answers_what_a_search_over_memory_does() {
+        let side = 16;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        let in_memory = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
+
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("blocks");
+        let map = pack(&in_memory, &tree, &path, 3);
+        assert!(map.len() > 1, "the store is worth more than one block");
+
+        let store = BlockStore::open(&path, map, tree).expect("a store to open");
+        let paged = PagedOverlay::new(
+            store,
+            StaticGraph::new(edges.clone()),
+            PackedPartition::of(&directory),
+            BorderLevels::of(&graph, &partition),
+            // deliberately small, so that tables are thrown away and read again
+            8 * 1024,
+        );
+
+        let mut over_memory = MldQuery::new();
+        let mut over_file = MldQuery::new();
+        let mut pairs = 0;
+        for source in (0..side * side).step_by(5) {
+            for target in (0..side * side).step_by(7) {
+                over_memory.clear();
+                over_file.clear();
+                let reached = over_memory.run(&in_memory, source, &[target]);
+                assert_eq!(reached, over_file.run(&paged, source, &[target]));
+                assert_eq!(
+                    over_memory.distance(target),
+                    over_file.distance(target),
+                    "from {source} to {target}"
+                );
+                pairs += 1;
+            }
+        }
+
+        let faults = paged.faults();
+        assert!(pairs > 500, "the sweep is worth running");
+        assert!(faults.misses > 0, "nothing was ever read off the file");
+        assert!(faults.hits > 0, "nothing was ever found already held");
+        assert!(faults.evicted > 0, "the budget was never reached");
+    }
+
+    #[test]
+    fn a_store_with_nothing_in_it_answers_that_it_has_nothing() {
+        let side = 8;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("blocks");
+        let map = BlockWriter::create(&path)
+            .expect("a file")
+            .finish()
+            .expect("a file to close");
+        let store = BlockStore::open(&path, map, tree).expect("a store to open");
+        let paged = PagedOverlay::new(
+            store,
+            StaticGraph::new(edges),
+            PackedPartition::of(&directory),
+            BorderLevels::of(&graph, &partition),
+            1 << 20,
+        );
+        assert!(paged.distances_of(0, 0).is_none());
+    }
+}

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -27,11 +27,13 @@
 //! that meant nothing: the same number of them is two megabytes or six hundred
 //! depending on which ones a search happened to want.
 
+use rayon::prelude::*;
 use std::sync::{Arc, Mutex};
 
 use crate::{
     block_store::{BlockStore, NotRead},
     border_levels::BorderLevels,
+    cell_tree::CellTree,
     graph::NodeID,
     level_directory::CellId,
     lru::LRU,
@@ -100,6 +102,73 @@ pub struct Faults {
     pub held: usize,
 }
 
+/// How much room a store may use, and how much of it is never given back.
+///
+/// # Why some levels are held and not cached
+///
+/// The coarse levels are read by every query that goes any distance and there
+/// are few of them: on europe.ptv the top level is 18 MiB unpacked and the
+/// finest is 186. Left to a cache they would be read, thrown away and read
+/// again as the fine levels churned through the same room, and they are
+/// exactly the tables a long query cannot do without.
+///
+/// So the coarse levels are held outright, from the top down, for as many as
+/// fit the share asked for, and what is left of the budget is the cache. Held
+/// tables need no lock and cannot be evicted; the rest take their chances.
+///
+/// Whatever the pinned share does not use goes to the cache rather than being
+/// left idle: a share is a ceiling on what may be held, not a reservation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Budget {
+    /// what the tables may come to in all, in bytes
+    pub bytes: usize,
+    /// the most of it that may be held outright, as a share of the whole
+    pub pinned_share: f64,
+}
+
+impl Budget {
+    /// A budget with half of it available to hold levels outright.
+    #[must_use]
+    pub fn of(bytes: usize) -> Self {
+        Self {
+            bytes,
+            pinned_share: 0.5,
+        }
+    }
+
+    /// The lowest level worth holding outright, and the level count when none
+    /// is: levels from here up are held, levels below are cached.
+    #[must_use]
+    pub fn pin_from(&self, tree: &CellTree) -> usize {
+        let room = (self.bytes as f64 * self.pinned_share.clamp(0.0, 1.0)) as u64;
+        let mut taken = 0_u64;
+        let mut from = tree.levels();
+        for level in (0..tree.levels()).rev() {
+            let wants = tree.unpacked_bytes(level);
+            if taken + wants > room {
+                break;
+            }
+            taken += wants;
+            from = level;
+        }
+        from
+    }
+
+    /// What the held levels come to, and what is left for the cache.
+    #[must_use]
+    pub fn split(&self, tree: &CellTree) -> (u64, usize) {
+        let from = self.pin_from(tree);
+        let pinned = (from..tree.levels())
+            .map(|level| tree.unpacked_bytes(level))
+            .sum::<u64>();
+        (
+            pinned,
+            self.bytes
+                .saturating_sub(usize::try_from(pinned).unwrap_or(usize::MAX)),
+        )
+    }
+}
+
 /// The cells of a partition, read off a file and kept while there is room.
 pub struct PagedOverlay {
     store: BlockStore,
@@ -108,6 +177,10 @@ pub struct PagedOverlay {
     borders: BorderLevels,
     kept: Mutex<Kept>,
     budget: usize,
+    /// the lowest level held outright, and the level count when none is
+    pin_from: usize,
+    /// the held levels, from `pin_from` up, and nothing for a cell with no table
+    pinned: Vec<Vec<Option<Arc<HeldTable>>>>,
 }
 
 struct Kept {
@@ -133,6 +206,8 @@ impl PagedOverlay {
             borders,
             // room for the entries, which the budget in bytes bounds; the
             // count is only what the map is made large enough for
+            pin_from: usize::MAX,
+            pinned: Vec::new(),
             kept: Mutex::new(Kept {
                 tables: LRU::new_with_capacity(1 << 16),
                 bytes: 0,
@@ -140,6 +215,63 @@ impl PagedOverlay {
             }),
             budget,
         }
+    }
+
+    /// Opens a store and holds as many of the coarse levels as the budget
+    /// allows, leaving the rest of it to the cache.
+    ///
+    /// The held levels are read here rather than on the first query, which is
+    /// what a startup pays so that a first query does not.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a level that was to be held cannot be read: a store missing
+    /// what it says it holds is broken rather than sparse.
+    #[must_use]
+    pub fn within(
+        store: BlockStore,
+        graph: StaticGraph<u32>,
+        partition: PackedPartition,
+        borders: BorderLevels,
+        budget: Budget,
+    ) -> Self {
+        let pin_from = budget.pin_from(store.tree());
+        let (_, cache) = budget.split(store.tree());
+        let levels = store.tree().levels();
+
+        let mut held = Self::new(store, graph, partition, borders, cache);
+        held.pinned = (pin_from..levels)
+            .map(|level| {
+                (0..held.store.tree().cells_on_level(level) as CellId)
+                    .into_par_iter()
+                    .map(|cell| match held.read(level, cell) {
+                        Ok(table) => Some(table),
+                        // a cell with no border has no table
+                        Err(NotRead::NotHere) => None,
+                        Err(why) => panic!("a level that was to be held: {why}"),
+                    })
+                    .collect()
+            })
+            .collect();
+        held.pin_from = pin_from;
+        held
+    }
+
+    /// The lowest level held outright, and the level count when none is.
+    #[must_use]
+    pub fn pinned_from(&self) -> usize {
+        self.pin_from
+    }
+
+    /// What the held levels come to.
+    #[must_use]
+    pub fn pinned_bytes(&self) -> usize {
+        self.pinned
+            .iter()
+            .flatten()
+            .flatten()
+            .map(|table| table.bytes())
+            .sum()
     }
 
     /// What has been asked of it so far.
@@ -178,6 +310,16 @@ impl PagedOverlay {
     ///
     /// Panics if another thread failed while holding the cache.
     pub fn table_of(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead> {
+        // a held level needs no lock and cannot have been thrown away
+        if level >= self.pin_from
+            && let Some(held) = self.pinned.get(level - self.pin_from)
+        {
+            return held
+                .get(cell as usize)
+                .and_then(Clone::clone)
+                .ok_or(NotRead::NotHere);
+        }
+
         let key = (u8::try_from(level).map_err(|_| NotRead::NotHere)?, cell);
         {
             let mut kept = self.kept.lock().expect("the cache is poisoned");
@@ -188,23 +330,7 @@ impl PagedOverlay {
             }
         }
 
-        // read outside the lock: a fault is a disk read and a pass of a codec,
-        // and holding the cache through it would stop every other thread
-        let mut matrix = Vec::new();
-        let mut nodes = Vec::new();
-        self.store.cell_into(level, cell, &mut matrix, &mut nodes)?;
-        let wide = nodes.len();
-        let mut transposed = vec![u32::MAX; matrix.len()];
-        for source in 0..wide {
-            for target in 0..wide {
-                transposed[target * wide + source] = matrix[source * wide + target];
-            }
-        }
-        let held = Arc::new(HeldTable {
-            matrix,
-            transposed,
-            nodes,
-        });
+        let held = self.read(level, cell)?;
 
         let mut kept = self.kept.lock().expect("the cache is poisoned");
         kept.faults.misses += 1;
@@ -221,6 +347,28 @@ impl PagedOverlay {
             kept.faults.evicted += 1;
         }
         Ok(held)
+    }
+
+    /// Reads a cell off the file, holding nothing while it does.
+    ///
+    /// A fault is a disk read and a pass of a codec, and holding the cache
+    /// through it would stop every other thread.
+    fn read(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead> {
+        let mut matrix = Vec::new();
+        let mut nodes = Vec::new();
+        self.store.cell_into(level, cell, &mut matrix, &mut nodes)?;
+        let wide = nodes.len();
+        let mut transposed = vec![u32::MAX; matrix.len()];
+        for source in 0..wide {
+            for target in 0..wide {
+                transposed[target * wide + source] = matrix[source * wide + target];
+            }
+        }
+        Ok(Arc::new(HeldTable {
+            matrix,
+            transposed,
+            nodes,
+        }))
     }
 }
 
@@ -451,6 +599,123 @@ mod tests {
         assert!(faults.misses > 0, "nothing was ever read off the file");
         assert!(faults.hits > 0, "nothing was ever found already held");
         assert!(faults.evicted > 0, "the budget was never reached");
+    }
+
+    /// The coarse levels are held and the fine ones are not, and the search
+    /// answers the same either way.
+    #[test]
+    fn a_held_level_is_never_read_twice_and_answers_the_same() {
+        let side = 16;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        let in_memory = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
+
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("blocks");
+        let map = pack(&in_memory, &tree, &path, 3);
+
+        // room enough for the two coarsest levels and no more
+        let levels = tree.levels();
+        let wanted = tree.unpacked_bytes(levels - 1) + tree.unpacked_bytes(levels - 2);
+        let budget = Budget {
+            bytes: usize::try_from(wanted).expect("a budget of that size") * 2,
+            pinned_share: 0.5,
+        };
+        let pin_from = budget.pin_from(&tree);
+        assert_eq!(pin_from, levels - 2, "two levels were to be held");
+
+        let store = BlockStore::open(&path, map, tree).expect("a store to open");
+        let paged = PagedOverlay::within(
+            store,
+            StaticGraph::new(edges.clone()),
+            PackedPartition::of(&directory),
+            BorderLevels::of(&graph, &partition),
+            budget,
+        );
+        assert_eq!(paged.pinned_from(), pin_from);
+        assert!(paged.pinned_bytes() > 0, "nothing was held");
+
+        // whatever the search does now, a held level is never read again
+        let read_when_held = paged.faults().misses;
+        let mut over_memory = MldQuery::new();
+        let mut over_file = MldQuery::new();
+        for source in (0..side * side).step_by(5) {
+            for target in (0..side * side).step_by(7) {
+                over_memory.clear();
+                over_file.clear();
+                over_memory.run(&in_memory, source, &[target]);
+                over_file.run(&paged, source, &[target]);
+                assert_eq!(
+                    over_memory.distance(target),
+                    over_file.distance(target),
+                    "from {source} to {target}"
+                );
+            }
+        }
+        let faults = paged.faults();
+        assert!(
+            faults.misses > read_when_held,
+            "the levels that were not held were never read"
+        );
+        // every read of a held level would have been a miss, and there are none
+        for level in pin_from..levels {
+            for cell in 0..paged.cells_on_level(level) as CellId {
+                let before = paged.faults().misses;
+                let _ = paged.distances_of(level, cell);
+                assert_eq!(paged.faults().misses, before, "level {level} was read");
+            }
+        }
+    }
+
+    #[test]
+    fn a_budget_too_small_holds_only_what_costs_nothing() {
+        let side = 8;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        let budget = Budget {
+            bytes: 8,
+            pinned_share: 0.5,
+        };
+        // The topmost cell holds the whole graph, so no arc leaves it, so it
+        // has no table and costs nothing to hold. A level that costs nothing
+        // fits any budget, so what is asserted is that nothing which costs
+        // anything was held.
+        let from = budget.pin_from(&tree);
+        for level in from..tree.levels() {
+            assert_eq!(
+                tree.unpacked_bytes(level),
+                0,
+                "level {level} was held in eight bytes"
+            );
+        }
+        assert_eq!(budget.split(&tree).0, 0, "nothing with a cost was held");
+    }
+
+    /// What the pinned share does not use is the cache's, not nobody's.
+    #[test]
+    fn room_the_held_levels_do_not_want_goes_to_the_cache() {
+        let side = 8;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        let budget = Budget {
+            bytes: 1 << 20,
+            pinned_share: 0.5,
+        };
+        let (pinned, cache) = budget.split(&tree);
+        assert_eq!(
+            cache,
+            budget.bytes - usize::try_from(pinned).expect("a size"),
+            "the cache gets everything the held levels did not"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`src/paged_overlay.rs` adds a store that answers the `Overlay` trait off a file:

```rust
pub struct PagedOverlay { /* ... */ }
impl Overlay for PagedOverlay {
    type Table<'a> = Arc<HeldTable>;
}

impl PagedOverlay {
    pub fn new(store, graph, partition, border_levels, budget) -> Self
    pub fn within(store, graph, partition, border_levels, budget) -> Self
    pub fn table_of(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead>
    pub fn faults(&self) -> Faults
    pub fn forget(&self)
    pub fn pinned_from(&self) -> usize
    pub fn pinned_bytes(&self) -> usize
}

pub struct Budget { pub bytes: usize, pub pinned_share: f64 }
impl Budget {
    pub fn of(bytes: usize) -> Self
    pub fn pin_from(&self, tree: &CellTree) -> usize
    pub fn split(&self, tree: &CellTree) -> (u64, usize)
}

pub struct Faults { pub hits, misses, evicted, reads, unpacked, held: usize }
```

`Budget::pin_from` walks the levels from the coarsest down and returns the
first level whose tables no longer fit in `pinned_share` of the budget. Those
coarser levels are read and unpacked at open and never evicted; everything
below is cached. `split` reports what the two come to.

Two caches, one under the other: `Arc<HeldTable>` by cell, and `BLOCKS_IN_HAND
= 8` decoded `Arc<CellBlock>` beneath them, so a run of cells in one block
costs one read rather than one read a cell.

`src/block_store.rs` gains `widths_of`, and positional reads behind `cfg` --
`read_exact_at` on unix, `seek_read` on windows -- so a store is read without
a seek that another thread can move. `src/cell_tree.rs` gains the bounds a
budget needs to size a level.

`examples/paged_query.rs` runs the same `MldQuery` over the customization and
over the store, pair by pair, and checks the two agree. Environment:

  TOOLBOX_BLOCK_KIB     block size to pack at
  TOOLBOX_ORDERING      puts the pairs through the numbering the store was
                        built on; without it the ids name different nodes
  TOOLBOX_TIMINGS       per-pair rows for rank_plot, engines `mld` and `offline`
  TOOLBOX_SUMMARY       one CSV row a budget
  TOOLBOX_PIN_SHARE     overrides `Budget::pinned_share`
  TOOLBOX_PAIR_STRIDE   keeps every Nth pair, holding the rank spread

`scripts/budget_plot.R` draws a summary as three panels on a shared log2 budget
axis: median query time, 95th, and blocks read a query. Query panels carry the
time on the left and the multiple of the in-memory query on the right. Output
is pdf where the name ends in `.pdf`, otherwise a 300dpi raster.

`scripts/rank_plot.R` gains multiplier ticks and gridlines on the lower panel,
names its axis after the engine being divided, and calls the paged engine
`offline`.

`docs/disk-storage-results.md` records the measurements: 64 KiB blocks beat the
4 MiB the plan assumed by 9.2x; codecs are worth 9% after bit packing, so the
choice is latency and not size; 252.8 MiB of tables pack to 111.0 MiB of
entries and 107.8 MiB of lz4 blocks. Over 4,800 pairs of europe.ptv the store
answers every one as the customization does. The budget sweep from 1 to 256 MiB
is there with what it shows, including a measurement that was wrong and is
corrected in place.