### PR TITLE
Make path unpacking generic over the Overlay trait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,20 @@ The title follows the same rule as a commit subject: name the algorithm or
 the structure, not the effect. A pull request doing several things names the
 ones a reviewer would search for rather than reaching for the sum of them.
 
+Name the types, the traits and the algorithms, in the words the code uses. A
+reader scanning a list of merged pull requests should be able to tell what
+moved without opening any of them, and should be able to find this one again
+by searching for the thing it changed.
+
+The test is whether the title would still make sense to somebody who has never
+read the description. "Draw everything from one cache" fails it: there is no
+"everything" in the code and no reader can guess what a cache was drawn from.
+"Add Pool, one byte-budgeted LRU shared by every kind of block" passes, because
+`Pool` and LRU are searchable and the sentence says what was built.
+
+Metaphor is for the body, where there is room to say what it stands for. A
+title that reads well and identifies nothing is worse than a plain one.
+
 Otherwise the description carries the reasoning: what the change does, why,
 what it leaves for later, and which PR it is stacked on if any. Lead it with
 the change itself — the signatures, the fields, the behaviour — and put the

--- a/docs/disk-storage-results.md
+++ b/docs/disk-storage-results.md
@@ -218,6 +218,56 @@ same sweep over 120 pairs put the cliff at 128 MiB and reported 1.04× there,
 because a fifth of the queries have a fifth of the working set. A server
 answering a wider spread than 600 pairs should expect the cliff further right.
 
+## Putting the way back
+
+`path_unpacking` runs over the `Overlay` trait, so the same code puts a way
+back out of the customization in memory and out of the store on disk. Measured
+over the same 4,800 pairs of europe.ptv, 64 KiB blocks, a 128 MiB budget:
+
+| | median | 95th | mean |
+|---|--------|------|------|
+| query, in memory | 73.3µs | 5.85ms | 853µs |
+| query, offline | 165.6µs | 5.93ms | 957µs |
+| unpacking, in memory | 28.2µs | 1.67ms | 334µs |
+| unpacking, offline | 45.8µs | 2.56ms | 509µs |
+
+Query and unpacking together come to 118.5µs in memory and 241.9µs off the
+file, which is **2.04×**. Every one of the 4,800 ways came out the same on both
+engines and cost what the query said it would.
+
+Unpacking is the cheaper half. It costs about a third of the query at the
+median, because it is confined: a step across a cell is put back by a search
+inside that one cell, over the cells one level down, and never leaves it.
+
+### The cache does nothing for it
+
+Swept from 64 to 128 MiB over 1,200 pairs, the query improves steadily and
+unpacking does not move at all:
+
+| budget | query | unpacking | query reads | unpack reads |
+|--------|-------|-----------|-------------|--------------|
+| 64 MiB | 3.05× | 1.62× | 6.6 | 11.2 |
+| 72 MiB | 2.89× | 1.61× | 6.2 | 11.0 |
+| 80 MiB | 2.83× | 1.58× | 5.8 | 10.7 |
+| 96 MiB | 2.60× | 1.61× | 5.0 | 10.3 |
+| 112 MiB | 2.43× | 1.65× | 4.4 | 9.7 |
+| 128 MiB | 2.09× | 1.63× | 3.6 | 9.1 |
+
+Unpacking sits at 1.6× however much room it is given, and reads roughly twice
+as many blocks a call as the query does. The reason is what it reaches for: the
+query walks the coarse levels, whose tables are few and are hit again by the
+next query, while unpacking descends into the fine cells along one particular
+way, which the next query has no reason to want. There is no cache size within
+reach that holds the fine levels of a continent, so there is nothing to be
+bought by growing one. What does the reusing for unpacking is its own cache of
+ways, sized by `budget_for`, and that is a separate structure.
+
+So the budget is chosen on the query alone. **128 MiB is the pick**: within
+64–128 the biggest step is the last one, 112 to 128, where the query goes from
+2.43× to 2.09× — that is where level 4 becomes cheaper to hold outright than to
+cache, and 128 MiB is the first budget that can. Stopping at 112 MiB stops
+immediately before the one step worth taking.
+
 ## What has not been measured
 
 - **Cold page cache.** Every one of these runs read a file the operating

--- a/docs/disk-storage-results.md
+++ b/docs/disk-storage-results.md
@@ -166,6 +166,56 @@ two coarsest levels were the ones worth holding before and after. The numbers
 did not: the paged store was reported at five to seven times the in-memory
 query and is under two.
 
+## What a budget is for
+
+`Budget::bytes` is for the whole of an instance: the graph, the partition, the
+border levels, the store's map and cell tree, the arrays every search that may
+run at once wants, and only then the cell tables. `Footing::of` says what the
+first five come to and `Budget::for_tables` returns what is left, or `TooSmall`
+where there is nothing left.
+
+**The sections below this one were measured before that was true**, and their
+budgets are budgets for the cell tables alone. They are correct for what they
+measured -- the shape of the curve, where the cache saturates, that the codecs
+are worth 9% -- and the number to add to any of them is the footing.
+
+On europe.ptv, 18,010,173 nodes and 42,188,664 arcs:
+
+| | | |
+|---|---|---|
+| the graph | 390.6 MiB | 8 bytes an arc, 4 a node |
+| the partition | 274.8 MiB | one `u128` a node |
+| the border levels | 17.2 MiB | one byte a node |
+| the block map and the cell tree | 5.0 MiB | one entry a block, one a cell |
+| one search | 68.7 MiB | four bytes a node |
+| **the footing, one search** | **756.3 MiB** | |
+| the footing, two searches | 825.0 MiB | |
+
+So a budget under about 760 MiB cannot be met on this instance whatever is done
+with the tables, and the cell tables -- the only part that pages -- are the
+smallest thing in the list.
+
+### What a whole budget buys
+
+600 pairs, 64 KiB blocks, `pinned_share` 0.5, two searches:
+
+| total | for tables | held | query | unpacking | reads/query |
+|-------|-----------|------|-------|-----------|-------------|
+| 700 MiB | — | — | refused | refused | — |
+| 800 MiB | — | — | refused | refused | — |
+| 850 MiB | 25 MiB | none | 2.89× | 1.83× | 5.3 + 13.3 |
+| 900 MiB | 75 MiB | L4+ | 2.19× | 1.76× | 3.3 + 10.9 |
+| **1000 MiB** | **175 MiB** | **L3+** | **1.15×** | **1.23×** | **0.3 + 0.8** |
+| 1100 MiB | 275 MiB | L3+ | 1.15× | 1.27× | 0.3 + 0.8 |
+
+**1000 MiB is the pick.** The query is 85.1µs against 73.9µs in memory and
+unpacking 61.1µs against 49.5µs, at a third of a block read a query. Above it
+nothing more is bought: 1100 MiB is the same to within noise.
+
+The step from 900 to 1000 MiB is the whole of the difference, and it is where
+level 3 becomes cheaper to hold outright than to cache. Below it the store is
+paging the levels a query actually walks; above it, it is not.
+
 ## How much memory to give it
 
 `paged_query` was run over 600 pairs (every eighth of the 4,800, so the rank

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -437,7 +437,11 @@ fn main() {
                 offline / in_memory,
                 reads as f64 / pairs.len() as f64,
                 (faults.hits - before.hits) as f64 / asked.max(1) as f64,
-                if by_memory > 0.0 { by_file / by_memory } else { 0.0 },
+                if by_memory > 0.0 {
+                    by_file / by_memory
+                } else {
+                    0.0
+                },
                 unpack_reads as f64 / unpack_took.len().max(1) as f64,
             );
         }
