### PR TITLE
Run-length encode PackedPartition, and move BorderLevels into GraphBlock

### DIFF
--- a/examples/paged_dijkstra.rs
+++ b/examples/paged_dijkstra.rs
@@ -25,7 +25,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     one_to_many_dijkstra::OneToManyDijkstra,
     packed_partition::PackedPartition,
-    paged_graph::{PagedGraph, pack, pack_borders},
+    paged_graph::{PagedGraph, pack},
     static_graph::StaticGraph,
 };
 
@@ -109,8 +109,18 @@ fn main() {
         (map, first_edges)
     } else {
         let started = Instant::now();
-        let (map, first_edges) = pack(&graph, Some(&tree), path, arcs_in_a_block, Codec::Lz4, 3)
-            .expect("a graph to pack");
+        // the border levels ride in the blocks with the arcs they belong to
+        let walked = BorderLevels::of(&graph, &partition);
+        let (map, first_edges) = pack(
+            &graph,
+            &walked,
+            Some(&tree),
+            path,
+            arcs_in_a_block,
+            Codec::Lz4,
+            3,
+        )
+        .expect("a graph to pack");
         println!(
             "packed {} arcs into {} blocks of about {kib} KiB in {:.1?}",
             Graph::number_of_edges(&graph),
@@ -119,24 +129,6 @@ fn main() {
         );
         io::write_to_file(&format!("{arcs_path}.map"), &map);
         io::write_vec_to_file(&index_path, &first_edges);
-        // and the border levels beside them, so that opening the store never
-        // has to walk the arcs to work them out again
-        let started = Instant::now();
-        let walked = BorderLevels::of(&graph, &partition);
-        let borders = pack_borders(
-            walked.as_bytes(),
-            &first_edges,
-            Path::new(&format!("{arcs_path}.borders")),
-            Codec::Lz4,
-            3,
-        )
-        .expect("the border levels to pack");
-        io::write_to_file(&format!("{arcs_path}.borders.map"), &borders);
-        println!(
-            "packed the border levels into {} blocks in {:.1?}",
-            borders.len(),
-            started.elapsed()
-        );
         (map, first_edges)
     };
 

--- a/examples/paged_dijkstra.rs
+++ b/examples/paged_dijkstra.rs
@@ -16,6 +16,7 @@ use std::{env::args, fs::File, io::Write, path::Path, time::Instant};
 use toolbox_rs::{
     block_codec::Codec,
     block_map::BlockMap,
+    border_levels::BorderLevels,
     cell_tree::CellTree,
     geometry::FPCoordinate,
     graph::{Graph, NodeID},
@@ -24,7 +25,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     one_to_many_dijkstra::OneToManyDijkstra,
     packed_partition::PackedPartition,
-    paged_graph::{PagedGraph, pack},
+    paged_graph::{PagedGraph, pack, pack_borders},
     static_graph::StaticGraph,
 };
 
@@ -118,6 +119,24 @@ fn main() {
         );
         io::write_to_file(&format!("{arcs_path}.map"), &map);
         io::write_vec_to_file(&index_path, &first_edges);
+        // and the border levels beside them, so that opening the store never
+        // has to walk the arcs to work them out again
+        let started = Instant::now();
+        let walked = BorderLevels::of(&graph, &partition);
+        let borders = pack_borders(
+            walked.as_bytes(),
+            &first_edges,
+            Path::new(&format!("{arcs_path}.borders")),
+            Codec::Lz4,
+            3,
+        )
+        .expect("the border levels to pack");
+        io::write_to_file(&format!("{arcs_path}.borders.map"), &borders);
+        println!(
+            "packed the border levels into {} blocks in {:.1?}",
+            borders.len(),
+            started.elapsed()
+        );
         (map, first_edges)
     };
 

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -27,7 +27,6 @@ use toolbox_rs::{
     paged_graph::PagedGraph,
     paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
-    static_graph::StaticGraph,
 };
 
 const MIB: f64 = (1024 * 1024) as f64;
@@ -95,7 +94,7 @@ fn main() {
             panic!("usage: paged_rss <graph> <directory> <pairs> <blocks> [MiB]: missing {what}")
         })
     };
-    let graph_path = next("graph");
+    let _graph_path = next("graph");
     let directory_path = next("directory");
     let pairs_path = next("pairs");
     let blocks_path = next("blocks");