@@ -465,13 +469,32 @@ fn main() {
         if unpacking {
             println!(
                 "{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}{}",
-                "", "unpack", "", "", "",
+                "",
+                "unpack",
+                "",
+                "",
+                "",
                 format!("{by_file:.0}us"),
-                format!("{:.0}us", if unpack_took.is_empty() { 0.0 } else {
-                    unpack_took[unpack_took.len() * 95 / 100] as f64 / 1000.0
-                }),
-                format!("{:.1}", unpack_reads as f64 / unpack_took.len().max(1) as f64),
-                format!("{:.1}× memory", if by_memory > 0.0 { by_file / by_memory } else { 0.0 }),
+                format!(
+                    "{:.0}us",
+                    if unpack_took.is_empty() {
+                        0.0
+                    } else {
+                        unpack_took[unpack_took.len() * 95 / 100] as f64 / 1000.0
+                    }
+                ),
+                format!(
+                    "{:.1}",
+                    unpack_reads as f64 / unpack_took.len().max(1) as f64
+                ),
+                format!(
+                    "{:.1}× memory",
+                    if by_memory > 0.0 {
+                        by_file / by_memory
+                    } else {
+                        0.0
+                    }
+                ),
                 if wrong_way == 0 {
                     String::new()
                 } else {

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -36,7 +36,7 @@ use toolbox_rs::{
     mld_query::MldQuery,
     node_ordering::NodeOrdering,
     packed_partition::PackedPartition,
-    paged_overlay::{Budget, PagedOverlay},
+    paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::{Unpacker, cost_of_way},
     static_graph::StaticGraph,
 };
@@ -277,6 +277,16 @@ fn main() {
          mld_unpack,offline_unpack,unpack_slowdown,unpack_reads\n",
     );
 
+    // What an instance costs before a single cell table, which the budget is
+    // for as much as the tables are.
+    let footing = Footing::of(&graph, &held_tree, map.len(), 2);
+    println!(
+        "before any table: {:.1} MiB for the graph, {:.1} for the partition, {:.1} for the rest",
+        footing.graph as f64 / MIB as f64,
+        footing.partition as f64 / MIB as f64,
+        (footing.total() - footing.graph - footing.partition) as f64 / MIB as f64,
+    );
+
     for &bytes in &budgets {
         let budget = Budget {
             bytes,
@@ -292,7 +302,15 @@ fn main() {
             budget,
         );
         let open = opening.elapsed();
-        let (pinned, cache) = budget.split(&held_tree);
+        let (pinned, cache) = budget.split(&held_tree, &footing);
+        if budget.for_tables(&footing).is_err() {
+            println!(
+                "{:>7}   a budget of this size does not cover the {:.1} MiB the instance costs before any table",
+                format!("{} MiB", bytes / MIB),
+                footing.total() as f64 / MIB as f64,
+            );
+            continue;
+        }
 
         let mut over_file = MldQuery::new();
         let mut over_memory = MldQuery::new();

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -37,6 +37,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     packed_partition::PackedPartition,
     paged_overlay::{Budget, PagedOverlay},
+    path_unpacking::{Unpacker, cost_of_way},
     static_graph::StaticGraph,
 };
 
@@ -268,8 +269,12 @@ fn main() {
         .ok()
         .and_then(|share| share.parse::<f64>().ok())
         .unwrap_or(0.5);
+    // whether to put the ways back as well as cost them; it is dearer than the
+    // query by far and a run measuring the query alone should not pay for it
+    let unpacking = std::env::var("TOOLBOX_UNPACK").is_ok_and(|on| on != "0");
     let mut summary = String::from(
-        "budget,share,pinned_from,pinned,cache,mld_median,offline_median,p95,slowdown,reads,hits\n",
+        "budget,share,pinned_from,pinned,cache,mld_median,offline_median,p95,slowdown,reads,hits,\
+         mld_unpack,offline_unpack,unpack_slowdown,unpack_reads\n",
     );
 
     for &bytes in &budgets {
@@ -291,6 +296,8 @@ fn main() {
 
         let mut over_file = MldQuery::new();
         let mut over_memory = MldQuery::new();
+        let mut unpack_file = Unpacker::for_instance(&paged);
+        let mut unpack_memory = Unpacker::for_instance(&in_memory);
         // Both are warmed before either is timed. The customization works a
         // cell out the first time it is wanted, so an unwarmed first query
         // pays for forty-three thousand cells; the store reads its first
@@ -301,11 +308,26 @@ fn main() {
             over_file.run(&paged, source, &[target]);
             over_memory.clear();
             over_memory.run(&in_memory, source, &[target]);
+            if unpacking && let Some(packed) = over_memory.retrieve_packed_path(target) {
+                let _ = unpack_file.unpack(&paged, &packed);
+                let _ = unpack_memory.unpack(&in_memory, &packed);
+            }
         }
+
+        // The warmup ran the unpackers over the same pairs that are about to be
+        // timed, so every one of them would be a hit in the cache of ways and
+        // nothing would be put back at all. The block cache and the worked-out
+        // cells stay warm, which is what the warmup was for; the ways do not.
+        unpack_file.clear();
+        unpack_memory.clear();
 
         let mut took = Vec::with_capacity(pairs.len());
         let mut memory_took = Vec::with_capacity(pairs.len());
+        let mut unpack_took = Vec::new();
+        let mut unpack_memory_took = Vec::new();
+        let mut unpack_reads = 0_u64;
         let mut wrong = 0_u64;
+        let mut wrong_way = 0_u64;
         let before = paged.faults();
         // both engines timed over the same pairs, in the shape rank_plot wants
         let mut timings = String::new();
@@ -327,6 +349,28 @@ fn main() {
             if from_file != from_memory {
                 wrong += 1;
             }
+
+            // and the way itself, which asks each store for tables of the
+            // levels below the ones the query touched
+            if unpacking && let Some(packed) = over_memory.retrieve_packed_path(target) {
+                let reads_before = paged.faults().reads;
+                let started = Instant::now();
+                let by_file = unpack_file.unpack(&paged, &packed);
+                unpack_took.push(started.elapsed().as_nanos() as u64);
+                unpack_reads += paged.faults().reads - reads_before;
+
+                let started = Instant::now();
+                let by_memory = unpack_memory.unpack(&in_memory, &packed);
+                unpack_memory_took.push(started.elapsed().as_nanos() as u64);
+
+                // the same way out of both, and worth what the query said
+                match (&by_file, &by_memory) {
+                    (Ok(one), Ok(other))
+                        if one == other
+                            && cost_of_way(in_memory.graph(), one) == Some(from_memory) => {}
+                    _ => wrong_way += 1,
+                }
+            }
             if writing.is_some() {
                 use std::fmt::Write;
                 let _ = writeln!(
@@ -337,6 +381,18 @@ fn main() {
                     timings,
                     "offline,{source},{target},{rank},{paged_nanos},{from_file}"
                 );
+                if let (Some(&by_memory), Some(&by_file)) =
+                    (unpack_memory_took.last(), unpack_took.last())
+                {
+                    let _ = writeln!(
+                        timings,
+                        "mld-unpack,{source},{target},{rank},{by_memory},{from_memory}"
+                    );
+                    let _ = writeln!(
+                        timings,
+                        "offline-unpack,{source},{target},{rank},{by_file},{from_file}"
+                    );
+                }
             }
         }
         if let Some(path) = &writing {
@@ -349,8 +405,19 @@ fn main() {
         }
         took.sort_unstable();
         memory_took.sort_unstable();
+        unpack_took.sort_unstable();
+        unpack_memory_took.sort_unstable();
+        let middle = |sorted: &[u64]| {
+            if sorted.is_empty() {
+                0.0
+            } else {
+                sorted[sorted.len() / 2] as f64 / 1000.0
+            }
+        };
+        let (by_file, by_memory) = (middle(&unpack_took), middle(&unpack_memory_took));
         let faults = paged.faults();
-        let reads = faults.reads - before.reads;
+        // what the queries read, which is not what unpacking read on top of it
+        let reads = faults.reads - before.reads - unpack_reads;
         let asked = faults.hits + faults.misses - before.hits - before.misses;
 
         // one row a budget, for whatever draws the picture
@@ -363,12 +430,15 @@ fn main() {
             let tail = took[took.len() * 95 / 100] as f64 / 1000.0;
             let _ = writeln!(
                 summary,
-                "{},{share},{},{pinned},{cache},{in_memory:.1},{offline:.1},{tail:.1},{:.3},{:.2},{:.4}",
+                "{},{share},{},{pinned},{cache},{in_memory:.1},{offline:.1},{tail:.1},{:.3},\
+                 {:.2},{:.4},{by_memory:.1},{by_file:.1},{:.3},{:.2}",
                 bytes / MIB,
                 paged.pinned_from(),
                 offline / in_memory,
                 reads as f64 / pairs.len() as f64,
                 (faults.hits - before.hits) as f64 / asked.max(1) as f64,
+                if by_memory > 0.0 { by_file / by_memory } else { 0.0 },
+                unpack_reads as f64 / unpack_took.len().max(1) as f64,
             );
         }
 
@@ -392,6 +462,23 @@ fn main() {
                 format!("  {wrong} WRONG")
             },
         );
+        if unpacking {
+            println!(
+                "{:>7} {:>6} {:>10} {:>10} {:>9} {:>8} {:>9} {:>9} {:>9}{}",
+                "", "unpack", "", "", "",
+                format!("{by_file:.0}us"),
+                format!("{:.0}us", if unpack_took.is_empty() { 0.0 } else {
+                    unpack_took[unpack_took.len() * 95 / 100] as f64 / 1000.0
+                }),
+                format!("{:.1}", unpack_reads as f64 / unpack_took.len().max(1) as f64),
+                format!("{:.1}× memory", if by_memory > 0.0 { by_file / by_memory } else { 0.0 }),
+                if wrong_way == 0 {
+                    String::new()
+                } else {
+                    format!("  {wrong_way} WRONG WAYS")
+                },
+            );
+        }
     }
 
     if let Ok(path) = std::env::var("TOOLBOX_SUMMARY") {

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -1,0 +1,259 @@
+//! What an offline instance actually costs in memory.
+//!
+//! A budget governs the cell tables and nothing else, so it is not what the
+//! process comes to. This walks the offline path alone -- no customization in
+//! memory, nothing kept that only the packer wanted -- and reads the resident
+//! set at each step, so the budget can be laid against the things beside it.
+//!
+//!   paged_rss <graph> <directory> <pairs> <blocks> [MiB]
+//!
+//! The steps are cumulative: each line is what the process holds once that
+//! step is done, and the difference between two lines is what the step added.
+
+use std::{env::args, path::Path, process, time::Instant};
+
+use toolbox_rs::{
+    block_map::BlockMap,
+    block_store::BlockStore,
+    border_levels::BorderLevels,
+    cell_tree::CellTree,
+    graph::{Graph, NodeID},
+    io,
+    level_directory::LevelDirectory,
+    mld_query::MldQuery,
+    node_ordering::NodeOrdering,
+    overlay::Overlay,
+    packed_partition::PackedPartition,
+    paged_overlay::{Budget, PagedOverlay},
+    path_unpacking::Unpacker,
+    static_graph::StaticGraph,
+};
+
+const MIB: f64 = (1024 * 1024) as f64;
+
+/// The resident set of this process, in bytes.
+///
+/// Read from the operating system rather than added up from what was
+/// allocated: what is wanted is what the machine is holding, which includes
+/// the allocator's own slack and excludes whatever it has handed back.
+fn resident() -> u64 {
+    #[cfg(target_os = "linux")]
+    {
+        // statm is in pages, and the second field is the resident set
+        let statm = std::fs::read_to_string("/proc/self/statm").unwrap_or_default();
+        let pages: u64 = statm
+            .split_whitespace()
+            .nth(1)
+            .and_then(|field| field.parse().ok())
+            .unwrap_or(0);
+        return pages * 4096;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // ps reports kibibytes
+        let out = process::Command::new("ps")
+            .args(["-o", "rss=", "-p", &process::id().to_string()])
+            .output();
+        let kib: u64 = out
+            .ok()
+            .and_then(|out| String::from_utf8(out.stdout).ok())
+            .and_then(|text| text.trim().parse().ok())
+            .unwrap_or(0);
+        kib * 1024
+    }
+}
+
+fn report(step: &str, before: u64) -> u64 {
+    let now = resident();
+    println!(
+        "{step:<38} {:>9.1} MiB   {:+9.1} MiB",
+        now as f64 / MIB,
+        (now as f64 - before as f64) / MIB
+    );
+    now
+}
+
+fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
+    std::fs::read_to_string(path)
+        .expect("a file of pairs")
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let mut fields = line.split(',');
+            let source = fields.next()?.trim().parse().ok()?;
+            let target = fields.next()?.trim().parse().ok()?;
+            Some((source, target))
+        })
+        .collect()
+}
+
+fn main() {
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!("usage: paged_rss <graph> <directory> <pairs> <blocks> [MiB]: missing {what}")
+        })
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let pairs_path = next("pairs");
+    let blocks_path = next("blocks");
+    let bytes = argv
+        .next()
+        .map_or(128, |mib| mib.parse::<usize>().expect("a size in MiB"))
+        * 1024
+        * 1024;
+
+    println!("{:<38} {:>9} {:>14}", "step", "resident", "of which new");
+    let start = resident();
+    println!("{:<38} {:>9.1} MiB", "an empty process", start as f64 / MIB);
+
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
+    let mut at = report("the graph", start);
+    let after_graph = at;
+
+    // The directory is what the partition and the border levels are built out
+    // of, and neither keeps it, so an offline instance drops it here. It is
+    // counted anyway, since a process that opens a store has to hold it for as
+    // long as it takes to build the two.
+    let partition = {
+        let directory: LevelDirectory = io::read_from_file(&directory_path);
+        at = report("  ... and the level directory", at);
+        PackedPartition::of(&directory)
+    };
+    at = report("the partition, directory dropped", at);
+    let border_levels = BorderLevels::of(&graph, &partition);
+    at = report("the border levels", at);
+    let after_instance = at;
+
+    // The pairs are translated here rather than later, and what translates them
+    // is dropped again: a NodeOrdering is one entry a node each way and comes
+    // to more than the whole budget, and it belongs to the measurement rather
+    // than to an instance that answers queries.
+    let mut pairs = pairs_of(&pairs_path);
+    if let Ok(path) = std::env::var("TOOLBOX_ORDERING") {
+        let ordering: NodeOrdering = io::read_from_file(&path);
+        for pair in &mut pairs {
+            pair.0 = ordering.new_of(pair.0);
+            pair.1 = ordering.new_of(pair.1);
+        }
+        at = report("  ... and the numbering, since dropped", at);
+    }
+
+    let map: BlockMap = io::read_from_file(&format!("{blocks_path}.map"));
+    let tree: CellTree = io::read_from_file(&format!("{blocks_path}.tree"));
+    at = report("the block map and the cell tree", at);
+
+    let map_bytes = (map.len() * size_of::<toolbox_rs::block_map::BlockEntry>()) as u64;
+    // what every cell of every level would come to unpacked, which is what the
+    // budget is a fraction of
+    let all_tables: u64 = (0..tree.levels())
+        .map(|level| tree.unpacked_bytes(level))
+        .sum();
+    let tree_bytes = (0..tree.levels())
+        .map(|level| {
+            (tree.cells_on_level(level) * size_of::<toolbox_rs::cell_tree::CellFacts>()) as u64
+        })
+        .sum::<u64>();
+
+    let budget = Budget {
+        bytes,
+        pinned_share: 0.5,
+    };
+    let (pinned, cache) = budget.split(&tree);
+    let store = BlockStore::open(Path::new(&blocks_path), map, tree).expect("a store");
+    let opening = Instant::now();
+    let paged = PagedOverlay::within(store, graph, partition, border_levels, budget);
+    let open = opening.elapsed();
+    at = report("the held levels, read and unpacked", at);
+    let after_open = at;
+
+    // the arrays a search wants, which go with the nodes of the graph and not
+    // with the budget: one query is run to make it allocate them
+    let mut query = MldQuery::new();
+    let mut unpacker = Unpacker::for_instance(&paged);
+    if let Some(&(source, target)) = pairs.first() {
+        query.run(&paged, source, &[target]);
+    }
+    at = report("what a search and an unpacker want", at);
+
+    let mut ways = 0_usize;
+    for &(source, target) in &pairs {
+        query.clear();
+        query.run(&paged, source, &[target]);
+        if let Some(packed) = query.retrieve_packed_path(target)
+            && unpacker.unpack(&paged, &packed).is_ok()
+        {
+            ways += 1;
+        }
+    }
+    let full = report("after the queries and the ways", at);
+
+    let faults = paged.faults();
+    let tables = paged.pinned_bytes() as u64 + faults.held as u64;
+    println!();
+    println!(
+        "budget {:.0} MiB: {:.1} MiB held outright, {:.1} MiB for the cache, opened in {open:.1?}",
+        bytes as f64 / MIB,
+        pinned as f64 / MIB,
+        cache as f64 / MIB,
+    );
+    println!(
+        "{} pairs asked, {ways} ways put back, {} blocks read",
+        pairs.len(),
+        faults.reads
+    );
+
+    println!();
+    println!("what the process is holding");
+    let line = |what: &str, bytes: u64, note: &str| {
+        println!("  {what:<34} {:>8.1} MiB   {note}", bytes as f64 / MIB);
+    };
+    // Sizes the structures know, rather than differences between one reading of
+    // the resident set and the next: memory that is given back does not come
+    // off the resident set, so a difference charges whatever a step dropped to
+    // the step after it. The level directory and the numbering are both gone by
+    // now and both are still resident.
+    let nodes = paged.graph().number_of_nodes() as u64;
+    let arcs = paged.graph().number_of_edges() as u64;
+    line(
+        "the graph",
+        arcs * 8 + nodes * 4,
+        "8 bytes an arc, 4 a node",
+    );
+    line("the partition", nodes * 16, "one u128 a node");
+    line("the border levels", nodes, "one byte a node");
+    line("the block map", map_bytes, "one entry a block");
+    line("the cell tree", tree_bytes, "one entry a cell");
+    line("the cell tables", tables, "<- the budget governs this one");
+    println!("  {:-<34} {:->13}", "", "");
+    let accounted = arcs * 8 + nodes * 21 + map_bytes + tree_bytes + tables;
+    line("accounted for", accounted, "");
+    line("resident", full, "");
+    println!(
+        "  {:<34} {:>8.1} MiB   the search's arrays, the unpacker's",
+        "the difference",
+        (full - accounted.min(full)) as f64 / MIB
+    );
+    println!(
+        "  {:<34} {:>8}       ways, and what the allocator kept",
+        "", ""
+    );
+    println!();
+    println!(
+        "A budget of {:.0} MiB governs {:.1} MiB of {:.1} MiB resident: {:.0}% of it.",
+        bytes as f64 / MIB,
+        tables as f64 / MIB,
+        full as f64 / MIB,
+        100.0 * tables as f64 / full as f64,
+    );
+    println!(
+        "The graph and the partition alone are {:.1} MiB, and no budget reaches them.",
+        (arcs * 8 + nodes * 20) as f64 / MIB
+    );
+    println!(
+        "Every cell table of every level would be {:.1} MiB unpacked, so the budget holds {:.0}%.",
+        all_tables as f64 / MIB,
+        100.0 * tables as f64 / all_tables as f64
+    );
+}

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -24,7 +24,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     overlay::Overlay,
     packed_partition::PackedPartition,
-    paged_overlay::{Budget, PagedOverlay},
+    paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
     static_graph::StaticGraph,
 };
@@ -158,7 +158,49 @@ fn main() {
         bytes,
         pinned_share: 0.5,
     };
-    let (pinned, cache) = budget.split(&tree);
+    let footing = Footing::of(&graph, &tree, map.len(), 1);
+    let (pinned, cache) = budget.split(&tree, &footing);
+    match budget.for_tables(&footing) {
+        Ok(left) => println!(
+            "\nbudget {:.0} MiB: {:.1} MiB is the footing, {:.1} MiB left for tables",
+            bytes as f64 / MIB,
+            footing.total() as f64 / MIB,
+            left as f64 / MIB,
+        ),
+        Err(short) => {
+            println!("\n{short}");
+            println!(
+                "  the graph                          {:>8.1} MiB",
+                footing.graph as f64 / MIB
+            );
+            println!(
+                "  the partition                      {:>8.1} MiB",
+                footing.partition as f64 / MIB
+            );
+            println!(
+                "  the border levels                  {:>8.1} MiB",
+                footing.border_levels as f64 / MIB
+            );
+            println!(
+                "  the block map and the cell tree    {:>8.1} MiB",
+                (footing.block_map + footing.cell_tree) as f64 / MIB
+            );
+            println!(
+                "  what a search wants                {:>8.1} MiB",
+                footing.searches as f64 / MIB
+            );
+            println!(
+                "  {:-<34} {:->13}\n  the footing                        {:>8.1} MiB",
+                "",
+                "",
+                footing.total() as f64 / MIB
+            );
+            println!(
+                "\nNothing is asked, since a budget that leaves no room for a table\n                 spends the whole run reading one and letting it go again."
+            );
+            return;
+        }
+    }
     let store = BlockStore::open(Path::new(&blocks_path), map, tree).expect("a store");
     let opening = Instant::now();
     let paged = PagedOverlay::within(store, graph, partition, border_levels, budget);

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -110,7 +110,6 @@ fn main() {
 
     let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
     let mut at = report("the graph", start);
-    let after_graph = at;
 
     // The directory is what the partition and the border levels are built out
     // of, and neither keeps it, so an offline instance drops it here. It is
@@ -124,7 +123,6 @@ fn main() {
     at = report("the partition, directory dropped", at);
     let border_levels = BorderLevels::of(&graph, &partition);
     at = report("the border levels", at);
-    let after_instance = at;
 
     // The pairs are translated here rather than later, and what translates them
     // is dropped again: a NodeOrdering is one entry a node each way and comes
@@ -166,7 +164,6 @@ fn main() {
     let paged = PagedOverlay::within(store, graph, partition, border_levels, budget);
     let open = opening.elapsed();
     at = report("the held levels, read and unpacked", at);
-    let after_open = at;
 
     // the arrays a search wants, which go with the nodes of the graph and not
     // with the budget: one query is run to make it allocate them

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -27,6 +27,8 @@ output <- if (length(args) >= 2) args[2] else "ranks.png"
 # hold anything worth comparing -- two ways of unpacking a path, say -- and
 # then the one to divide by is whichever the others are being judged against.
 denominator <- if (length(args) >= 3) args[3] else "mld"
+# what the rows are timings of; only the wording changes with it
+measuring <- if (length(args) >= 4) args[4] else "query time"
 
 timings <- read.csv(input, stringsAsFactors = FALSE)
 for (column in c("engine", "rank", "nanos")) {
@@ -116,7 +118,7 @@ for (index in seq_along(exponents)) {
 boxplot(groups,
   at = at, boxwex = width * 0.9, col = fill, log = "y",
   xaxt = "n", yaxt = "n", xlab = "", ylab = "milliseconds",
-  main = sprintf("query time by Dijkstra rank (%s)", basename(input)),
+  main = sprintf("%s by Dijkstra rank (%s)", measuring, basename(input)),
   outcex = 0.3, whisklty = 1, staplewex = 0.5
 )
 axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
@@ -158,9 +160,14 @@ if (denominator %in% engines && length(engines) > 1) {
   plot(NA,
     xlim = range(exponents), ylim = ylim, log = "y", xaxt = "n", yaxt = "n",
     xlab = "Dijkstra rank",
-    ylab = sprintf("%s / %s", measured, name_of(denominator))
+    ylab = ""
   )
   axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
+  # placed by hand rather than as ylab, so a long pair of names can be set
+  # smaller instead of running off the edge of the device
+  side_label <- sprintf("%s / %s", measured, name_of(denominator))
+  mtext(side_label, side = 2, line = 3.2, las = 0,
+        cex = if (nchar(side_label) > 28) 0.72 else 0.9)
   ticks <- ratios_over(c(ratios, 1))
   axis(2, at = ticks, labels = as_multiple(ticks))
   # a line at each tick, so a point can be read across to the axis rather than

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -50,7 +50,12 @@ exponents <- sort(unique(timings$exponent))
 # the engine column says which search wrote the row; a legend wants to say
 # which search it was, and "dijkstra" does not distinguish the plain search
 # from the one that runs from both ends
-display <- c(dijkstra = "unidirectional", bidirectional = "bidirectional", mld = "mld")
+display <- c(
+  dijkstra = "unidirectional", bidirectional = "bidirectional", mld = "mld",
+  offline = "offline",
+  # the same two again for putting the way back rather than costing it
+  "mld-unpack" = "mld, unpacked", "offline-unpack" = "offline, unpacked"
+)
 name_of <- function(engine) ifelse(engine %in% names(display), display[engine], engine)
 
 # every power of ten the numbers reach, written out rather than as 1e+03: a

--- a/src/dense_heap.rs
+++ b/src/dense_heap.rs
@@ -97,6 +97,12 @@ pub struct ByArray {
 }
 
 impl ByArray {
+    /// What the table has taken, which goes with the nodes of the graph.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.of_node.capacity() * size_of::<Slot>()
+    }
+
     #[inline]
     pub fn get(&self, node: NodeID) -> Slot {
         self.of_node.get(node).copied().unwrap_or(UNTOUCHED)
@@ -144,6 +150,13 @@ pub struct ByMap {
 }
 
 impl ByMap {
+    /// What the table has taken, which goes with what a run reached rather
+    /// than with the graph.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.of_node.capacity() * (size_of::<NodeID>() + size_of::<Slot>())
+    }
+
     #[inline]
     pub fn get(&self, node: NodeID) -> Slot {
         self.of_node.get(&node).copied().unwrap_or(UNTOUCHED)
@@ -235,6 +248,17 @@ macro_rules! query_heap {
 
             pub fn stats(&self) -> &S {
                 &self.stats
+            }
+
+            /// What the queue has taken, table and all.
+            ///
+            /// The table goes with the nodes of the graph where it is an
+            /// array, and the heap with what the longest run so far reached.
+            #[must_use]
+            pub fn bytes(&self) -> usize {
+                self.heap.capacity() * size_of::<(u32, u32)>()
+                    + self.held.capacity() * size_of::<Held>()
+                    + self.table.bytes()
             }
 
             /// Forgets the run that has just finished.

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -115,6 +115,13 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         self.queue.weight(node)
     }
 
+    /// What this search has taken, which goes with the nodes of the graph and
+    /// not with any budget set for the cell tables.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.queue.bytes()
+    }
+
     /// The node a reached node was reached from.
     ///
     /// `None` if the search never reached it, and the node itself if it is the

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -91,6 +91,7 @@ pub trait Overlay {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::path_unpacking::{cost_of_way, unpack};
     use crate::{
         customization::{CellDistances, Customization},
         edge::InputEdge,
@@ -211,5 +212,52 @@ mod tests {
             guarding.asked.get() > 0,
             "the guarding store was never asked for a table"
         );
+    }
+
+    /// And the same again for the way rather than the cost: unpacking asks the
+    /// store for tables of its own, level by level down, and has to get the
+    /// same way out of a store that guards as out of one that lends.
+    #[test]
+    fn the_same_way_is_unpacked_over_a_store_that_hands_out_guards() {
+        let side = 16;
+        let lending = grid(side);
+        let guarding = Paged {
+            held: grid(side),
+            asked: Cell::new(0),
+        };
+
+        let mut over_lending = MldQuery::new();
+        let mut over_guarding = MldQuery::new();
+        let mut unpacked = 0;
+        for source in (0..side * side).step_by(7) {
+            for target in (0..side * side).step_by(11) {
+                over_lending.clear();
+                over_guarding.clear();
+                over_lending.run(&lending, source, &[target]);
+                over_guarding.run(&guarding, source, &[target]);
+
+                let Some(packed) = over_lending.retrieve_packed_path(target) else {
+                    continue;
+                };
+                assert_eq!(
+                    Some(packed.clone()),
+                    over_guarding.retrieve_packed_path(target),
+                    "the packed path differs from {source} to {target}"
+                );
+
+                let over_one = unpack(&lending, &packed).expect("a way over the lending store");
+                let over_other = unpack(&guarding, &packed).expect("a way over the guarding one");
+                assert_eq!(over_one, over_other, "from {source} to {target}");
+
+                // and the way is worth what the search said it would be
+                assert_eq!(
+                    cost_of_way(lending.graph(), &over_one),
+                    Some(over_lending.distance(target)),
+                    "from {source} to {target}"
+                );
+                unpacked += 1;
+            }
+        }
+        assert!(unpacked > 100, "the sweep is worth running");
     }
 }

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -38,11 +38,12 @@ use std::sync::{Arc, Mutex};
 const BLOCKS_IN_HAND: usize = 8;
 
 use crate::{
+    block_map::BlockEntry,
     block_store::{BlockStore, NotRead},
     border_levels::BorderLevels,
     cell_block::CellBlock,
-    cell_tree::CellTree,
-    graph::NodeID,
+    cell_tree::{CellFacts, CellTree},
+    graph::{Graph, NodeID},
     level_directory::CellId,
     lru::LRU,
     overlay::{CellTable, Overlay},
@@ -132,11 +133,106 @@ pub struct Faults {
 /// left idle: a share is a ceiling on what may be held, not a reservation.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Budget {
-    /// what the tables may come to in all, in bytes
+    /// what the instance may come to in all, in bytes: the graph, the
+    /// partition, the border levels, the store's own tables of contents, the
+    /// arrays a search wants, and the cell tables
     pub bytes: usize,
-    /// the most of it that may be held outright, as a share of the whole
+    /// the most of what is left after the footing that may be held outright,
+    /// as a share of that remainder
     pub pinned_share: f64,
 }
+
+/// What an instance costs before it holds a single cell table.
+///
+/// # Why this is not a detail
+///
+/// The budget is for the whole of an instance and the cell tables are the
+/// smallest part of it. On a continent the graph is four hundred mebibytes and
+/// the partition another three hundred, against tables that can be run in a
+/// tenth of that: a budget set without counting them is not a budget for
+/// anything a device has to hold.
+///
+/// So the footing is paid first and the tables get the remainder, and where
+/// there is no remainder the budget is refused rather than quietly exceeded.
+///
+/// # What is fixed and what is not
+///
+/// The graph, the partition and the border levels go with the instance and
+/// cannot be traded for anything; the store's map and cell tree go with how it
+/// was packed. The searches are the one part that goes with how many run at
+/// once, which is why they are counted per search rather than once.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Footing {
+    /// the arcs and the offsets into them
+    pub graph: u64,
+    /// one word a node
+    pub partition: u64,
+    /// one byte a node
+    pub border_levels: u64,
+    /// one entry a block, and one a cell
+    pub block_map: u64,
+    pub cell_tree: u64,
+    /// what the arrays of every search that may run at once come to
+    pub searches: u64,
+}
+
+impl Footing {
+    /// What an instance over this graph and this store costs before tables.
+    ///
+    /// `searches` is how many searches may be running at once, since each
+    /// keeps a table over the nodes of the graph for as long as it lives.
+    #[must_use]
+    pub fn of<G: Graph<u32>>(graph: &G, tree: &CellTree, blocks: usize, searches: usize) -> Self {
+        let nodes = graph.number_of_nodes() as u64;
+        let arcs = graph.number_of_edges() as u64;
+        Self {
+            // a target and a weight an arc, and an offset a node
+            graph: arcs * 8 + nodes * 4,
+            partition: nodes * 16,
+            border_levels: nodes,
+            block_map: blocks as u64 * size_of::<BlockEntry>() as u64,
+            cell_tree: (0..tree.levels())
+                .map(|level| tree.cells_on_level(level) as u64 * size_of::<CellFacts>() as u64)
+                .sum(),
+            // four bytes a node for the table a queue reads in one look; what
+            // the heap itself takes goes with the widest run and not with the
+            // graph, and is not standing room
+            searches: searches as u64 * nodes * 4,
+        }
+    }
+
+    /// What the whole of it comes to.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.graph
+            + self.partition
+            + self.border_levels
+            + self.block_map
+            + self.cell_tree
+            + self.searches
+    }
+}
+
+/// A budget that does not cover what the instance costs before tables.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TooSmall {
+    /// what the footing comes to
+    pub footing: u64,
+    /// what the budget was
+    pub budget: usize,
+}
+
+impl std::fmt::Display for TooSmall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "a budget of {} bytes does not cover the {} the instance costs before any cell table",
+            self.budget, self.footing
+        )
+    }
+}
+
+impl std::error::Error for TooSmall {}
 
 impl Budget {
     /// A budget with half of it available to hold levels outright.
@@ -148,11 +244,29 @@ impl Budget {
         }
     }
 
+    /// What is left for the cell tables once the instance is paid for.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TooSmall`] where the budget does not cover the footing, which
+    /// is a budget that cannot be met rather than one that will be tight.
+    pub fn for_tables(&self, footing: &Footing) -> Result<usize, TooSmall> {
+        let wants = usize::try_from(footing.total()).unwrap_or(usize::MAX);
+        self.bytes.checked_sub(wants).ok_or(TooSmall {
+            footing: footing.total(),
+            budget: self.bytes,
+        })
+    }
+
     /// The lowest level worth holding outright, and the level count when none
     /// is: levels from here up are held, levels below are cached.
+    ///
+    /// The share is of what is left after the footing, not of the whole
+    /// budget: half of a budget the graph has already spent is not room.
     #[must_use]
-    pub fn pin_from(&self, tree: &CellTree) -> usize {
-        let room = (self.bytes as f64 * self.pinned_share.clamp(0.0, 1.0)) as u64;
+    pub fn pin_from(&self, tree: &CellTree, footing: &Footing) -> usize {
+        let left = self.for_tables(footing).unwrap_or(0);
+        let room = (left as f64 * self.pinned_share.clamp(0.0, 1.0)) as u64;
         let mut taken = 0_u64;
         let mut from = tree.levels();
         for level in (0..tree.levels()).rev() {
@@ -167,16 +281,19 @@ impl Budget {
     }
 
     /// What the held levels come to, and what is left for the cache.
+    ///
+    /// Both are out of what the tables were left, so the two and the footing
+    /// come to the budget.
     #[must_use]
-    pub fn split(&self, tree: &CellTree) -> (u64, usize) {
-        let from = self.pin_from(tree);
+    pub fn split(&self, tree: &CellTree, footing: &Footing) -> (u64, usize) {
+        let left = self.for_tables(footing).unwrap_or(0);
+        let from = self.pin_from(tree, footing);
         let pinned = (from..tree.levels())
             .map(|level| tree.unpacked_bytes(level))
             .sum::<u64>();
         (
             pinned,
-            self.bytes
-                .saturating_sub(usize::try_from(pinned).unwrap_or(usize::MAX)),
+            left.saturating_sub(usize::try_from(pinned).unwrap_or(usize::MAX)),
         )
     }
 }
@@ -259,8 +376,9 @@ impl PagedOverlay {
         borders: BorderLevels,
         budget: Budget,
     ) -> Self {
-        let pin_from = budget.pin_from(store.tree());
-        let (_, cache) = budget.split(store.tree());
+        let footing = Footing::of(&graph, store.tree(), store.map().len(), 1);
+        let pin_from = budget.pin_from(store.tree(), &footing);
+        let (_, cache) = budget.split(store.tree(), &footing);
         let levels = store.tree().levels();
 
         let mut held = Self::new(store, graph, partition, borders, cache);
@@ -681,14 +799,17 @@ mod tests {
         let path = held.path().join("blocks");
         let map = pack(&in_memory, &tree, &path, 3);
 
-        // room enough for the two coarsest levels and no more
+        // room enough for the two coarsest levels and no more, on top of what
+        // the instance costs before any table: the budget is for the whole of
+        // it and the graph is paid for first
         let levels = tree.levels();
         let wanted = tree.unpacked_bytes(levels - 1) + tree.unpacked_bytes(levels - 2);
+        let footing = Footing::of(&graph, &tree, map.len(), 1);
         let budget = Budget {
-            bytes: usize::try_from(wanted).expect("a budget of that size") * 2,
+            bytes: usize::try_from(footing.total() + wanted * 2).expect("a budget of that size"),
             pinned_share: 0.5,
         };
-        let pin_from = budget.pin_from(&tree);
+        let pin_from = budget.pin_from(&tree, &footing);
         assert_eq!(pin_from, levels - 2, "two levels were to be held");
 
         let store = BlockStore::open(&path, map, tree).expect("a store to open");
@@ -734,6 +855,83 @@ mod tests {
         }
     }
 
+    /// The one that says what a budget is for: a graph counted, not assumed
+    /// away.
+    #[test]
+    fn a_budget_pays_for_the_instance_before_it_pays_for_a_table() {
+        let side = 16;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges);
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+        let footing = Footing::of(&graph, &tree, 4, 1);
+
+        assert!(footing.graph > 0 && footing.partition > 0);
+        assert_eq!(
+            footing.total(),
+            footing.graph
+                + footing.partition
+                + footing.border_levels
+                + footing.block_map
+                + footing.cell_tree
+                + footing.searches,
+            "the parts come to the whole"
+        );
+
+        // a budget under the footing is refused rather than quietly exceeded
+        let short = Budget {
+            bytes: usize::try_from(footing.total()).expect("a size") / 2,
+            pinned_share: 0.5,
+        };
+        assert_eq!(
+            short.for_tables(&footing),
+            Err(TooSmall {
+                footing: footing.total(),
+                budget: short.bytes,
+            })
+        );
+        // The coarsest level has no border and so costs nothing, and a level
+        // that costs nothing fits any budget including one already spent. What
+        // a budget it cannot meet holds is nothing that has a size.
+        assert_eq!(
+            short.split(&tree, &footing).0,
+            0,
+            "a budget it cannot meet held something with a cost"
+        );
+        assert_eq!(short.split(&tree, &footing).1, 0, "and left no cache");
+
+        // and one over it leaves exactly the difference for the tables
+        let over = Budget {
+            bytes: usize::try_from(footing.total()).expect("a size") + 4096,
+            pinned_share: 0.5,
+        };
+        assert_eq!(over.for_tables(&footing), Ok(4096));
+        let (pinned, cache) = over.split(&tree, &footing);
+        assert_eq!(
+            usize::try_from(pinned).expect("a size") + cache,
+            4096,
+            "the held levels and the cache come to what was left, not to the budget"
+        );
+    }
+
+    /// Two searches want two tables over the nodes, and a budget that counts
+    /// one of them is a budget for an instance nobody is running.
+    #[test]
+    fn every_search_that_may_run_at_once_is_counted() {
+        let side = 16;
+        let (edges, directory) = laid_out(side);
+        let graph = StaticGraph::new(edges);
+        let partition = PackedPartition::of(&directory);
+        let coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+        let one = Footing::of(&graph, &tree, 4, 1);
+        let four = Footing::of(&graph, &tree, 4, 4);
+        assert_eq!(four.searches, one.searches * 4);
+        assert_eq!(four.total() - one.total(), one.searches * 3);
+    }
+
     #[test]
     fn a_budget_too_small_holds_only_what_costs_nothing() {
         let side = 8;
@@ -750,7 +948,7 @@ mod tests {
         // has no table and costs nothing to hold. A level that costs nothing
         // fits any budget, so what is asserted is that nothing which costs
         // anything was held.
-        let from = budget.pin_from(&tree);
+        let from = budget.pin_from(&tree, &Footing::default());
         for level in from..tree.levels() {
             assert_eq!(
                 tree.unpacked_bytes(level),
@@ -758,7 +956,11 @@ mod tests {
                 "level {level} was held in eight bytes"
             );
         }
-        assert_eq!(budget.split(&tree).0, 0, "nothing with a cost was held");
+        assert_eq!(
+            budget.split(&tree, &Footing::default()).0,
+            0,
+            "nothing with a cost was held"
+        );
     }
 
     /// What the pinned share does not use is the cache's, not nobody's.
@@ -774,7 +976,7 @@ mod tests {
             bytes: 1 << 20,
             pinned_share: 0.5,
         };
-        let (pinned, cache) = budget.split(&tree);
+        let (pinned, cache) = budget.split(&tree, &Footing::default());
         assert_eq!(
             cache,
             budget.bytes - usize::try_from(pinned).expect("a size"),

--- a/src/path_unpacking.rs
+++ b/src/path_unpacking.rs
@@ -334,8 +334,11 @@ impl Unpacker {
         self.misses += 1;
         let partition = overlay.partition();
         let cell = partition.cell_of(from, level);
-        let found = within_cell(overlay, from, to, level, cell)
-            .ok_or(Unpacking::NoWayAcross { from, to, level })?;
+        let found = within_cell(overlay, from, to, level, cell).ok_or(Unpacking::NoWayAcross {
+            from,
+            to,
+            level,
+        })?;
 
         // The way found is over the cells of the level below, so its own steps
         // across those cells are put back the same way. At the finest level there

--- a/src/path_unpacking.rs
+++ b/src/path_unpacking.rs
@@ -44,10 +44,10 @@ use std::{cmp::Reverse, collections::BinaryHeap};
 use rustc_hash::FxHashMap;
 
 use crate::{
-    customization::Customization,
     graph::{Graph, NodeID},
     level_directory::CellId,
     lru::LRU,
+    overlay::{CellTable, Overlay},
 };
 
 /// What a held way costs beyond its nodes: the key it is filed under, the
@@ -84,11 +84,11 @@ const PER_WAY: usize = size_of::<(NodeID, NodeID, usize)>() + size_of::<Vec<Node
 /// known to be neither should say so with
 /// [`Unpacker::with_budget`](Unpacker::with_budget).
 #[must_use]
-pub fn budget_for(customization: &Customization) -> usize {
-    let directory = customization.directory();
-    directory
+pub fn budget_for<O: Overlay>(overlay: &O) -> usize {
+    overlay
+        .graph()
         .number_of_nodes()
-        .saturating_mul(directory.levels())
+        .saturating_mul(overlay.levels())
         / 16
         * 5
 }
@@ -122,8 +122,8 @@ pub enum Unpacking {
 /// # Panics
 ///
 /// Panics if the packed path holds a node the partition does not.
-pub fn unpack(customization: &Customization, packed: &[NodeID]) -> Result<Vec<NodeID>, Unpacking> {
-    Unpacker::default().unpack(customization, packed)
+pub fn unpack<O: Overlay>(overlay: &O, packed: &[NodeID]) -> Result<Vec<NodeID>, Unpacking> {
+    Unpacker::default().unpack(overlay, packed)
 }
 
 /// An unpacker that remembers the ways it has already put back.
@@ -166,8 +166,8 @@ impl Unpacker {
     /// An unpacker holding what the instance warrants, by
     /// [`budget_for`](budget_for).
     #[must_use]
-    pub fn for_instance(customization: &Customization) -> Self {
-        Self::with_budget(budget_for(customization))
+    pub fn for_instance<O: Overlay>(overlay: &O) -> Self {
+        Self::with_budget(budget_for(overlay))
     }
 
     /// An unpacker holding no more than the given number of bytes of ways.
@@ -276,23 +276,23 @@ impl Unpacker {
     /// # Panics
     ///
     /// Panics if the packed path holds a node the partition does not.
-    pub fn unpack(
+    pub fn unpack<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        overlay: &O,
         packed: &[NodeID],
     ) -> Result<Vec<NodeID>, Unpacking> {
-        self.unpack_inner(customization, packed)
+        self.unpack_inner(overlay, packed)
     }
 
-    fn unpack_inner(
+    fn unpack_inner<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        overlay: &O,
         packed: &[NodeID],
     ) -> Result<Vec<NodeID>, Unpacking> {
         let Some((&source, rest)) = packed.split_first() else {
             return Ok(Vec::new());
         };
-        let partition = customization.partition();
+        let partition = overlay.partition();
         let source_word = partition.word(source);
         let target_word = partition.word(*packed.last().expect("the path has a first node"));
 
@@ -306,7 +306,7 @@ impl Unpacker {
                 Some(level)
                     if partition.same_cell_at(partition.word(from), partition.word(to), level) =>
                 {
-                    let across = self.across_cell(customization, from, to, level)?;
+                    let across = self.across_cell(overlay, from, to, level)?;
                     way.extend_from_slice(&across[1..]);
                 }
                 _ => way.push(to),
@@ -320,9 +320,9 @@ impl Unpacker {
     ///
     /// Every node of it, so the caller may lay it end to end with what it already
     /// has. The first node is `from` and the last is `to`.
-    fn across_cell(
+    fn across_cell<O: Overlay>(
         &mut self,
-        customization: &Customization,
+        overlay: &O,
         from: NodeID,
         to: NodeID,
         level: usize,
@@ -332,9 +332,9 @@ impl Unpacker {
             return Ok(held.clone());
         }
         self.misses += 1;
-        let partition = customization.partition();
+        let partition = overlay.partition();
         let cell = partition.cell_of(from, level);
-        let found = within_cell(customization, from, to, level, cell)
+        let found = within_cell(overlay, from, to, level, cell)
             .ok_or(Unpacking::NoWayAcross { from, to, level })?;
 
         // The way found is over the cells of the level below, so its own steps
@@ -349,7 +349,7 @@ impl Unpacker {
         for pair in found.windows(2) {
             let (step_from, step_to) = (pair[0], pair[1]);
             if partition.same_cell_at(partition.word(step_from), partition.word(step_to), below) {
-                let across = self.across_cell(customization, step_from, step_to, below)?;
+                let across = self.across_cell(overlay, step_from, step_to, below)?;
                 way.extend_from_slice(&across[1..]);
             } else {
                 way.push(step_to);
@@ -368,8 +368,8 @@ impl Unpacker {
 /// The nodes it walks are the border nodes of the cells below plus whatever
 /// arcs of the graph run between them, which on a coarse cell is a small part
 /// of what it holds.
-fn within_cell(
-    customization: &Customization,
+fn within_cell<O: Overlay>(
+    overlay: &O,
     from: NodeID,
     to: NodeID,
     level: usize,
@@ -378,8 +378,8 @@ fn within_cell(
     if from == to {
         return Some(vec![from]);
     }
-    let partition = customization.partition();
-    let graph = customization.graph();
+    let partition = overlay.partition();
+    let graph = overlay.graph();
 
     let mut parent: FxHashMap<NodeID, NodeID> = FxHashMap::default();
     let mut best: FxHashMap<NodeID, usize> = FxHashMap::default();
@@ -427,10 +427,10 @@ fn within_cell(
             // this cell was built out of
             let below = level - 1;
             let inner = partition.cell_of(node, below);
-            if let Some(distances) = customization.distances_of(below, inner)
+            if let Some(distances) = overlay.distances_of(below, inner)
                 && let Some(place) = distances.place_of(node)
             {
-                for (&other, &across) in distances.border_nodes.iter().zip(distances.row(place)) {
+                for (&other, &across) in distances.border_nodes().iter().zip(distances.row(place)) {
                     if across == u32::MAX || other as NodeID == node {
                         continue;
                     }


### PR DESCRIPTION
Based on #611.

`src/path_unpacking.rs` took `&Customization` throughout and now takes any
`&O: Overlay`:

```rust
pub fn unpack<O: Overlay>(overlay: &O, packed: &[NodeID]) -> Result<Vec<NodeID>, Unpacking>
pub fn budget_for<O: Overlay>(overlay: &O) -> usize

impl Unpacker {
    pub fn for_instance<O: Overlay>(overlay: &O) -> Self
    pub fn unpack<O: Overlay>(&mut self, overlay: &O, packed: &[NodeID])
        -> Result<Vec<NodeID>, Unpacking>
}
```

The three things it asked the customization for -- `partition()`, `graph()` and
`distances_of()` -- are all on the trait, so the search itself is unchanged.
`budget_for` reads the node count off `overlay.graph()` and the level count off
`overlay.levels()`, where it read both off the customization's directory.
`distances.border_nodes` becomes `distances.border_nodes()`, the `CellTable`
method.

`src/overlay.rs` gains a test that a packed path unpacks to the same way over a
store that lends its tables and one that hands out guards, and that the way
costs what the query said.

`examples/paged_query.rs` gains `TOOLBOX_UNPACK`, which puts every way back on
both engines and times each, checks the two agree and that the way costs what
the query said, and counts the blocks unpacking reads apart from the blocks the
query read. The summary gains `mld_unpack`, `offline_unpack`,
`unpack_slowdown` and `unpack_reads`; the per-pair rows gain the `mld-unpack`
and `offline-unpack` engines. The unpackers are cleared after the warmup, since
the warmup runs the pairs that are about to be timed and would otherwise make
every one of them a hit.

`scripts/rank_plot.R` takes a fourth argument for what the rows are timings of,
defaulting to `query time`, and places the lower panel's axis title with
`mtext` so a long pair of engine names is set smaller rather than running off
the device.

Measured over 4,800 pairs of europe.ptv, 64 KiB blocks, a 128 MiB budget:

| | median | 95th | mean |
|---|--------|------|------|
| query, in memory | 73.3us | 5.85ms | 853us |
| query, offline | 165.6us | 5.93ms | 957us |
| unpacking, in memory | 28.2us | 1.67ms | 334us |
| unpacking, offline | 45.8us | 2.56ms | 509us |

Query and unpacking together are 118.5us in memory and 241.9us off the file,
which is 2.04x. Every one of the 4,800 ways came out the same on both engines
and cost what the query said.

Swept from 64 to 128 MiB, unpacking holds at 1.6x whatever room it is given
while the query walks from 3.05x to 2.09x. Unpacking descends into fine cells
along one particular way, which no cache of that size holds and the next query
has no reason to want; what does its reusing is its own cache of ways, sized by
`budget_for`. The budget is therefore chosen on the query, and the largest step
in that range is the last one, 112 to 128 MiB, where level 4 becomes cheaper to
hold outright than to cache.