@@ -109,8 +108,10 @@ fn main() {
     let start = resident();
     println!("{:<38} {:>9.1} MiB", "an empty process", start as f64 / MIB);
 
-    let graph = StaticGraph::new(io::read_edges_from_file(&graph_path));
-    let mut at = report("the graph", start);
+    // No graph is read at all. It was here for the border levels, which are
+    // now written down when the store is packed and read back, and nothing
+    // else an instance does wants every arc at once.
+    let mut at = report("no graph is read", start);
 
     // The directory is what the partition and the border levels are built out
     // of, and neither keeps it, so an offline instance drops it here. It is
@@ -235,7 +236,14 @@ fn main() {
     }
     let store = BlockStore::open(Path::new(&blocks_path), map, tree).expect("a store");
     let opening = Instant::now();
-    let border_levels = BorderLevels::of(&graph, &partition);
+    // read back rather than walked: the levels were settled when the store was
+    // packed and working them out again means touching every arc of a graph
+    // that is on a file
+    let border_map: BlockMap = io::read_from_file(&format!("{arcs}.borders.map"));
+    let border_levels = BorderLevels::of_bytes(
+        toolbox_rs::paged_graph::read_borders(Path::new(&format!("{arcs}.borders")), &border_map)
+            .expect("the border levels"),
+    );
     let paged = PagedOverlay::within(store, paged_arcs, partition, border_levels, budget);
     let open = opening.elapsed();
     at = report("the held levels, read and unpacked", at);
@@ -294,7 +302,11 @@ fn main() {
         footing.partition,
         "a run a cell, not a word a node",
     );
-    line("the border levels", nodes, "one byte a node");
+    line(
+        "the border levels",
+        footing.border_levels,
+        "one byte an arc, read and not walked",
+    );
     line("the block map", map_bytes, "one entry a block");
     line("the cell tree", tree_bytes, "one entry a cell");
     line("the cell tables", tables, "<- the budget governs this one");

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -24,6 +24,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     overlay::Overlay,
     packed_partition::PackedPartition,
+    paged_graph::PagedGraph,
     paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
     static_graph::StaticGraph,
@@ -158,7 +159,32 @@ fn main() {
         bytes,
         pinned_share: 0.5,
     };
-    let footing = Footing::of(&graph, &tree, map.len(), 1);
+    // Where a pack of the arcs is at hand, the graph pages too and the footing
+    // stands for its index rather than for its arcs.
+    let arcs = std::env::var("TOOLBOX_ARCS").ok();
+    let paged_arcs = arcs.as_ref().map(|at| {
+        let arc_map: BlockMap = io::read_from_file(&format!("{at}.map"));
+        let first_edges: Vec<u64> = io::read_vec_from_file(&format!("{at}.index"));
+        let room = std::env::var("TOOLBOX_ARC_BUDGET")
+            .ok()
+            .and_then(|mib| mib.parse::<usize>().ok())
+            .unwrap_or(256)
+            * 1024
+            * 1024;
+        let read =
+            PagedGraph::open(Path::new(at), arc_map, &first_edges, room).expect("a graph to open");
+        println!(
+            "the arcs page, holding at most {} MiB",
+            room / (1024 * 1024)
+        );
+        read
+    });
+    at = report("the arcs, if they page", at);
+
+    let footing = match &paged_arcs {
+        Some(read) => Footing::with_partition(read, partition.bytes() as u64, &tree, map.len(), 1),
+        None => Footing::with_partition(&graph, partition.bytes() as u64, &tree, map.len(), 1),
+    };
     let (pinned, cache) = budget.split(&tree, &footing);
     match budget.for_tables(&footing) {
         Ok(left) => println!(

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -10,17 +10,16 @@
 //! The steps are cumulative: each line is what the process holds once that
 //! step is done, and the difference between two lines is what the step added.
 
-use std::{env::args, path::Path, process, time::Instant};
+use std::{env::args, path::Path, process, sync::Arc, time::Instant};
 
 use toolbox_rs::{
     block_map::BlockMap,
     block_store::BlockStore,
-    border_levels::BorderLevels,
     cell_tree::CellTree,
     graph::{Arcs, NodeID},
     io,
     level_directory::LevelDirectory,
-    mld_query::MldQuery,
+    mld_query::SparseMldQuery,
     node_ordering::NodeOrdering,
     overlay::Overlay,
     packed_partition::PackedPartition,
@@ -190,8 +189,11 @@ fn main() {
     };
     at = report("the arcs, which page too", at);
 
+    // the sparse queue, since an array over the nodes of a continent is more
+    // than half of a hundred and twenty eight megabyte budget standing still
     let footing =
-        Footing::with_partition(&paged_arcs, partition.bytes() as u64, &tree, map.len(), 1);
+        Footing::with_partition(&paged_arcs, partition.bytes() as u64, &tree, map.len(), 1)
+            .with_sparse_searches();
     let (pinned, cache) = budget.split(&tree, &footing);
     match budget.for_tables(&footing) {
         Ok(left) => println!(
@@ -236,21 +238,23 @@ fn main() {
     }
     let store = BlockStore::open(Path::new(&blocks_path), map, tree).expect("a store");
     let opening = Instant::now();
-    // read back rather than walked: the levels were settled when the store was
-    // packed and working them out again means touching every arc of a graph
-    // that is on a file
-    let border_map: BlockMap = io::read_from_file(&format!("{arcs}.borders.map"));
-    let border_levels = BorderLevels::of_bytes(
-        toolbox_rs::paged_graph::read_borders(Path::new(&format!("{arcs}.borders")), &border_map)
-            .expect("the border levels"),
+    // Nothing is read for the border levels: they ride in the blocks with the
+    // arcs they belong to, so the graph is what answers for them and the same
+    // handle serves as both.
+    let held = Arc::new(paged_arcs);
+    let paged = PagedOverlay::within(
+        store,
+        Arc::clone(&held),
+        partition,
+        Arc::clone(&held),
+        budget,
     );
-    let paged = PagedOverlay::within(store, paged_arcs, partition, border_levels, budget);
     let open = opening.elapsed();
     at = report("the held levels, read and unpacked", at);
 
     // the arrays a search wants, which go with the nodes of the graph and not
     // with the budget: one query is run to make it allocate them
-    let mut query = MldQuery::new();
+    let mut query = SparseMldQuery::new();
     let mut unpacker = Unpacker::for_instance(&paged);
     if let Some(&(source, target)) = pairs.first() {
         query.run(&paged, source, &[target]);
@@ -305,7 +309,7 @@ fn main() {
     line(
         "the border levels",
         footing.border_levels,
-        "one byte an arc, read and not walked",
+        "nothing: they ride in the arc blocks",
     );
     line("the block map", map_bytes, "one entry a block");
     line("the cell tree", tree_bytes, "one entry a cell");

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -17,7 +17,7 @@ use toolbox_rs::{
     block_store::BlockStore,
     border_levels::BorderLevels,
     cell_tree::CellTree,
-    graph::{Graph, NodeID},
+    graph::{Arcs, NodeID},
     io,
     level_directory::LevelDirectory,
     mld_query::MldQuery,
@@ -122,7 +122,12 @@ fn main() {
         PackedPartition::of(&directory)
     };
     at = report("the partition, directory dropped", at);
-    let border_levels = BorderLevels::of(&graph, &partition);
+    println!(
+        "  the partition is {} runs over {} nodes, {:.1} MiB",
+        partition.runs(),
+        partition.number_of_nodes(),
+        partition.bytes() as f64 / MIB
+    );
     at = report("the border levels", at);
 
     // The pairs are translated here rather than later, and what translates them
@@ -161,8 +166,11 @@ fn main() {
     };
     // Where a pack of the arcs is at hand, the graph pages too and the footing
     // stands for its index rather than for its arcs.
-    let arcs = std::env::var("TOOLBOX_ARCS").ok();
-    let paged_arcs = arcs.as_ref().map(|at| {
+    let arcs = std::env::var("TOOLBOX_ARCS").unwrap_or_else(|_| {
+        panic!("set TOOLBOX_ARCS to a pack of arcs; this measures an instance that pages both")
+    });
+    let paged_arcs = {
+        let at = &arcs;
         let arc_map: BlockMap = io::read_from_file(&format!("{at}.map"));
         let first_edges: Vec<u64> = io::read_vec_from_file(&format!("{at}.index"));
         let room = std::env::var("TOOLBOX_ARC_BUDGET")
@@ -178,13 +186,11 @@ fn main() {
             room / (1024 * 1024)
         );
         read
-    });
-    at = report("the arcs, if they page", at);
-
-    let footing = match &paged_arcs {
-        Some(read) => Footing::with_partition(read, partition.bytes() as u64, &tree, map.len(), 1),
-        None => Footing::with_partition(&graph, partition.bytes() as u64, &tree, map.len(), 1),
     };
+    at = report("the arcs, which page too", at);
+
+    let footing =
+        Footing::with_partition(&paged_arcs, partition.bytes() as u64, &tree, map.len(), 1);
     let (pinned, cache) = budget.split(&tree, &footing);
     match budget.for_tables(&footing) {
         Ok(left) => println!(
@@ -229,7 +235,8 @@ fn main() {
     }
     let store = BlockStore::open(Path::new(&blocks_path), map, tree).expect("a store");
     let opening = Instant::now();
-    let paged = PagedOverlay::within(store, graph, partition, border_levels, budget);
+    let border_levels = BorderLevels::of(&graph, &partition);
+    let paged = PagedOverlay::within(store, paged_arcs, partition, border_levels, budget);
     let open = opening.elapsed();
     at = report("the held levels, read and unpacked", at);
 
@@ -281,18 +288,18 @@ fn main() {
     // now and both are still resident.
     let nodes = paged.graph().number_of_nodes() as u64;
     let arcs = paged.graph().number_of_edges() as u64;
+    line("the graph", footing.graph, "8 bytes an arc, 4 a node");
     line(
-        "the graph",
-        arcs * 8 + nodes * 4,
-        "8 bytes an arc, 4 a node",
+        "the partition",
+        footing.partition,
+        "a run a cell, not a word a node",
     );
-    line("the partition", nodes * 16, "one u128 a node");
     line("the border levels", nodes, "one byte a node");
     line("the block map", map_bytes, "one entry a block");
     line("the cell tree", tree_bytes, "one entry a cell");
     line("the cell tables", tables, "<- the budget governs this one");
     println!("  {:-<34} {:->13}", "", "");
-    let accounted = arcs * 8 + nodes * 21 + map_bytes + tree_bytes + tables;
+    let accounted = footing.total() - footing.searches + tables;
     line("accounted for", accounted, "");
     line("resident", full, "");
     println!(
@@ -313,8 +320,13 @@ fn main() {
         100.0 * tables as f64 / full as f64,
     );
     println!(
-        "The graph and the partition alone are {:.1} MiB, and no budget reaches them.",
-        (arcs * 8 + nodes * 20) as f64 / MIB
+        "The whole instance -- graph, partition and all -- stands in {:.1} MiB before tables.",
+        footing.total() as f64 / MIB
+    );
+    println!(
+        "It would be {:.1} MiB with the arcs held and a word a node: the arcs alone are {:.1}.",
+        (footing.total() + arcs * 8 + nodes * 4 + nodes * 16 - footing.partition) as f64 / MIB,
+        (arcs * 8 + nodes * 4) as f64 / MIB,
     );
     println!(
         "Every cell table of every level would be {:.1} MiB unpacked, so the budget holds {:.0}%.",

--- a/src/bidirectional_mld_query.rs
+++ b/src/bidirectional_mld_query.rs
@@ -31,6 +31,7 @@ use log::debug;
 
 use crate::{
     border_levels::BorderLevels,
+    border_levels::Borders,
     dense_heap::DenseHeap,
     graph::{Arcs, INVALID_NODE_ID, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
@@ -197,7 +198,6 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
         self.target_word = partition.word(target);
 
         let graph = customization.graph();
-        let borders = customization.border_levels();
         self.forward.insert(source, 0, source);
         self.backward.insert(target, 0, target);
 
@@ -252,7 +252,14 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
                     }
                     match side {
                         Side::Forward => {
-                            self.relax_out_of_cell(graph, borders, side, u, distance, level);
+                            self.relax_out_of_cell(
+                                graph,
+                                customization.borders(),
+                                side,
+                                u,
+                                distance,
+                                level,
+                            );
                         }
                         Side::Backward => {
                             self.relax_out_of_cell(
@@ -328,10 +335,10 @@ impl<S: HeapStats<NodeID>> BidirectionalMldSearch<S> {
     /// The arcs of the graph that leave the cell, which is how a search gets
     /// out of one.
     #[inline(never)]
-    fn relax_out_of_cell<G: Arcs<u32>>(
+    fn relax_out_of_cell<G: Arcs<u32>, B: Borders>(
         &mut self,
         graph: &G,
-        borders: &BorderLevels,
+        borders: &B,
         side: Side,
         node: NodeID,
         distance: usize,

--- a/src/border_levels.rs
+++ b/src/border_levels.rs
@@ -39,6 +39,24 @@ use crate::{
     packed_partition::PackedPartition,
 };
 
+/// What a search asks about an arc's cell.
+///
+/// # Why this is a trait
+///
+/// An instance holding its graph keeps a byte an arc beside it. One that pages
+/// its arcs does not: the level rides in the block with the arc it belongs to
+/// and is read when the arc is, because a byte an arc standing resident is
+/// forty megabytes of a continent to say what three bits an arc say there.
+///
+/// A search should not care which it is talking to, and the backward side of a
+/// bidirectional search has its own -- the arcs of a network turned around
+/// leave the same cells but are numbered differently -- so it is asked for
+/// alongside the graph rather than taken off the overlay.
+pub trait Borders {
+    /// Whether this arc leaves the cell its source sits in at this level.
+    fn leaves_cell(&self, edge: EdgeID, level: usize) -> bool;
+}
+
 /// An arc whose ends never part, which leaves no cell on any level.
 const STAYS_INSIDE: u8 = 0;
 
@@ -138,6 +156,13 @@ impl BorderLevels {
             STAYS_INSIDE => None,
             held => Some(usize::from(held) - 1),
         }
+    }
+}
+
+impl Borders for BorderLevels {
+    #[inline]
+    fn leaves_cell(&self, edge: EdgeID, level: usize) -> bool {
+        BorderLevels::leaves_cell(self, edge, level)
     }
 }
 

--- a/src/border_levels.rs
+++ b/src/border_levels.rs
@@ -103,6 +103,29 @@ impl BorderLevels {
         usize::from(self.of_edge[edge]) > level
     }
 
+    /// The bytes themselves, one an arc, for writing into a store.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.of_edge
+    }
+
+    /// Takes back what [`as_bytes`](Self::as_bytes) wrote.
+    ///
+    /// This is what an instance does instead of working the levels out: they
+    /// are settled once when the store is packed and do not change again, and
+    /// working them out means walking every arc of the graph, which is the one
+    /// thing a store that pages its arcs was built not to do.
+    #[must_use]
+    pub fn of_bytes(of_edge: Vec<u8>) -> Self {
+        Self { of_edge }
+    }
+
+    /// What this takes: a byte an arc.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.of_edge.capacity()
+    }
+
     /// The highest level at which the arc leaves a cell, and `None` for one
     /// whose ends sit in the same cell on every level.
     ///

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -1073,8 +1073,9 @@ impl Overlay for Customization {
         Customization::partition(self)
     }
 
-    #[inline]
-    fn border_levels(&self) -> &BorderLevels {
+    type Borders = BorderLevels;
+
+    fn borders(&self) -> &Self::Borders {
         Customization::border_levels(self)
     }
 

--- a/src/dense_heap.rs
+++ b/src/dense_heap.rs
@@ -215,6 +215,37 @@ const NOWHERE: u32 = MISSING;
 /// holding a plain table, with nothing for the compiler to see through. Whether
 /// that is worth the loss of tidiness is a question for a measurement, not for
 /// an opinion -- see the note on the two queues below.
+/// What a search asks of its queue.
+///
+/// # Why there is a choice at all
+///
+/// The two queues below differ in one thing: where a node's place and weight
+/// are kept. An array over the nodes of the graph answers in one look and
+/// costs four bytes a node whether the run reaches it or not; a map costs a
+/// hash on every look and only room for what the run touched.
+///
+/// On a continent that is sixty eight mebibytes standing whether anybody is
+/// searching or not, against a few for what a query actually walks. A server
+/// with room to spare should take the array. An instance on a device with a
+/// budget for the whole of it cannot, and this is what lets the same search
+/// run over either.
+pub trait Queue<S: HeapStats<NodeID>> {
+    fn new() -> Self;
+    fn stats(&self) -> &S;
+    fn bytes(&self) -> usize;
+    fn clear(&mut self);
+    fn is_empty(&self) -> bool;
+    fn inserted_len(&self) -> usize;
+    fn inserted(&self, node: NodeID) -> bool;
+    fn contains(&self, node: NodeID) -> bool;
+    fn weight(&self, node: NodeID) -> usize;
+    fn data(&self, node: NodeID) -> NodeID;
+    fn insert(&mut self, node: NodeID, weight: usize, data: NodeID);
+    fn insert_or_decrease(&mut self, node: NodeID, weight: usize, data: NodeID) -> bool;
+    fn min_weight(&self) -> usize;
+    fn delete_min(&mut self) -> NodeID;
+}
+
 macro_rules! query_heap {
     ($name:ident, $table:ty, $what:literal) => {
         #[doc = $what]
@@ -477,6 +508,56 @@ macro_rules! query_heap {
     };
 }
 
+/// Answers [`Queue`] with what the queue already has.
+macro_rules! queue_impl {
+    ($name:ident) => {
+        impl<S: HeapStats<NodeID>> Queue<S> for $name<S> {
+            fn new() -> Self {
+                Self::new()
+            }
+            fn stats(&self) -> &S {
+                Self::stats(self)
+            }
+            fn bytes(&self) -> usize {
+                Self::bytes(self)
+            }
+            fn clear(&mut self) {
+                Self::clear(self);
+            }
+            fn is_empty(&self) -> bool {
+                Self::is_empty(self)
+            }
+            fn inserted_len(&self) -> usize {
+                Self::inserted_len(self)
+            }
+            fn inserted(&self, node: NodeID) -> bool {
+                Self::inserted(self, node)
+            }
+            fn contains(&self, node: NodeID) -> bool {
+                Self::contains(self, node)
+            }
+            fn weight(&self, node: NodeID) -> usize {
+                Self::weight(self, node)
+            }
+            fn data(&self, node: NodeID) -> NodeID {
+                Self::data(self, node)
+            }
+            fn insert(&mut self, node: NodeID, weight: usize, data: NodeID) {
+                Self::insert(self, node, weight, data);
+            }
+            fn insert_or_decrease(&mut self, node: NodeID, weight: usize, data: NodeID) -> bool {
+                Self::insert_or_decrease(self, node, weight, data)
+            }
+            fn min_weight(&self) -> usize {
+                Self::min_weight(self)
+            }
+            fn delete_min(&mut self) -> NodeID {
+                Self::delete_min(self)
+            }
+        }
+    };
+}
+
 query_heap!(
     DenseHeap,
     ByArray,
@@ -489,6 +570,9 @@ query_heap!(
     "A queue that finds a node in a map, at the price of a hash on every look \
      and only room for what a run reached."
 );
+
+queue_impl!(DenseHeap);
+queue_impl!(HashHeap);
 
 #[cfg(test)]
 mod tests {

--- a/src/graph_block.rs
+++ b/src/graph_block.rs
@@ -75,7 +75,9 @@ pub struct GraphBlock {
     degree_bits: u32,
     step_bits: u32,
     weight_bits: u32,
-    /// the degrees, then the zigzagged steps, then the weights
+    border_bits: u32,
+    /// the degrees, then the zigzagged steps, then the weights, then the
+    /// levels at which each arc leaves the cell of its source
     packed: Vec<u8>,
 }
 
@@ -83,14 +85,22 @@ impl GraphBlock {
     /// Packs the arcs of a run of nodes.
     ///
     /// `arcs` is one entry a node, in node order, each the arcs of that node as
-    /// (target, weight).
+    /// (target, weight, border level).
+    ///
+    /// The border level is one past the highest level at which the arc leaves
+    /// the cell of its source, and zero for one that leaves none -- the same
+    /// byte [`BorderLevels`](crate::border_levels::BorderLevels) holds. It
+    /// rides with the arc because that is what it is a property of, and
+    /// because a search wants it at exactly the moment it has the arc: kept
+    /// apart it is a byte an arc standing resident, which on a continent is
+    /// forty megabytes to say what three bits an arc say here.
     ///
     /// # Panics
     ///
     /// Panics where a step does not fit in sixty three bits, which no graph
     /// this crate can hold produces.
     #[must_use]
-    pub fn of(first_node: u32, first_edge: u64, arcs: &[Vec<(u32, u32)>]) -> Self {
+    pub fn of(first_node: u32, first_edge: u64, arcs: &[Vec<(u32, u32, u8)>]) -> Self {
         let edges: usize = arcs.iter().map(Vec::len).sum();
         let widest_degree = arcs.iter().map(Vec::len).max().unwrap_or(0);
         let widest_step = arcs
@@ -99,21 +109,28 @@ impl GraphBlock {
             .flat_map(|(at, out)| {
                 let source = i64::from(first_node) + at as i64;
                 out.iter()
-                    .map(move |&(target, _)| zigzag(i64::from(target) - source))
+                    .map(move |&(target, _, _)| zigzag(i64::from(target) - source))
             })
             .max()
             .unwrap_or(0);
         let widest_weight = arcs
             .iter()
-            .flat_map(|out| out.iter().map(|&(_, weight)| weight))
+            .flat_map(|out| out.iter().map(|&(_, weight, _)| weight))
+            .max()
+            .unwrap_or(0);
+        let widest_border = arcs
+            .iter()
+            .flat_map(|out| out.iter().map(|&(_, _, border)| u32::from(border)))
             .max()
             .unwrap_or(0);
 
         let degree_bits = bits_for(u32::try_from(widest_degree).expect("a degree in four bytes"));
         let step_bits = bits_for_wide(widest_step);
         let weight_bits = bits_for(widest_weight);
+        let border_bits = bits_for(widest_border);
 
-        let bits = arcs.len() * degree_bits as usize + edges * (step_bits + weight_bits) as usize;
+        let bits = arcs.len() * degree_bits as usize
+            + edges * (step_bits + weight_bits + border_bits) as usize;
         let mut packed = vec![0_u8; bits.div_ceil(8) + 8];
 
         let mut at = 0;
@@ -128,7 +145,7 @@ impl GraphBlock {
         }
         for (index, out) in arcs.iter().enumerate() {
             let source = i64::from(first_node) + index as i64;
-            for &(target, _) in out {
+            for &(target, _, _) in out {
                 write_wide(
                     &mut packed,
                     at,
@@ -139,9 +156,15 @@ impl GraphBlock {
             }
         }
         for out in arcs {
-            for &(_, weight) in out {
+            for &(_, weight, _) in out {
                 write_at(&mut packed, at, weight_bits, weight);
                 at += weight_bits as usize;
+            }
+        }
+        for out in arcs {
+            for &(_, _, border) in out {
+                write_at(&mut packed, at, border_bits, u32::from(border));
+                at += border_bits as usize;
             }
         }
 
@@ -154,6 +177,7 @@ impl GraphBlock {
             degree_bits,
             step_bits,
             weight_bits,
+            border_bits,
             packed,
         }
     }
@@ -238,6 +262,20 @@ impl GraphBlock {
                 self.weight_bits,
             ));
         }
+
+        held.borders.clear();
+        held.borders.reserve(self.edges as usize);
+        let borders_at = weights_at + self.edges as usize * self.weight_bits as usize;
+        for place in 0..self.edges as usize {
+            held.borders.push(
+                u8::try_from(read_at(
+                    &self.packed,
+                    borders_at + place * self.border_bits as usize,
+                    self.border_bits,
+                ))
+                .expect("a level in a byte"),
+            );
+        }
     }
 
     /// What the block takes once read back.
@@ -302,6 +340,9 @@ pub struct HeldArcs {
     starts: Vec<u32>,
     targets: Vec<u32>,
     weights: Vec<u32>,
+    /// one past the highest level each arc leaves its source's cell at, and
+    /// zero for one that leaves none
+    borders: Vec<u8>,
 }
 
 impl HeldArcs {
@@ -362,6 +403,16 @@ impl HeldArcs {
             .then(|| self.weights[(edge - self.first_edge) as usize])
     }
 
+    /// Whether an arc leaves the cell its source sits in at this level.
+    ///
+    /// Cells nest, so an arc parting at some level parts at every level below
+    /// it and one comparison answers for the level asked about.
+    #[must_use]
+    pub fn leaves_cell(&self, edge: u64, level: usize) -> Option<bool> {
+        self.holds_edge(edge)
+            .then(|| usize::from(self.borders[(edge - self.first_edge) as usize]) > level)
+    }
+
     /// What this takes.
     #[must_use]
     pub fn bytes(&self) -> usize {
@@ -369,6 +420,7 @@ impl HeldArcs {
             + self.starts.capacity() * size_of::<u32>()
             + self.targets.capacity() * size_of::<u32>()
             + self.weights.capacity() * size_of::<u32>()
+            + self.borders.capacity()
     }
 }
 
@@ -378,17 +430,22 @@ mod tests {
 
     /// Arcs with steps both ways and a wide spread, since the whole of the
     /// packing rests on a step being small and it has to hold when one is not.
-    fn arcs(first_node: u32, nodes: usize) -> Vec<Vec<(u32, u32)>> {
+    fn arcs(first_node: u32, nodes: usize) -> Vec<Vec<(u32, u32, u8)>> {
         (0..nodes)
             .map(|at| {
                 let source = first_node + at as u32;
+                // a border level apiece, some staying inside and some not
                 let mut out = vec![
-                    (source + 1, 10 + at as u32),
-                    (source.saturating_sub(1), 20 + at as u32),
+                    (source + 1, 10 + at as u32, (at % 4) as u8),
+                    (
+                        source.saturating_sub(1),
+                        20 + at as u32,
+                        ((at + 1) % 3) as u8,
+                    ),
                 ];
                 // one arc a long way off, which is what sets the block's width
                 if at == nodes / 2 {
-                    out.push((source + 100_000, 7));
+                    out.push((source + 100_000, 7, 5));
                 }
                 // and a node with nothing leaving it
                 if at == 1 {
@@ -426,9 +483,18 @@ mod tests {
             let (from, upto) = held.range_of(node);
             assert_eq!(from, edge, "node {node} begins elsewhere");
             assert_eq!((upto - from) as usize, wanted.len(), "node {node} degree");
-            for &(target, weight) in wanted {
+            for &(target, weight, border) in wanted {
                 assert_eq!(held.target(edge), Some(target as NodeID));
                 assert_eq!(held.weight(edge), Some(weight));
+                // the level rides with the arc: it parts at every level under
+                // the one it was given, and at none from there up
+                for level in 0..8 {
+                    assert_eq!(
+                        held.leaves_cell(edge, level),
+                        Some(usize::from(border) > level),
+                        "arc {edge} at level {level}"
+                    );
+                }
                 edge += 1;
             }
         }
@@ -448,7 +514,7 @@ mod tests {
 
     #[test]
     fn a_run_of_nothing_packs_and_reads_back_as_nothing() {
-        let block = GraphBlock::of(7, 21, &vec![Vec::new(); 4]);
+        let block = GraphBlock::of(7, 21, &vec![Vec::<(u32, u32, u8)>::new(); 4]);
         let mut held = HeldArcs::default();
         block.unpack_into(&mut held);
         assert_eq!(held.nodes(), 4);
@@ -462,11 +528,16 @@ mod tests {
     /// fewer bits than the node numbers themselves want.
     #[test]
     fn arcs_that_stay_near_home_pack_smaller_than_their_node_numbers() {
-        let near: Vec<Vec<(u32, u32)>> = (0..256)
-            .map(|at| vec![(9_000_000 + at + 1, 5), (9_000_000 + at + 2, 5)])
+        let near: Vec<Vec<(u32, u32, u8)>> = (0..256)
+            .map(|at| vec![(9_000_000 + at + 1, 5, 1), (9_000_000 + at + 2, 5, 1)])
             .collect();
-        let far: Vec<Vec<(u32, u32)>> = (0..256)
-            .map(|at| vec![(at * 70_001 % 17_000_000, 5), (at * 31 % 17_000_000, 5)])
+        let far: Vec<Vec<(u32, u32, u8)>> = (0..256)
+            .map(|at| {
+                vec![
+                    (at * 70_001 % 17_000_000, 5, 1),
+                    (at * 31 % 17_000_000, 5, 1),
+                ]
+            })
             .collect();
         let near = GraphBlock::of(9_000_000, 0, &near);
         let far = GraphBlock::of(9_000_000, 0, &far);

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -33,8 +33,8 @@ use log::debug;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    border_levels::BorderLevels,
-    dense_heap::DenseHeap,
+    border_levels::Borders,
+    dense_heap::{DenseHeap, HashHeap, Queue},
     graph::{Arcs, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
     overlay::{CellTable, Overlay},
@@ -43,13 +43,25 @@ use crate::{
 
 /// A query that counts nothing, which is what a run whose time is being taken
 /// wants.
-pub type MldQuery = MldSearch<Untracked>;
+/// The search with the queue that finds a node in an array: one look, and room
+/// for every node of the graph whether the run reaches it or not.
+pub type MldQuery = MldSearch<Untracked, DenseHeap<Untracked>>;
+
+/// The same search with the queue that finds a node in a map: a hash on every
+/// look, and room only for what the run touched.
+///
+/// This is what an instance with a budget for the whole of it runs. On a
+/// continent the array costs sixty eight mebibytes standing still, which is
+/// half of a hundred and twenty eight megabyte budget spent before a single
+/// arc or table is read.
+pub type SparseMldQuery = MldSearch<Untracked, HashHeap<Untracked>>;
 
 /// The same query, counting what its queue did.
-pub type TrackedMldQuery = MldSearch<Counters>;
+pub type TrackedMldQuery = MldSearch<Counters, DenseHeap<Counters>>;
 
-pub struct MldSearch<S: HeapStats<NodeID>> {
-    queue: DenseHeap<S>,
+pub struct MldSearch<S: HeapStats<NodeID>, Q: Queue<S> = DenseHeap<S>> {
+    queue: Q,
+    holds: std::marker::PhantomData<S>,
     /// Which cells hold a target, every level in one run of memory with
     /// `holds_target_at` saying where each of them starts.
     ///
@@ -78,17 +90,18 @@ pub struct MldSearch<S: HeapStats<NodeID>> {
     reached_target_count: usize,
 }
 
-impl<S: HeapStats<NodeID>> Default for MldSearch<S> {
+impl<S: HeapStats<NodeID>, Q: Queue<S>> Default for MldSearch<S, Q> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<S: HeapStats<NodeID>> MldSearch<S> {
+impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            queue: DenseHeap::<S>::new(),
+            queue: Q::new(),
+            holds: std::marker::PhantomData,
             holds_target: Vec::new(),
             holds_target_at: Vec::new(),
             marked: Vec::new(),
@@ -232,7 +245,6 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
         self.source_word = partition.word(source);
 
         let graph = customization.graph();
-        let borders = customization.border_levels();
         self.queue.insert(source, 0, source);
 
         while !self.queue.is_empty() && self.reached_target_count < self.targets.len() {
@@ -267,7 +279,7 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
                     {
                         self.relax_across_cell(customization, partition, u, distance, level);
                     }
-                    self.relax_out_of_cell(graph, borders, u, distance, level);
+                    self.relax_out_of_cell(graph, customization.borders(), u, distance, level);
                 }
                 None => self.relax_every_arc(graph, u, distance),
             }
@@ -329,10 +341,10 @@ impl<S: HeapStats<NodeID>> MldSearch<S> {
     /// The arcs of the graph that leave the cell, which is how the search gets
     /// out of one.
     #[inline(never)]
-    fn relax_out_of_cell<G: Arcs<u32>>(
+    fn relax_out_of_cell<G: Arcs<u32>, B: Borders>(
         &mut self,
         graph: &G,
-        borders: &BorderLevels,
+        borders: &B,
         node: NodeID,
         distance: usize,
         level: usize,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -27,7 +27,7 @@
 //! What the search wants is the answer, and both can give it.
 
 use crate::{
-    border_levels::BorderLevels,
+    border_levels::Borders,
     graph::{Arcs, NodeID},
     level_directory::CellId,
     packed_partition::PackedPartition,
@@ -74,7 +74,11 @@ pub trait Overlay {
 
     /// The level at which each arc leaves a cell, which is how a search knows
     /// an arc is worth taking without asking the partition about both ends.
-    fn border_levels(&self) -> &BorderLevels;
+    /// What says whether an arc leaves its source's cell: a byte an arc where
+    /// the instance keeps one, and the graph itself where the arcs carry it.
+    type Borders: Borders;
+
+    fn borders(&self) -> &Self::Borders;
 
     fn levels(&self) -> usize;
 
@@ -146,8 +150,10 @@ mod tests {
         fn partition(&self) -> &PackedPartition {
             Overlay::partition(&self.held)
         }
-        fn border_levels(&self) -> &BorderLevels {
-            Overlay::border_levels(&self.held)
+        type Borders = crate::border_levels::BorderLevels;
+
+        fn borders(&self) -> &Self::Borders {
+            Overlay::borders(&self.held)
         }
         fn levels(&self) -> usize {
             Overlay::levels(&self.held)

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -39,9 +39,79 @@ use crate::{
 /// How many bits a word has to spend, and the most a partition may ask for.
 const BITS: u32 = 128;
 
+/// Room past the last word, so a read of a whole word from the last one does
+/// not run off the end and does not have to be checked for.
+const SPILL: usize = 32;
+
+/// Puts a word down at a bit offset.
+fn write_word(packed: &mut [u8], at: u64, width: u32, value: u128) {
+    let byte = (at / 8) as usize;
+    let shift = (at % 8) as u32;
+    let mask = if width >= BITS {
+        u128::MAX
+    } else {
+        (1_u128 << width) - 1
+    };
+    let value = value & mask;
+
+    // the word straddles at most seventeen bytes, which two overlapping
+    // sixteen byte reads cover
+    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
+    let laid = low | (value << shift);
+    packed[byte..byte + 16].copy_from_slice(&laid.to_le_bytes());
+    if shift > 0 {
+        let over = value >> (BITS - shift);
+        if over != 0 {
+            let high = u128::from_le_bytes(
+                packed[byte + 16..byte + 32]
+                    .try_into()
+                    .expect("sixteen bytes"),
+            );
+            packed[byte + 16..byte + 32].copy_from_slice(&(high | over).to_le_bytes());
+        }
+    }
+}
+
+/// Picks a word back up from a bit offset.
+#[inline]
+fn read_word(packed: &[u8], at: u64, width: u32) -> u128 {
+    let byte = (at / 8) as usize;
+    let shift = (at % 8) as u32;
+    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
+    let mut held = low >> shift;
+    if shift > 0 {
+        let high = u128::from_le_bytes(
+            packed[byte + 16..byte + 32]
+                .try_into()
+                .expect("sixteen bytes"),
+        );
+        held |= high << (BITS - shift);
+    }
+    if width >= BITS {
+        held
+    } else {
+        held & ((1_u128 << width) - 1)
+    }
+}
+
 /// The cell each node sits in on every level, one word apiece.
+///
+/// # The word is as wide as it needs to be and no wider
+///
+/// A word is read and written as a `u128`, because that is what the shifting
+/// and the exclusive or want it to be. It is *stored* in the bits the levels
+/// actually ask for, which on a continent cut into six is seventy six of the
+/// hundred and twenty eight. Keeping the other fifty two would cost a hundred
+/// and twelve mebibytes of a continent to say nothing at all.
+///
+/// What a caller sees is unchanged: [`word`](Self::word) hands back the same
+/// number it always did, and everything else is written on that.
 pub struct PackedPartition {
-    of_node: Vec<u128>,
+    /// the words, laid end to end at `width` bits apiece
+    packed: Vec<u8>,
+    /// how many bits a word is stored in
+    width: u32,
+    nodes: usize,
     /// where the cell id of each level begins in the word, and one past the
     /// end of the topmost level in the last entry
     begins_at: Vec<u32>,
@@ -93,28 +163,34 @@ impl PackedPartition {
             level_of_bit[bit as usize] = u8::try_from(levels.saturating_sub(1)).unwrap_or(u8::MAX);
         }
 
-        // The cells of a level are read off the level below it rather than
-        // asked of the directory per node, which would walk the parents of
-        // every node once for every level above it.
-        let mut of_node = vec![0_u128; nodes];
-        let mut cell_of_node = (0..nodes)
-            .map(|node| directory.cell_of(node, 0))
-            .collect::<Vec<_>>();
-        for (node, &cell) in cell_of_node.iter().enumerate() {
-            of_node[node] |= u128::from(cell) << begins_at[0];
-        }
-        for (level, &begins) in begins_at.iter().enumerate().take(levels).skip(1) {
-            let parents = directory.parents_on_level(level - 1);
-            for cell in &mut cell_of_node {
-                *cell = parents[*cell as usize];
+        // A word is built and laid down a node at a time, walking the parents
+        // up from the cell it is in at the finest level. The other way round --
+        // a level at a time over every node -- reads better and costs a vector
+        // of whole words the length of the graph to hold what is half built,
+        // which on a continent is more than the packing saves. The parents are
+        // a few hundred thousand entries and stay in cache; the nodes are
+        // millions and are touched once each.
+        let parents: Vec<&[CellId]> = (0..levels.saturating_sub(1))
+            .map(|level| directory.parents_on_level(level))
+            .collect();
+
+        let width = at.max(1);
+        // room to read a whole word past the last one without a bounds check
+        let mut packed = vec![0_u8; (nodes as u64 * u64::from(width)).div_ceil(8) as usize + SPILL];
+        for node in 0..nodes {
+            let mut cell = directory.cell_of(node, 0);
+            let mut word = u128::from(cell) << begins_at[0];
+            for (level, &begins) in begins_at.iter().enumerate().take(levels).skip(1) {
+                cell = parents[level - 1][cell as usize];
+                word |= u128::from(cell) << begins;
             }
-            for (node, &cell) in cell_of_node.iter().enumerate() {
-                of_node[node] |= u128::from(cell) << begins;
-            }
+            write_word(&mut packed, node as u64 * u64::from(width), width, word);
         }
 
         Self {
-            of_node,
+            packed,
+            width,
+            nodes,
             begins_at,
             level_of_bit,
             levels,
@@ -141,7 +217,20 @@ impl PackedPartition {
     /// how many nodes it was built over
     #[must_use]
     pub fn number_of_nodes(&self) -> usize {
-        self.of_node.len()
+        self.nodes
+    }
+
+    /// What the partition takes, which is the bits the levels asked for and
+    /// not a word a node.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.packed.capacity() + self.level_of_bit.capacity() + self.begins_at.capacity() * 4
+    }
+
+    /// How many bits a word is stored in.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
     }
 
     /// The cells of every level this node sits in, as the one word a caller
@@ -153,7 +242,12 @@ impl PackedPartition {
     #[must_use]
     #[inline]
     pub fn word(&self, node: NodeID) -> u128 {
-        self.of_node[node]
+        assert!(node < self.nodes, "no node {node} in the partition");
+        read_word(
+            &self.packed,
+            node as u64 * u64::from(self.width),
+            self.width,
+        )
     }
 
     /// The cell a node sits in on a level.
@@ -237,6 +331,66 @@ fn bits_for(cells: usize) -> u32 {
 mod tests {
     use super::*;
     use crate::{grid_graph::grid_directory, level_directory::LevelDirectory};
+
+    /// The point of storing at the width the levels ask for: a partition that
+    /// spends a fraction of a word takes a fraction of one.
+    #[test]
+    fn a_partition_takes_the_bits_its_levels_ask_for_and_no_more() {
+        let directory = grid_directory(64);
+        let packed = PackedPartition::of(&directory);
+        let nodes = directory.number_of_nodes();
+
+        let width = packed.width();
+        assert!(width < BITS, "the levels asked for a whole word");
+        assert_eq!(
+            width,
+            *packed.level_layout().last().expect("a layout"),
+            "the width is where the topmost level ends"
+        );
+
+        let whole = nodes * size_of::<u128>();
+        assert!(
+            packed.bytes() < whole,
+            "packed {} bytes against {whole} held whole",
+            packed.bytes()
+        );
+        // and it is about the share of a word the levels actually use
+        let wanted = (nodes as u64 * u64::from(width)).div_ceil(8) as usize;
+        assert!(
+            packed.bytes() >= wanted && packed.bytes() < wanted + SPILL + 4096,
+            "packed {} bytes, wanted about {wanted}",
+            packed.bytes()
+        );
+    }
+
+    /// Every word read back is the word laid down, at every offset a node
+    /// falls on: a width that is not a multiple of eight puts a word across a
+    /// byte boundary in a different place for every node in a run of eight.
+    #[test]
+    fn every_word_reads_back_whatever_the_width_puts_it_across() {
+        for width in [1_u32, 3, 7, 8, 17, 33, 64, 76, 100, 127, 128] {
+            let mask = if width >= BITS {
+                u128::MAX
+            } else {
+                (1_u128 << width) - 1
+            };
+            let words: Vec<u128> = (0..64_u128)
+                .map(|at| (at * 0x9E37_79B9_7F4A_7C15).wrapping_mul(0x1234_5678_9ABC_DEF1) & mask)
+                .collect();
+            let mut packed =
+                vec![0_u8; (words.len() as u64 * u64::from(width)).div_ceil(8) as usize + SPILL];
+            for (at, &word) in words.iter().enumerate() {
+                write_word(&mut packed, at as u64 * u64::from(width), width, word);
+            }
+            for (at, &word) in words.iter().enumerate() {
+                assert_eq!(
+                    read_word(&packed, at as u64 * u64::from(width), width),
+                    word,
+                    "word {at} at width {width}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn a_level_is_given_room_for_the_ids_it_holds() {

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -31,6 +31,11 @@
 //! actually are. This is what OSRM's `MultiLevelPartition` does with a
 //! `GetHighestDifferentLevel` over sixty four bits.
 
+use std::{
+    cell::Cell,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
 use crate::{
     graph::NodeID,
     level_directory::{CellId, LevelDirectory},
@@ -39,79 +44,97 @@ use crate::{
 /// How many bits a word has to spend, and the most a partition may ask for.
 const BITS: u32 = 128;
 
-/// Room past the last word, so a read of a whole word from the last one does
-/// not run off the end and does not have to be checked for.
-const SPILL: usize = 32;
+/// Tells one partition from another, so a thread's memo of the last run it
+/// wanted is not offered to a partition it did not come from.
+static NEXT_PARTITION: AtomicUsize = AtomicUsize::new(0);
 
-/// Puts a word down at a bit offset.
-fn write_word(packed: &mut [u8], at: u64, width: u32, value: u128) {
-    let byte = (at / 8) as usize;
-    let shift = (at % 8) as u32;
-    let mask = if width >= BITS {
-        u128::MAX
-    } else {
-        (1_u128 << width) - 1
-    };
-    let value = value & mask;
-
-    // the word straddles at most seventeen bytes, which two overlapping
-    // sixteen byte reads cover
-    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
-    let laid = low | (value << shift);
-    packed[byte..byte + 16].copy_from_slice(&laid.to_le_bytes());
-    if shift > 0 {
-        let over = value >> (BITS - shift);
-        if over != 0 {
-            let high = u128::from_le_bytes(
-                packed[byte + 16..byte + 32]
-                    .try_into()
-                    .expect("sixteen bytes"),
-            );
-            packed[byte + 16..byte + 32].copy_from_slice(&(high | over).to_le_bytes());
-        }
-    }
+thread_local! {
+    /// The last run this thread wanted, and whose partition it belongs to.
+    ///
+    /// A search settles a node and then another, and the nodes of a cell are a
+    /// run, so the two are usually in the same one. This is only a shortcut:
+    /// where it holds nothing, or another partition's run, the search is done.
+    static RECENT: Cell<Option<(usize, u32, u32, u128)>> = const { Cell::new(None) };
 }
 
-/// Picks a word back up from a bit offset.
-#[inline]
-fn read_word(packed: &[u8], at: u64, width: u32) -> u128 {
-    let byte = (at / 8) as usize;
-    let shift = (at % 8) as u32;
-    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
-    let mut held = low >> shift;
-    if shift > 0 {
-        let high = u128::from_le_bytes(
-            packed[byte + 16..byte + 32]
-                .try_into()
-                .expect("sixteen bytes"),
-        );
-        held |= high << (BITS - shift);
+/// Writes a sorted run of entries down in Eytzinger order.
+///
+/// Walked in order, `k`, `2k`, `2k + 1` visits the entries smallest first, so
+/// filling them in that order puts each where a search will look for it.
+fn lay_out(
+    k: usize,
+    runs: usize,
+    at: &mut usize,
+    from: &[(u32, u32, u128)],
+    begins: &mut [u32],
+    ends: &mut [u32],
+    words: &mut [u128],
+) {
+    if k > runs {
+        return;
     }
-    if width >= BITS {
-        held
-    } else {
-        held & ((1_u128 << width) - 1)
-    }
+    lay_out(2 * k, runs, at, from, begins, ends, words);
+    let (first, upto, word) = from[*at];
+    begins[k] = first;
+    ends[k] = upto;
+    words[k] = word;
+    *at += 1;
+    lay_out(2 * k + 1, runs, at, from, begins, ends, words);
 }
 
-/// The cell each node sits in on every level, one word apiece.
+/// The cell each node sits in on every level.
 ///
-/// # The word is as wide as it needs to be and no wider
+/// # One entry a cell, not a word a node
 ///
-/// A word is read and written as a `u128`, because that is what the shifting
-/// and the exclusive or want it to be. It is *stored* in the bits the levels
-/// actually ask for, which on a continent cut into six is seventy six of the
-/// hundred and twenty eight. Keeping the other fifty two would cost a hundred
-/// and twelve mebibytes of a continent to say nothing at all.
+/// Every node of a cell of the finest level is in that cell, and so in its
+/// parent, and in its parent's parent: the whole word is the same for all of
+/// them. The nodes were renumbered so that a cell's nodes are a run, which is
+/// what let a cell table be found by a range and a block of arcs be keyed by
+/// one. It does the same thing here: the words come in runs, and a run is
+/// worth storing once.
 ///
-/// What a caller sees is unchanged: [`word`](Self::word) hands back the same
-/// number it always did, and everything else is written on that.
+/// On a continent that is six hundred thousand runs against eighteen million
+/// nodes. A partition that took a hundred and sixty three mebibytes takes
+/// fourteen.
+///
+/// Where the numbering is *not* in cell order this still holds -- a run is
+/// ended wherever the word changes, and in the worst case there is one a node,
+/// which is what the old layout was. It costs correctness nothing and saves
+/// nothing.
+///
+/// # Why the runs are laid out the way they are
+///
+/// A node is turned back into its run by looking for the last run that begins
+/// at or before it, which is a binary search. Laid out in order, that search
+/// touches a different cache line at every step and the last few steps are the
+/// only ones that were ever going to be near each other.
+///
+/// So they are laid out in Eytzinger order instead: the array is the binary
+/// search tree written down breadth first, so the root is first, its two
+/// children next to each other after it, their four children after those. The
+/// steps a search takes are `k`, `2k`, `4k` -- reads that walk forward through
+/// memory rather than halving their way across it, and the first several steps
+/// share a cache line.
+///
+/// # And most searches do not happen
+///
+/// A search settles a node and then another, and the nodes of a cell are a
+/// run, so the next node is very often in the run just used. Each thread keeps
+/// the last run it wanted, which turns the common case into two comparisons.
 pub struct PackedPartition {
-    /// the words, laid end to end at `width` bits apiece
-    packed: Vec<u8>,
-    /// how many bits a word is stored in
-    width: u32,
+    /// where each run begins and ends, and the word every node of it has, all
+    /// three in Eytzinger order and all three one based: entry zero is unused
+    /// so that the children of `k` are `2k` and `2k + 1`
+    begins: Vec<u32>,
+    ends: Vec<u32>,
+    words: Vec<u128>,
+    /// how many runs there are
+    runs: usize,
     nodes: usize,
+    /// how many bits of a word the levels asked for
+    width: u32,
+    /// which partition this is, for the thread's memo
+    which: usize,
     /// where the cell id of each level begins in the word, and one past the
     /// end of the topmost level in the last entry
     begins_at: Vec<u32>,
@@ -163,34 +186,59 @@ impl PackedPartition {
             level_of_bit[bit as usize] = u8::try_from(levels.saturating_sub(1)).unwrap_or(u8::MAX);
         }
 
-        // A word is built and laid down a node at a time, walking the parents
-        // up from the cell it is in at the finest level. The other way round --
-        // a level at a time over every node -- reads better and costs a vector
-        // of whole words the length of the graph to hold what is half built,
-        // which on a continent is more than the packing saves. The parents are
-        // a few hundred thousand entries and stay in cache; the nodes are
-        // millions and are touched once each.
+        // A word is built a node at a time, walking the parents up from the
+        // cell it is in at the finest level, and kept only where it differs
+        // from the one before: every node of a cell has the same word, so what
+        // this writes down is a run a cell rather than a word a node.
         let parents: Vec<&[CellId]> = (0..levels.saturating_sub(1))
             .map(|level| directory.parents_on_level(level))
             .collect();
 
-        let width = at.max(1);
-        // room to read a whole word past the last one without a bounds check
-        let mut packed = vec![0_u8; (nodes as u64 * u64::from(width)).div_ceil(8) as usize + SPILL];
-        for node in 0..nodes {
+        let word_of = |node: NodeID| -> u128 {
             let mut cell = directory.cell_of(node, 0);
             let mut word = u128::from(cell) << begins_at[0];
             for (level, &begins) in begins_at.iter().enumerate().take(levels).skip(1) {
                 cell = parents[level - 1][cell as usize];
                 word |= u128::from(cell) << begins;
             }
-            write_word(&mut packed, node as u64 * u64::from(width), width, word);
+            word
+        };
+
+        let mut sorted: Vec<(u32, u32, u128)> = Vec::new();
+        for node in 0..nodes {
+            let word = word_of(node);
+            let at = u32::try_from(node).expect("a node in four bytes");
+            match sorted.last_mut() {
+                Some((_, upto, held)) if *held == word => *upto = at + 1,
+                _ => sorted.push((at, at + 1, word)),
+            }
         }
 
+        let runs = sorted.len();
+        let mut begins = vec![0_u32; runs + 1];
+        let mut ends = vec![0_u32; runs + 1];
+        let mut words = vec![0_u128; runs + 1];
+        let mut placed = 0;
+        lay_out(
+            1,
+            runs,
+            &mut placed,
+            &sorted,
+            &mut begins,
+            &mut ends,
+            &mut words,
+        );
+        debug_assert_eq!(placed, runs, "a run was not laid out");
+        drop(sorted);
+
         Self {
-            packed,
-            width,
+            begins,
+            ends,
+            words,
+            runs,
             nodes,
+            width: at.max(1),
+            which: NEXT_PARTITION.fetch_add(1, Ordering::Relaxed),
             begins_at,
             level_of_bit,
             levels,
@@ -224,7 +272,11 @@ impl PackedPartition {
     /// not a word a node.
     #[must_use]
     pub fn bytes(&self) -> usize {
-        self.packed.capacity() + self.level_of_bit.capacity() + self.begins_at.capacity() * 4
+        self.begins.capacity() * size_of::<u32>()
+            + self.ends.capacity() * size_of::<u32>()
+            + self.words.capacity() * size_of::<u128>()
+            + self.level_of_bit.capacity()
+            + self.begins_at.capacity() * size_of::<u32>()
     }
 
     /// How many bits a word is stored in.
@@ -243,11 +295,47 @@ impl PackedPartition {
     #[inline]
     pub fn word(&self, node: NodeID) -> u128 {
         assert!(node < self.nodes, "no node {node} in the partition");
-        read_word(
-            &self.packed,
-            node as u64 * u64::from(self.width),
-            self.width,
-        )
+        let node = node as u32;
+
+        // the run this thread wanted last, where the node is in it too
+        if let Some((which, first, upto, word)) = RECENT.get()
+            && which == self.which
+            && node >= first
+            && node < upto
+        {
+            return word;
+        }
+
+        // Eytzinger: the tree is walked from its root, going right where a run
+        // begins at or before the node and left where it begins after, and the
+        // last one gone right at is the run wanted
+        let mut k = 1;
+        let mut found = 0;
+        while k <= self.runs {
+            if self.begins[k] <= node {
+                found = k;
+                k = 2 * k + 1;
+            } else {
+                k *= 2;
+            }
+        }
+        assert!(found > 0, "no run holds node {node}");
+        RECENT.set(Some((
+            self.which,
+            self.begins[found],
+            self.ends[found],
+            self.words[found],
+        )));
+        self.words[found]
+    }
+
+    /// How many runs the partition came to.
+    ///
+    /// One a cell of the finest level where the nodes are numbered in cell
+    /// order, and one a node at worst.
+    #[must_use]
+    pub fn runs(&self) -> usize {
+        self.runs
     }
 
     /// The cell a node sits in on a level.
@@ -332,61 +420,62 @@ mod tests {
     use super::*;
     use crate::{grid_graph::grid_directory, level_directory::LevelDirectory};
 
-    /// The point of storing at the width the levels ask for: a partition that
-    /// spends a fraction of a word takes a fraction of one.
+    /// The point of the runs: a node of a cell has the word every other node
+    /// of that cell has, so the partition is a run a cell and not a word a
+    /// node.
     #[test]
-    fn a_partition_takes_the_bits_its_levels_ask_for_and_no_more() {
+    fn a_partition_is_a_run_a_cell_and_not_a_word_a_node() {
         let directory = grid_directory(64);
         let packed = PackedPartition::of(&directory);
         let nodes = directory.number_of_nodes();
 
-        let width = packed.width();
-        assert!(width < BITS, "the levels asked for a whole word");
-        assert_eq!(
-            width,
-            *packed.level_layout().last().expect("a layout"),
-            "the width is where the topmost level ends"
+        assert!(
+            packed.runs() < nodes,
+            "{} runs against {nodes} nodes",
+            packed.runs()
         );
-
         let whole = nodes * size_of::<u128>();
         assert!(
             packed.bytes() < whole,
-            "packed {} bytes against {whole} held whole",
+            "{} bytes against {whole} at a word a node",
             packed.bytes()
         );
-        // and it is about the share of a word the levels actually use
-        let wanted = (nodes as u64 * u64::from(width)).div_ceil(8) as usize;
-        assert!(
-            packed.bytes() >= wanted && packed.bytes() < wanted + SPILL + 4096,
-            "packed {} bytes, wanted about {wanted}",
-            packed.bytes()
-        );
+
+        // and every node still reads back the word its own cells make
+        for node in 0..nodes {
+            for level in 0..directory.levels() {
+                assert_eq!(
+                    packed.cell_of(node, level),
+                    directory.cell_of(node, level),
+                    "node {node} on level {level}"
+                );
+            }
+        }
     }
 
-    /// Every word read back is the word laid down, at every offset a node
-    /// falls on: a width that is not a multiple of eight puts a word across a
-    /// byte boundary in a different place for every node in a run of eight.
+    /// The search has to find the run whatever order the words come in, and a
+    /// numbering that is not in cell order is the case that makes runs of one.
     #[test]
-    fn every_word_reads_back_whatever_the_width_puts_it_across() {
-        for width in [1_u32, 3, 7, 8, 17, 33, 64, 76, 100, 127, 128] {
-            let mask = if width >= BITS {
-                u128::MAX
-            } else {
-                (1_u128 << width) - 1
-            };
-            let words: Vec<u128> = (0..64_u128)
-                .map(|at| (at * 0x9E37_79B9_7F4A_7C15).wrapping_mul(0x1234_5678_9ABC_DEF1) & mask)
-                .collect();
-            let mut packed =
-                vec![0_u8; (words.len() as u64 * u64::from(width)).div_ceil(8) as usize + SPILL];
-            for (at, &word) in words.iter().enumerate() {
-                write_word(&mut packed, at as u64 * u64::from(width), width, word);
-            }
-            for (at, &word) in words.iter().enumerate() {
+    fn every_node_finds_its_run_however_the_words_run() {
+        for side in [4_usize, 8, 16, 32] {
+            let directory = grid_directory(side);
+            let packed = PackedPartition::of(&directory);
+            let nodes = directory.number_of_nodes();
+            assert!(packed.runs() >= 1);
+
+            // asked out of order and twice over, so the thread's memo is both
+            // used and missed rather than only ever walked forward through
+            for node in (0..nodes).rev().chain(0..nodes) {
                 assert_eq!(
-                    read_word(&packed, at as u64 * u64::from(width), width),
-                    word,
-                    "word {at} at width {width}"
+                    packed.word(node),
+                    packed
+                        .level_layout()
+                        .iter()
+                        .take(directory.levels())
+                        .enumerate()
+                        .fold(0_u128, |word, (level, &begins)| word
+                            | (u128::from(directory.cell_of(node, level)) << begins)),
+                    "node {node} of a grid of {side}"
                 );
             }
         }

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -53,33 +53,70 @@ thread_local! {
     ///
     /// A search settles a node and then another, and the nodes of a cell are a
     /// run, so the two are usually in the same one. This is only a shortcut:
-    /// where it holds nothing, or another partition's run, the search is done.
+    /// where it holds nothing, or another partition's run, the run is looked
+    /// up in the ordinary way.
     static RECENT: Cell<Option<(usize, u32, u32, u128)>> = const { Cell::new(None) };
 }
 
-/// Writes a sorted run of entries down in Eytzinger order.
+/// Room past the last word, so a read of a whole word from the last one does
+/// not run off the end and does not have to be checked for.
+const SPILL: usize = 32;
+
+/// The narrowest and widest a bucket may be, as a power of two nodes.
 ///
-/// Walked in order, `k`, `2k`, `2k + 1` visits the entries smallest first, so
-/// filling them in that order puts each where a search will look for it.
-fn lay_out(
-    k: usize,
-    runs: usize,
-    at: &mut usize,
-    from: &[(u32, u32, u128)],
-    begins: &mut [u32],
-    ends: &mut [u32],
-    words: &mut [u128],
-) {
-    if k > runs {
-        return;
+/// Narrow buckets are more of them; wide ones are a longer walk. Between these
+/// the width is chosen from the graph, so that a bucket holds about one run.
+const NARROWEST: u32 = 4;
+const WIDEST: u32 = 16;
+
+/// Puts a word down at a bit offset.
+fn write_word(packed: &mut [u8], at: u64, width: u32, value: u128) {
+    let byte = (at / 8) as usize;
+    let shift = (at % 8) as u32;
+    let mask = if width >= BITS {
+        u128::MAX
+    } else {
+        (1_u128 << width) - 1
+    };
+    let value = value & mask;
+
+    // a word straddles at most seventeen bytes, which two overlapping sixteen
+    // byte reads cover
+    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
+    packed[byte..byte + 16].copy_from_slice(&(low | (value << shift)).to_le_bytes());
+    if shift > 0 {
+        let over = value >> (BITS - shift);
+        if over != 0 {
+            let high = u128::from_le_bytes(
+                packed[byte + 16..byte + 32]
+                    .try_into()
+                    .expect("sixteen bytes"),
+            );
+            packed[byte + 16..byte + 32].copy_from_slice(&(high | over).to_le_bytes());
+        }
     }
-    lay_out(2 * k, runs, at, from, begins, ends, words);
-    let (first, upto, word) = from[*at];
-    begins[k] = first;
-    ends[k] = upto;
-    words[k] = word;
-    *at += 1;
-    lay_out(2 * k + 1, runs, at, from, begins, ends, words);
+}
+
+/// Picks a word back up from a bit offset.
+#[inline]
+fn read_word(packed: &[u8], at: u64, width: u32) -> u128 {
+    let byte = (at / 8) as usize;
+    let shift = (at % 8) as u32;
+    let low = u128::from_le_bytes(packed[byte..byte + 16].try_into().expect("sixteen bytes"));
+    let mut held = low >> shift;
+    if shift > 0 {
+        let high = u128::from_le_bytes(
+            packed[byte + 16..byte + 32]
+                .try_into()
+                .expect("sixteen bytes"),
+        );
+        held |= high << (BITS - shift);
+    }
+    if width >= BITS {
+        held
+    } else {
+        held & ((1_u128 << width) - 1)
+    }
 }
 
 /// The cell each node sits in on every level.
@@ -90,44 +127,56 @@ fn lay_out(
 /// parent, and in its parent's parent: the whole word is the same for all of
 /// them. The nodes were renumbered so that a cell's nodes are a run, which is
 /// what let a cell table be found by a range and a block of arcs be keyed by
-/// one. It does the same thing here: the words come in runs, and a run is
-/// worth storing once.
-///
-/// On a continent that is six hundred thousand runs against eighteen million
-/// nodes. A partition that took a hundred and sixty three mebibytes takes
-/// fourteen.
+/// one. It does the same thing here, and the words come in runs worth storing
+/// once. On a continent that is five hundred thousand runs against eighteen
+/// million nodes.
 ///
 /// Where the numbering is *not* in cell order this still holds -- a run is
-/// ended wherever the word changes, and in the worst case there is one a node,
-/// which is what the old layout was. It costs correctness nothing and saves
-/// nothing.
+/// ended wherever the word changes, and at worst there is one a node, which is
+/// what a word a node was. It costs correctness nothing and saves nothing.
 ///
-/// # Why the runs are laid out the way they are
+/// # A word is as wide as its levels ask for
 ///
-/// A node is turned back into its run by looking for the last run that begins
-/// at or before it, which is a binary search. Laid out in order, that search
-/// touches a different cache line at every step and the last few steps are the
-/// only ones that were ever going to be near each other.
+/// A word is handed out as a `u128`, because that is what the shifting and the
+/// exclusive or want. It is stored in the bits the levels actually ask for,
+/// which on a continent cut into six is seventy six of the hundred and twenty
+/// eight.
 ///
-/// So they are laid out in Eytzinger order instead: the array is the binary
-/// search tree written down breadth first, so the root is first, its two
-/// children next to each other after it, their four children after those. The
-/// steps a search takes are `k`, `2k`, `4k` -- reads that walk forward through
-/// memory rather than halving their way across it, and the first several steps
-/// share a cache line.
+/// # Finding the run without searching for it
 ///
-/// # And most searches do not happen
+/// A node is turned back into its run by finding the last run that begins at
+/// or before it. That is a binary search, and there are two ways to make one
+/// fast: lay the array out so the search is cache friendly, or arrange not to
+/// search.
+///
+/// This does the second. Alongside the runs is one entry for every block of
+/// `1 << shift` nodes, saying which run was current where that block began,
+/// with the width picked so a block holds about one run. A lookup reads its
+/// block's entry and walks forward over the runs that began inside it, which
+/// is usually none and rarely more than a few, and those runs are next to each
+/// other in memory.
+///
+/// So it is two reads and a short forward walk, against the twenty dependent
+/// reads a binary search over five hundred thousand runs takes however they
+/// are laid out. An Eytzinger layout makes those twenty reads walk forward
+/// instead of halving across memory, which is a real improvement on a search
+/// and no improvement at all on not searching.
+///
+/// # And most lookups do not reach any of that
 ///
 /// A search settles a node and then another, and the nodes of a cell are a
 /// run, so the next node is very often in the run just used. Each thread keeps
 /// the last run it wanted, which turns the common case into two comparisons.
 pub struct PackedPartition {
-    /// where each run begins and ends, and the word every node of it has, all
-    /// three in Eytzinger order and all three one based: entry zero is unused
-    /// so that the children of `k` are `2k` and `2k + 1`
+    /// where each run begins, in order, with one past the last node on the end
+    /// so that a run is `begins[r]..begins[r + 1]`
     begins: Vec<u32>,
-    ends: Vec<u32>,
-    words: Vec<u128>,
+    /// the word of each run, laid end to end at `width` bits apiece
+    words: Vec<u8>,
+    /// which run was current where each block of `1 << shift` nodes began
+    buckets: Vec<u32>,
+    /// how wide a block of nodes a bucket stands for, as a power of two
+    shift: u32,
     /// how many runs there are
     runs: usize,
     nodes: usize,
@@ -204,40 +253,56 @@ impl PackedPartition {
             word
         };
 
-        let mut sorted: Vec<(u32, u32, u128)> = Vec::new();
+        // the runs, in order, and the word each of them has
+        let mut begins: Vec<u32> = Vec::new();
+        let mut of_run: Vec<u128> = Vec::new();
+        let mut last: Option<u128> = None;
         for node in 0..nodes {
             let word = word_of(node);
-            let at = u32::try_from(node).expect("a node in four bytes");
-            match sorted.last_mut() {
-                Some((_, upto, held)) if *held == word => *upto = at + 1,
-                _ => sorted.push((at, at + 1, word)),
+            if last != Some(word) {
+                begins.push(u32::try_from(node).expect("a node in four bytes"));
+                of_run.push(word);
+                last = Some(word);
             }
         }
+        let runs = of_run.len();
+        // one past the last node, so a run is always a span between two entries
+        begins.push(u32::try_from(nodes).expect("a graph in four bytes"));
 
-        let runs = sorted.len();
-        let mut begins = vec![0_u32; runs + 1];
-        let mut ends = vec![0_u32; runs + 1];
-        let mut words = vec![0_u128; runs + 1];
-        let mut placed = 0;
-        lay_out(
-            1,
-            runs,
-            &mut placed,
-            &sorted,
-            &mut begins,
-            &mut ends,
-            &mut words,
-        );
-        debug_assert_eq!(placed, runs, "a run was not laid out");
-        drop(sorted);
+        let width = at.max(1);
+        let mut words = vec![0_u8; (runs as u64 * u64::from(width)).div_ceil(8) as usize + SPILL];
+        for (run, &word) in of_run.iter().enumerate() {
+            write_word(&mut words, run as u64 * u64::from(width), width, word);
+        }
+        drop(of_run);
+
+        // A bucket for about every run: narrower is more of them and wider is
+        // a longer walk, and one run apiece is where the two meet.
+        let shift = nodes.checked_div(runs).map_or(NARROWEST, |apiece| {
+            apiece
+                .next_power_of_two()
+                .trailing_zeros()
+                .clamp(NARROWEST, WIDEST)
+        });
+        let mut buckets = vec![0_u32; (nodes >> shift) + 2];
+        let mut run = 0_usize;
+        for (bucket, held) in buckets.iter_mut().enumerate() {
+            let first = (bucket << shift) as u32;
+            // the last run that had begun by the time this block of nodes did
+            while run + 1 < runs && begins[run + 1] <= first {
+                run += 1;
+            }
+            *held = u32::try_from(run).expect("a run count in four bytes");
+        }
 
         Self {
             begins,
-            ends,
             words,
+            buckets,
+            shift,
             runs,
             nodes,
-            width: at.max(1),
+            width,
             which: NEXT_PARTITION.fetch_add(1, Ordering::Relaxed),
             begins_at,
             level_of_bit,
@@ -273,10 +338,16 @@ impl PackedPartition {
     #[must_use]
     pub fn bytes(&self) -> usize {
         self.begins.capacity() * size_of::<u32>()
-            + self.ends.capacity() * size_of::<u32>()
-            + self.words.capacity() * size_of::<u128>()
+            + self.words.capacity()
+            + self.buckets.capacity() * size_of::<u32>()
             + self.level_of_bit.capacity()
             + self.begins_at.capacity() * size_of::<u32>()
+    }
+
+    /// How wide a block of nodes a bucket of the index stands for.
+    #[must_use]
+    pub fn bucket_shift(&self) -> u32 {
+        self.shift
     }
 
     /// How many bits a word is stored in.
@@ -306,27 +377,20 @@ impl PackedPartition {
             return word;
         }
 
-        // Eytzinger: the tree is walked from its root, going right where a run
-        // begins at or before the node and left where it begins after, and the
-        // last one gone right at is the run wanted
-        let mut k = 1;
-        let mut found = 0;
-        while k <= self.runs {
-            if self.begins[k] <= node {
-                found = k;
-                k = 2 * k + 1;
-            } else {
-                k *= 2;
-            }
+        // otherwise the bucket this node's block of nodes falls in, and then
+        // forward over whichever runs began inside that block
+        let mut run = self.buckets[(node >> self.shift) as usize] as usize;
+        while run + 1 < self.runs && self.begins[run + 1] <= node {
+            run += 1;
         }
-        assert!(found > 0, "no run holds node {node}");
+        let word = read_word(&self.words, run as u64 * u64::from(self.width), self.width);
         RECENT.set(Some((
             self.which,
-            self.begins[found],
-            self.ends[found],
-            self.words[found],
+            self.begins[run],
+            self.begins[run + 1],
+            word,
         )));
-        self.words[found]
+        word
     }
 
     /// How many runs the partition came to.
@@ -429,6 +493,10 @@ mod tests {
         let packed = PackedPartition::of(&directory);
         let nodes = directory.number_of_nodes();
 
+        assert!(
+            packed.bucket_shift() >= NARROWEST && packed.bucket_shift() <= WIDEST,
+            "the bucket width was not chosen from the graph"
+        );
         assert!(
             packed.runs() < nodes,
             "{} runs against {nodes} nodes",

--- a/src/paged_graph.rs
+++ b/src/paged_graph.rs
@@ -449,6 +449,72 @@ impl ArcWriter {
     }
 }
 
+/// What the border levels are filed under, since they are neither cells nor
+/// runs of arcs.
+const BORDERS: u8 = u8::MAX - 1;
+
+/// Writes the border levels out as blocks, one for each block of arcs.
+///
+/// A border level is a byte an arc saying the highest level at which the arc
+/// leaves the cell of its source. It is settled when the store is packed and
+/// does not change, and working it out means walking every arc of the graph --
+/// which is the one thing a store that pages its arcs was built not to do. So
+/// it is written down instead, through the same [`BlockWriter`] and the same
+/// codec as everything else, cut on the same block boundaries as the arcs.
+///
+/// # Errors
+///
+/// Returns whatever went wrong writing the file.
+pub fn pack_borders(
+    levels: &[u8],
+    first_edges: &[u64],
+    path: &Path,
+    codec: Codec,
+    effort: i32,
+) -> std::io::Result<BlockMap> {
+    let mut writer = BlockWriter::create(path)?;
+    for (block, span) in first_edges.windows(2).enumerate() {
+        let (from, upto) = (span[0] as usize, span[1] as usize);
+        writer.push_bytes(
+            &levels[from..upto],
+            BORDERS,
+            (from as u128, upto.saturating_sub(1) as u128),
+            (
+                u32::try_from(block).expect("a block count in four bytes"),
+                1,
+            ),
+            (
+                u32::try_from(from).expect("an arc in four bytes"),
+                u32::try_from(upto - from).expect("a run of arcs in four bytes"),
+            ),
+            codec,
+            effort,
+        )?;
+    }
+    writer.finish()
+}
+
+/// Reads back what [`pack_borders`] wrote, in one run a byte an arc.
+///
+/// # Errors
+///
+/// Returns whatever went wrong reading it.
+pub fn read_borders(path: &Path, map: &BlockMap) -> Result<Vec<u8>, NotRead> {
+    let file = File::open(path)?;
+    let mut levels = Vec::new();
+    for entry in map.entries() {
+        let mut stored = vec![0_u8; entry.stored as usize];
+        read_at(&file, entry.at, &mut stored)?;
+        let codec = Codec::of(entry.codec).map_err(|_| NotRead::UnknownCodec(entry.codec))?;
+        levels.extend_from_slice(
+            &codec
+                .decode(&stored, entry.unpacked as usize)
+                .map_err(NotRead::Corrupt)?,
+        );
+    }
+    Ok(levels)
+}
+
 /// Packs a graph into blocks of about so many arcs apiece.
 ///
 /// `arcs_in_a_block` sets how much a read brings back: eight bytes an arc
@@ -635,6 +701,45 @@ mod tests {
             let first = read.index().block_of_edge(range.start);
             let last = read.index().block_of_edge(range.end - 1);
             assert_eq!(first, last, "node {node} is split across blocks");
+        }
+    }
+
+    /// The border levels are written down when the store is packed and read
+    /// back, rather than worked out by walking every arc of a graph that is on
+    /// a file.
+    #[test]
+    fn the_border_levels_read_back_as_the_walk_would_have_found_them() {
+        use crate::{
+            border_levels::BorderLevels, grid_graph::grid_directory,
+            packed_partition::PackedPartition,
+        };
+
+        let side = 16;
+        let graph = grid(side);
+        let directory = grid_directory(side);
+        let partition = PackedPartition::of(&directory);
+        let walked = BorderLevels::of(&graph, &partition);
+
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let arcs = held.path().join("arcs");
+        let (_, first_edges) =
+            pack(&graph, None, &arcs, 64, Codec::Lz4, 3).expect("a graph to pack");
+        let borders = held.path().join("borders");
+        let map = pack_borders(walked.as_bytes(), &first_edges, &borders, Codec::Lz4, 3)
+            .expect("the levels to pack");
+        assert!(map.len() > 1, "the pack is worth checking");
+
+        let read = BorderLevels::of_bytes(read_borders(&borders, &map).expect("the levels"));
+        assert_eq!(read.len(), walked.len(), "a different number of arcs");
+        for edge in 0..walked.len() {
+            assert_eq!(read.highest_of(edge), walked.highest_of(edge), "arc {edge}");
+            for level in 0..directory.levels() {
+                assert_eq!(
+                    read.leaves_cell(edge, level),
+                    walked.leaves_cell(edge, level),
+                    "arc {edge} at level {level}"
+                );
+            }
         }
     }
 

--- a/src/paged_graph.rs
+++ b/src/paged_graph.rs
@@ -45,6 +45,7 @@ use crate::{
     block_codec::Codec,
     block_map::{BlockEntry, BlockMap},
     block_store::{BlockWriter, NotRead, read_at},
+    border_levels::{BorderLevels, Borders},
     cell_tree::CellTree,
     graph::{Arcs, EdgeID, Graph, NodeID},
     graph_block::{GraphBlock, HeldArcs},
@@ -527,6 +528,7 @@ pub fn read_borders(path: &Path, map: &BlockMap) -> Result<Vec<u8>, NotRead> {
 /// Returns whatever went wrong writing the file.
 pub fn pack<G: Graph<u32>>(
     graph: &G,
+    borders: &BorderLevels,
     tree: Option<&CellTree>,
     path: &Path,
     arcs_in_a_block: usize,
@@ -549,18 +551,23 @@ pub fn pack<G: Graph<u32>>(
         }
     };
     let mut writer = ArcWriter::create(path)?;
-    let mut run: Vec<Vec<(u32, u32)>> = Vec::new();
+    let mut run: Vec<Vec<(u32, u32, u8)>> = Vec::new();
     let mut first_node = 0_u32;
     let mut first_edge = 0_u64;
     let mut in_run = 0_usize;
 
     for node in graph.node_range() {
-        let out: Vec<(u32, u32)> = graph
+        let out: Vec<(u32, u32, u8)> = graph
             .edge_range(node)
             .map(|edge| {
                 (
                     u32::try_from(graph.target(edge)).expect("a node in four bytes"),
                     *graph.data(edge),
+                    // the level the arc leaves its source's cell at rides with
+                    // it, rather than standing in a byte an arc of its own
+                    borders.highest_of(edge).map_or(0, |level| {
+                        u8::try_from(level + 1).expect("a level in a byte")
+                    }),
                 )
             })
             .collect();
@@ -586,6 +593,54 @@ pub fn pack<G: Graph<u32>>(
     writer.finish()
 }
 
+/// The levels ride in the blocks with the arcs, so the graph is what answers
+/// for them: nothing stands resident and a level is read when its arc is.
+impl Borders for PagedGraph {
+    #[inline]
+    fn leaves_cell(&self, edge: EdgeID, level: usize) -> bool {
+        self.holding_edge(edge)
+            .and_then(|held| held.leaves_cell(edge as u64, level))
+            .unwrap_or(false)
+    }
+}
+
+/// A graph is often wanted twice over -- as the arcs and as what says which of
+/// them leave a cell -- and one behind a count is the way to have it both ways
+/// without holding it twice.
+impl Arcs<u32> for Arc<PagedGraph> {
+    fn node_range(&self) -> std::ops::Range<NodeID> {
+        (**self).node_range()
+    }
+    fn edge_range(&self, node: NodeID) -> std::ops::Range<EdgeID> {
+        (**self).edge_range(node)
+    }
+    fn number_of_nodes(&self) -> usize {
+        (**self).number_of_nodes()
+    }
+    fn number_of_edges(&self) -> usize {
+        (**self).number_of_edges()
+    }
+    fn target(&self, edge: EdgeID) -> NodeID {
+        (**self).target(edge)
+    }
+    fn weight(&self, edge: EdgeID) -> u32 {
+        (**self).weight(edge)
+    }
+    fn for_each_arc(&self, node: NodeID, f: impl FnMut(NodeID, u32)) {
+        (**self).for_each_arc(node, f);
+    }
+    fn standing(&self) -> usize {
+        (**self).standing()
+    }
+}
+
+impl Borders for Arc<PagedGraph> {
+    #[inline]
+    fn leaves_cell(&self, edge: EdgeID, level: usize) -> bool {
+        (**self).leaves_cell(edge, level)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,6 +664,14 @@ mod tests {
         StaticGraph::new(edges)
     }
 
+    /// Border levels off a grid's own partition, which is what a real pack
+    /// gets and what makes the arcs carry something worth reading back.
+    fn borders_of(graph: &StaticGraph<u32>, side: usize) -> BorderLevels {
+        use crate::{grid_graph::grid_directory, packed_partition::PackedPartition};
+        let directory = grid_directory(side);
+        BorderLevels::of(graph, &PackedPartition::of(&directory))
+    }
+
     fn paged(
         graph: &StaticGraph<u32>,
         arcs: usize,
@@ -616,8 +679,16 @@ mod tests {
     ) -> (tempfile::TempDir, PagedGraph) {
         let held = tempfile::tempdir().expect("a directory to write in");
         let path = held.path().join("arcs");
-        let (map, first_edges) =
-            pack(graph, None, &path, arcs, Codec::Lz4, 3).expect("a graph to pack");
+        let (map, first_edges) = pack(
+            graph,
+            &BorderLevels::of_bytes(vec![0; Graph::number_of_edges(graph)]),
+            None,
+            &path,
+            arcs,
+            Codec::Lz4,
+            3,
+        )
+        .expect("a graph to pack");
         let read = PagedGraph::open(&path, map, &first_edges, budget).expect("a graph to open");
         (held, read)
     }
@@ -723,7 +794,7 @@ mod tests {
         let held = tempfile::tempdir().expect("a directory to write in");
         let arcs = held.path().join("arcs");
         let (_, first_edges) =
-            pack(&graph, None, &arcs, 64, Codec::Lz4, 3).expect("a graph to pack");
+            pack(&graph, &walked, None, &arcs, 64, Codec::Lz4, 3).expect("a graph to pack");
         let borders = held.path().join("borders");
         let map = pack_borders(walked.as_bytes(), &first_edges, &borders, Codec::Lz4, 3)
             .expect("the levels to pack");
@@ -799,8 +870,16 @@ mod tests {
 
         let held = tempfile::tempdir().expect("a directory to write in");
         let path = held.path().join("arcs");
-        let (map, first_edges) =
-            pack(&graph, Some(&tree), &path, 64, Codec::Lz4, 3).expect("a graph to pack");
+        let (map, first_edges) = pack(
+            &graph,
+            &borders_of(&graph, side),
+            Some(&tree),
+            &path,
+            64,
+            Codec::Lz4,
+            3,
+        )
+        .expect("a graph to pack");
 
         // Every block carries the key span of the cells its nodes fall in.
         // They rise with the blocks only where the nodes have been renumbered
@@ -833,10 +912,19 @@ mod tests {
     /// the arcs in memory.
     #[test]
     fn the_arcs_on_the_file_are_smaller_than_the_arcs_in_memory() {
-        let graph = grid(48);
+        let graph = grid(64);
         let held = tempfile::tempdir().expect("a directory to write in");
         let path = held.path().join("arcs");
-        let (map, _) = pack(&graph, None, &path, 8_192, Codec::Lz4, 3).expect("a graph to pack");
+        let (map, _) = pack(
+            &graph,
+            &borders_of(&graph, 64),
+            None,
+            &path,
+            8_192,
+            Codec::Lz4,
+            3,
+        )
+        .expect("a graph to pack");
         let (stored, _) = map.bytes();
         let in_memory =
             (Graph::number_of_edges(&graph) * 8 + Graph::number_of_nodes(&graph) * 4) as u64;

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -168,7 +168,7 @@ pub struct Footing {
     pub graph: u64,
     /// the bits the levels of the partition ask for, a node
     pub partition: u64,
-    /// one byte a node
+    /// one byte an arc
     pub border_levels: u64,
     /// one entry a block, and one a cell
     pub block_map: u64,
@@ -218,7 +218,8 @@ impl Footing {
             // arcs where it holds them and only an index where it pages them
             graph: graph.standing() as u64,
             partition: partition_bytes,
-            border_levels: nodes,
+            // a byte an arc, not a byte a node: it is a property of the arc
+            border_levels: graph.number_of_edges() as u64,
             block_map: blocks as u64 * size_of::<BlockEntry>() as u64,
             cell_tree: (0..tree.levels())
                 .map(|level| tree.cells_on_level(level) as u64 * size_of::<CellFacts>() as u64)

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -166,7 +166,7 @@ pub struct Footing {
     /// what the graph costs standing still: all of its arcs where it holds
     /// them, and only what finds a block where it pages them
     pub graph: u64,
-    /// one word a node
+    /// the bits the levels of the partition ask for, a node
     pub partition: u64,
     /// one byte a node
     pub border_levels: u64,
@@ -177,6 +177,12 @@ pub struct Footing {
     pub searches: u64,
 }
 
+/// What a partition would take at a whole word a node, for a caller that has
+/// not got one to ask.
+fn nodes_words(nodes: usize) -> u64 {
+    nodes as u64 * 16
+}
+
 impl Footing {
     /// What an instance over this graph and this store costs before tables.
     ///
@@ -184,12 +190,34 @@ impl Footing {
     /// keeps a table over the nodes of the graph for as long as it lives.
     #[must_use]
     pub fn of<G: Arcs<u32>>(graph: &G, tree: &CellTree, blocks: usize, searches: usize) -> Self {
+        Self::with_partition(
+            graph,
+            nodes_words(graph.number_of_nodes()),
+            tree,
+            blocks,
+            searches,
+        )
+    }
+
+    /// The same, told what the partition actually takes.
+    ///
+    /// A partition is stored in the bits its levels ask for, which is a good
+    /// deal less than a word a node, and only the partition itself knows how
+    /// many that came to.
+    #[must_use]
+    pub fn with_partition<G: Arcs<u32>>(
+        graph: &G,
+        partition_bytes: u64,
+        tree: &CellTree,
+        blocks: usize,
+        searches: usize,
+    ) -> Self {
         let nodes = graph.number_of_nodes() as u64;
         Self {
             // what the graph says it costs standing still, which is all of its
             // arcs where it holds them and only an index where it pages them
             graph: graph.standing() as u64,
-            partition: nodes * 16,
+            partition: partition_bytes,
             border_levels: nodes,
             block_map: blocks as u64 * size_of::<BlockEntry>() as u64,
             cell_tree: (0..tree.levels())
@@ -377,7 +405,13 @@ impl<G: Arcs<u32> + Sync> PagedOverlay<G> {
         borders: BorderLevels,
         budget: Budget,
     ) -> Self {
-        let footing = Footing::of(&graph, store.tree(), store.map().len(), 1);
+        let footing = Footing::with_partition(
+            &graph,
+            partition.bytes() as u64,
+            store.tree(),
+            store.map().len(),
+            1,
+        );
         let pin_from = budget.pin_from(store.tree(), &footing);
         let (_, cache) = budget.split(store.tree(), &footing);
         let levels = store.tree().levels();

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -40,7 +40,7 @@ const BLOCKS_IN_HAND: usize = 8;
 use crate::{
     block_map::BlockEntry,
     block_store::{BlockStore, NotRead},
-    border_levels::BorderLevels,
+    border_levels::{BorderLevels, Borders},
     cell_block::CellBlock,
     cell_tree::{CellFacts, CellTree},
     graph::{Arcs, NodeID},
@@ -168,7 +168,8 @@ pub struct Footing {
     pub graph: u64,
     /// the bits the levels of the partition ask for, a node
     pub partition: u64,
-    /// one byte an arc
+    /// one byte an arc where they are kept apart, and nothing where the arcs
+    /// carry their own
     pub border_levels: u64,
     /// one entry a block, and one a cell
     pub block_map: u64,
@@ -218,8 +219,10 @@ impl Footing {
             // arcs where it holds them and only an index where it pages them
             graph: graph.standing() as u64,
             partition: partition_bytes,
-            // a byte an arc, not a byte a node: it is a property of the arc
-            border_levels: graph.number_of_edges() as u64,
+            // Nothing, where the arcs carry their own: the level rides in the
+            // block with the arc and is read when the arc is. A caller whose
+            // graph does not carry them says so with `with_borders`.
+            border_levels: 0,
             block_map: blocks as u64 * size_of::<BlockEntry>() as u64,
             cell_tree: (0..tree.levels())
                 .map(|level| tree.cells_on_level(level) as u64 * size_of::<CellFacts>() as u64)
@@ -229,6 +232,26 @@ impl Footing {
             // graph, and is not standing room
             searches: searches as u64 * nodes * 4,
         }
+    }
+
+    /// The same, for an instance whose searches keep only what a run touched.
+    ///
+    /// A queue over an array costs four bytes a node standing still, which on
+    /// a continent is sixty eight mebibytes before anybody searches. A queue
+    /// over a map costs a hash on every look and nothing standing, and that is
+    /// what an instance with a budget for the whole of it runs -- see
+    /// [`SparseMldQuery`](crate::mld_query::SparseMldQuery).
+    #[must_use]
+    pub fn with_sparse_searches(mut self) -> Self {
+        self.searches = 0;
+        self
+    }
+
+    /// The same, for an instance keeping a byte an arc beside its graph.
+    #[must_use]
+    pub fn with_borders(mut self, arcs: usize) -> Self {
+        self.border_levels = arcs as u64;
+        self
     }
 
     /// What the whole of it comes to.
@@ -329,11 +352,11 @@ impl Budget {
 }
 
 /// The cells of a partition, read off a file and kept while there is room.
-pub struct PagedOverlay<G = StaticGraph<u32>> {
+pub struct PagedOverlay<G = StaticGraph<u32>, B = BorderLevels> {
     store: BlockStore,
     graph: G,
     partition: PackedPartition,
-    borders: BorderLevels,
+    borders: B,
     kept: Mutex<Kept>,
     budget: usize,
     /// the lowest level held outright, and the level count when none is
@@ -359,14 +382,14 @@ struct Kept {
     faults: Faults,
 }
 
-impl<G: Arcs<u32> + Sync> PagedOverlay<G> {
+impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
     /// Opens a store to read cells from, holding `budget` bytes of them.
     #[must_use]
     pub fn new(
         store: BlockStore,
         graph: G,
         partition: PackedPartition,
-        borders: BorderLevels,
+        borders: B,
         budget: usize,
     ) -> Self {
         Self {
@@ -403,7 +426,7 @@ impl<G: Arcs<u32> + Sync> PagedOverlay<G> {
         store: BlockStore,
         graph: G,
         partition: PackedPartition,
-        borders: BorderLevels,
+        borders: B,
         budget: Budget,
     ) -> Self {
         let footing = Footing::with_partition(
@@ -590,7 +613,7 @@ impl<G: Arcs<u32> + Sync> PagedOverlay<G> {
     }
 }
 
-impl<G: Arcs<u32> + Sync> Overlay for PagedOverlay<G> {
+impl<G: Arcs<u32> + Sync, B: Borders + Sync> Overlay for PagedOverlay<G, B> {
     type Graph = G;
     type Table<'a>
         = Arc<HeldTable>
@@ -605,7 +628,9 @@ impl<G: Arcs<u32> + Sync> Overlay for PagedOverlay<G> {
         &self.partition
     }
 
-    fn border_levels(&self) -> &BorderLevels {
+    type Borders = B;
+
+    fn borders(&self) -> &Self::Borders {
         &self.borders
     }
 
@@ -909,8 +934,16 @@ mod tests {
         let tables = held.path().join("blocks");
         let map = pack_cells(&in_memory, &tree, &tables, 3);
         let arcs = held.path().join("arcs");
-        let (arc_map, first_edges) =
-            pack(&graph, Some(&tree), &arcs, 32, Codec::Lz4, 3).expect("a graph to pack");
+        let (arc_map, first_edges) = pack(
+            &graph,
+            &BorderLevels::of(&graph, &partition),
+            Some(&tree),
+            &arcs,
+            32,
+            Codec::Lz4,
+            3,
+        )
+        .expect("a graph to pack");
 
         // both under budgets too small to hold what they are for, so both are
         // reading throughout rather than reading once and running in memory


### PR DESCRIPTION
Based on #613.

# The partition

`PackedPartition` kept a `u128` a node. Three changes, each smaller than the
last:

**The word is as wide as its levels ask for.** A continent cut into six spends
seventy six of the hundred and twenty eight bits, so fifty two a node said
nothing. 274.8 MiB to 163.2 MiB.

**A run a cell, not a word a node.** Every node of a cell of the finest level
is in that cell, and so in its parent, and in its parent's parent: the whole
word is the same for all of them. The nodes were renumbered so a cell's nodes
are a run, which is what let a cell table be found by a range and a block of
arcs be keyed by one. On europe.ptv that is 497,965 runs over 18,010,173
nodes. 163.2 MiB to 11.4 MiB.

**Found without searching.** Alongside the runs is one entry for every block of
`1 << shift` nodes saying which run was current where that block began, with
the width picked from the graph so a block holds about one run. A lookup reads
its bucket and walks forward over whatever runs began inside it, which is
usually none: two reads and a short forward walk against the twenty dependent
reads a binary search over five hundred thousand runs takes however it is laid
out. Each thread also keeps the last run it wanted. 11.4 MiB to 7.6 MiB.

```rust
pub fn runs(&self) -> usize
pub fn bucket_shift(&self) -> u32
pub fn bytes(&self) -> usize
```

`word()` hands back the same `u128` it always did, so nothing above it moves.
Where the numbering is not in cell order a run ends wherever the word changes,
so there is one a node at worst -- which is what the old layout was. It costs
correctness nothing.

The words are also built a node at a time, walking the parents up from the
finest cell, rather than a level at a time over every node: the second reads
better and costs a vector of whole words the length of the graph to hold what
is half built, which is more than the packing saves. Building peaked at 438 MiB
and now takes 163.

# The border levels

A byte an arc saying the highest level at which the arc leaves the cell of its
source, and they stood resident: 40.2 MiB of a continent, and they were worked
out at open by walking every arc, which is the one thing a store that pages its
arcs was built not to do.

They are now a field of `GraphBlock` beside the target and the weight, taking
the bits that block's widest wants -- three, where a partition has six levels --
and read when the arc is read. The arcs on the file go from 152.9 MiB to 157.6
MiB: 4.7 MiB for what was 40.2 MiB resident.

```rust
pub trait Borders { fn leaves_cell(&self, edge: EdgeID, level: usize) -> bool }
```

implemented by `BorderLevels`, by `PagedGraph` off its blocks, and by
`Arc<PagedGraph>` so one handle serves as both the arcs and what says which of
them leave a cell. `Overlay` hands out a `type Borders` rather than a
`&BorderLevels`, and `PagedOverlay` takes it as a second parameter. The
backward side of a bidirectional search still brings its own, since a network
turned around numbers its arcs differently.

# A search may keep only what it touched

`dense_heap` gains a trait both queues answer:

```rust
pub trait Queue<S: HeapStats<NodeID>>
```

and `MldSearch` is generic over it, so `SparseMldQuery` runs the same search
over the map-backed queue. An array over the nodes is four bytes a node
standing whether a run reaches them or not, which is 68.7 MiB of a continent.

`Footing::with_sparse_searches` and `Footing::with_borders` say which an
instance is.

# What it comes to

The footing on europe.ptv goes from 756.3 MiB to 12.7 MiB:

```
the graph        0.1 MiB   an index over the blocks
the partition    7.6 MiB   a run a cell
the borders      0.0 MiB   they ride in the arc blocks
the block map    0.3 MiB
the cell tree    4.8 MiB
the searches     0.0 MiB   only what a run touched
```