### PR TITLE
Add Pool and PagedArray: one byte-budgeted LRU, and direct-indexed arrays on disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ xxhash-rust = {version = "0.8.15", features = ["xxh3"] }
 lz4_flex = "0.14.0"
 flate2 = "1.1.9"
 zstd = "0.13.3"
+libc = "0.2.189"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5.4"

--- a/examples/paged_dijkstra.rs
+++ b/examples/paged_dijkstra.rs
@@ -140,7 +140,12 @@ fn main() {
         let mut trimmed = tree.clone();
         trimmed.trim_for_queries();
         io::write_to_file(&format!("{arcs_path}.tree"), &trimmed);
-        println!("wrote the partition and the trimmed tree beside the arcs");
+        // and the two arrays a query asks of a tree, so an instance reads them
+        // a block at a time rather than keeping one entry a cell
+        trimmed
+            .save_cells(Path::new(&format!("{arcs_path}.cells")))
+            .expect("the cells to write");
+        println!("wrote the partition, the trimmed tree and its cells beside the arcs");
         (map, first_edges)
     };
 

--- a/examples/paged_dijkstra.rs
+++ b/examples/paged_dijkstra.rs
@@ -130,6 +130,17 @@ fn main() {
         );
         io::write_to_file(&format!("{arcs_path}.map"), &map);
         io::write_vec_to_file(&index_path, &first_edges);
+        // the level information, settled once here so that opening an instance
+        // never reads a directory it is going to throw away
+        partition
+            .save(Path::new(&format!("{arcs_path}.partition")))
+            .expect("a partition to write");
+        // and the query half of the cell tree, so that opening an instance
+        // never reads the build half to throw it away
+        let mut trimmed = tree.clone();
+        trimmed.trim_for_queries();
+        io::write_to_file(&format!("{arcs_path}.tree"), &trimmed);
+        println!("wrote the partition and the trimmed tree beside the arcs");
         (map, first_edges)
     };
 

--- a/examples/paged_dijkstra.rs
+++ b/examples/paged_dijkstra.rs
@@ -26,6 +26,7 @@ use toolbox_rs::{
     one_to_many_dijkstra::OneToManyDijkstra,
     packed_partition::PackedPartition,
     paged_graph::{PagedGraph, pack},
+    pool::Pool,
     static_graph::StaticGraph,
 };
 
@@ -148,8 +149,8 @@ fn main() {
         "budget", "median", "p95", "reads/q", "hit rate", "vs memory"
     );
     for &bytes in &budgets {
-        let read =
-            PagedGraph::open(path, map.clone(), &first_edges, bytes).expect("a graph to open");
+        let read = PagedGraph::open(path, map.clone(), &first_edges, Pool::of(bytes))
+            .expect("a graph to open");
 
         let mut over_memory = OneToManyDijkstra::new();
         let mut over_file = OneToManyDijkstra::new();
@@ -164,7 +165,8 @@ fn main() {
         let mut took = Vec::with_capacity(pairs.len());
         let mut memory_took = Vec::with_capacity(pairs.len());
         let mut wrong = 0_u64;
-        let before = read.faults();
+        let before = read.pool().faults();
+        let before_reads = read.reads();
         let mut timings = String::new();
         let writing = std::env::var("TOOLBOX_TIMINGS").ok();
         for &(source, target, rank) in &pairs {
@@ -207,7 +209,7 @@ fn main() {
 
         took.sort_unstable();
         memory_took.sort_unstable();
-        let faults = read.faults();
+        let faults = read.pool().faults();
         let asked = faults.hits + faults.misses - before.hits - before.misses;
         let median = took[took.len() / 2] as f64 / 1000.0;
         let in_memory = memory_took[memory_took.len() / 2] as f64 / 1000.0;
@@ -218,7 +220,7 @@ fn main() {
             format!("{:.0}us", took[took.len() * 95 / 100] as f64 / 1000.0),
             format!(
                 "{:.1}",
-                (faults.reads - before.reads) as f64 / pairs.len() as f64
+                (read.reads() - before_reads) as f64 / pairs.len() as f64
             ),
             format!(
                 "{:.1}%",

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -194,8 +194,12 @@ fn main() {
     let arcs = std::env::var("TOOLBOX_ARCS").unwrap_or_else(|_| {
         panic!("set TOOLBOX_ARCS to a pack of arcs; this measures an instance that pages both")
     });
-    let tree: CellTree = io::read_from_file(&format!("{arcs}.tree"));
+    let mut tree: CellTree = io::read_from_file(&format!("{arcs}.tree"));
     assert!(!tree.whole(), "the tree beside the arcs was not trimmed");
+    // the two arrays a query asks of a tree are read as well, so what stands
+    // in their place is an offset a level rather than an entry a cell
+    tree.open_cells(Path::new(&format!("{arcs}.cells")), &early)
+        .expect("the cells beside the arcs");
     at = report("the block map and the cell tree", at);
     for (part, bytes) in tree.bytes_by_part() {
         println!("    the tree's {part:<12} {:>7.1} MiB", bytes as f64 / MIB);

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -268,6 +268,15 @@ fn main() {
 
     // the arrays a search wants, which go with the nodes of the graph and not
     // with the budget: one query is run to make it allocate them
+    // every Nth pair, so a run can be made shorter without losing the spread
+    // of ranks: what RSS does against the number of queries is what says
+    // whether something is growing with the run or standing still
+    if let Ok(stride) = std::env::var("TOOLBOX_PAIR_STRIDE") {
+        let stride: usize = stride.parse().expect("a stride");
+        pairs = pairs.into_iter().step_by(stride.max(1)).collect();
+        println!("every {stride} pairs kept, leaving {}", pairs.len());
+    }
+
     let mut query = SparseMldQuery::new();
     // the ways go into the same pool the arcs and the tables draw on
     let mut unpacker = Unpacker::sharing(Arc::clone(paged.pool()));

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -18,7 +18,6 @@ use toolbox_rs::{
     cell_tree::CellTree,
     graph::{Arcs, NodeID},
     io,
-    level_directory::LevelDirectory,
     mld_query::SparseMldQuery,
     node_ordering::NodeOrdering,
     overlay::Overlay,
@@ -26,6 +25,7 @@ use toolbox_rs::{
     paged_graph::{GraphIndex, PagedGraph},
     paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
+    pool::Pool,
 };
 
 const MIB: f64 = (1024 * 1024) as f64;
@@ -133,7 +133,7 @@ fn main() {
         })
     };
     let _graph_path = next("graph");
-    let directory_path = next("directory");
+    let _directory_path = next("directory");
     let pairs_path = next("pairs");
     let blocks_path = next("blocks");
     let bytes = argv
@@ -151,16 +151,20 @@ fn main() {
     // else an instance does wants every arc at once.
     let mut at = report("no graph is read", start);
 
-    // The directory is what the partition and the border levels are built out
-    // of, and neither keeps it, so an offline instance drops it here. It is
-    // counted anyway, since a process that opens a store has to hold it for as
-    // long as it takes to build the two.
-    let partition = {
-        let directory: LevelDirectory = io::read_from_file(&directory_path);
-        at = report("  ... and the level directory", at);
-        PackedPartition::of(&directory)
-    };
-    at = report("the partition, directory dropped", at);
+    // No directory is read either. The partition was settled when the store
+    // was packed, and building it from a directory means reading seventy one
+    // mebibytes of one to throw it away again -- which puts the high-water
+    // mark of the process above anything it goes on to hold.
+    let early = Pool::of(4 * toolbox_rs::paged_array::BLOCK_BYTES);
+    let partition = PackedPartition::open(
+        Path::new(&format!(
+            "{}.partition",
+            std::env::var("TOOLBOX_ARCS").unwrap_or_default()
+        )),
+        &early,
+    )
+    .expect("a partition beside the arcs");
+    at = report("the partition, read not built", at);
     println!(
         "  the partition is {} runs over {} nodes, {:.1} MiB",
         partition.runs(),
@@ -184,12 +188,14 @@ fn main() {
     }
 
     let map: BlockMap = io::read_from_file(&format!("{blocks_path}.map"));
-    let mut tree: CellTree = io::read_from_file(&format!("{blocks_path}.tree"));
-    // A query asks a tree where a cell's nodes begin and how wide it is, and
-    // nothing else. The children, the parents and the boxes are for building
-    // one and for asking what lies where, and an instance that only answers
-    // routes has no use for them.
-    tree.trim_for_queries();
+    // The tree written beside the arcs is already the query half: reading the
+    // whole one to throw the build half away would put twenty two mebibytes
+    // through the process on the way to holding seven.
+    let arcs = std::env::var("TOOLBOX_ARCS").unwrap_or_else(|_| {
+        panic!("set TOOLBOX_ARCS to a pack of arcs; this measures an instance that pages both")
+    });
+    let tree: CellTree = io::read_from_file(&format!("{arcs}.tree"));
+    assert!(!tree.whole(), "the tree beside the arcs was not trimmed");
     at = report("the block map and the cell tree", at);
     for (part, bytes) in tree.bytes_by_part() {
         println!("    the tree's {part:<12} {:>7.1} MiB", bytes as f64 / MIB);
@@ -209,7 +215,12 @@ fn main() {
 
     let budget = Budget {
         bytes,
-        pinned_share: 0.5,
+        // levels held outright are read at open and never let go of, so a run
+        // that must never exceed its budget while starting up may want none
+        pinned_share: std::env::var("TOOLBOX_PIN_SHARE")
+            .ok()
+            .and_then(|share| share.parse().ok())
+            .unwrap_or(0.5),
     };
     // Where a pack of the arcs is at hand, the graph pages too and the footing
     // stands for its index rather than for its arcs.

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -23,7 +23,7 @@ use toolbox_rs::{
     node_ordering::NodeOrdering,
     overlay::Overlay,
     packed_partition::PackedPartition,
-    paged_graph::PagedGraph,
+    paged_graph::{GraphIndex, PagedGraph},
     paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
 };
@@ -169,31 +169,44 @@ fn main() {
     let arcs = std::env::var("TOOLBOX_ARCS").unwrap_or_else(|_| {
         panic!("set TOOLBOX_ARCS to a pack of arcs; this measures an instance that pages both")
     });
-    let paged_arcs = {
+    let (paged_arcs, pool, footing) = {
         let at = &arcs;
         let arc_map: BlockMap = io::read_from_file(&format!("{at}.map"));
         let first_edges: Vec<u64> = io::read_vec_from_file(&format!("{at}.index"));
-        let room = std::env::var("TOOLBOX_ARC_BUDGET")
-            .ok()
-            .and_then(|mib| mib.parse::<usize>().ok())
-            .unwrap_or(256)
-            * 1024
-            * 1024;
-        let read =
-            PagedGraph::open(Path::new(at), arc_map, &first_edges, room).expect("a graph to open");
+        // The pool is sized before anything is opened, because everything that
+        // reads draws on the same one: the arcs, the tables and the ways an
+        // unpacker keeps. Its size is the budget less what stands whatever
+        // happens, and the index is what the graph stands for.
+        let index = GraphIndex::of(&arc_map, &first_edges);
+        let footing = Footing {
+            graph: index.bytes() as u64,
+            partition: partition.bytes() as u64,
+            // nothing: the levels ride in the arc blocks
+            border_levels: 0,
+            block_map: (map.len() * size_of::<toolbox_rs::block_map::BlockEntry>()) as u64,
+            cell_tree: (0..tree.levels())
+                .map(|level| {
+                    (tree.cells_on_level(level) * size_of::<toolbox_rs::cell_tree::CellFacts>())
+                        as u64
+                })
+                .sum(),
+            // nothing: the queue keeps only what a run touched
+            searches: 0,
+        };
+        let pool = budget.pool_for(&tree, &footing);
         println!(
-            "the arcs page, holding at most {} MiB",
-            room / (1024 * 1024)
+            "one pool of {:.1} MiB for the arcs, the tables and the ways alike",
+            pool.budget() as f64 / MIB
         );
-        read
+        let read = PagedGraph::open(Path::new(at), arc_map, &first_edges, Arc::clone(&pool))
+            .expect("a graph to open");
+        (read, pool, footing)
     };
     at = report("the arcs, which page too", at);
 
     // the sparse queue, since an array over the nodes of a continent is more
     // than half of a hundred and twenty eight megabyte budget standing still
-    let footing =
-        Footing::with_partition(&paged_arcs, partition.bytes() as u64, &tree, map.len(), 1)
-            .with_sparse_searches();
+
     let (pinned, cache) = budget.split(&tree, &footing);
     match budget.for_tables(&footing) {
         Ok(left) => println!(
@@ -242,12 +255,13 @@ fn main() {
     // arcs they belong to, so the graph is what answers for them and the same
     // handle serves as both.
     let held = Arc::new(paged_arcs);
-    let paged = PagedOverlay::within(
+    let paged = PagedOverlay::sharing(
         store,
         Arc::clone(&held),
         partition,
         Arc::clone(&held),
         budget,
+        pool,
     );
     let open = opening.elapsed();
     at = report("the held levels, read and unpacked", at);
@@ -255,7 +269,8 @@ fn main() {
     // the arrays a search wants, which go with the nodes of the graph and not
     // with the budget: one query is run to make it allocate them
     let mut query = SparseMldQuery::new();
-    let mut unpacker = Unpacker::for_instance(&paged);
+    // the ways go into the same pool the arcs and the tables draw on
+    let mut unpacker = Unpacker::sharing(Arc::clone(paged.pool()));
     if let Some(&(source, target)) = pairs.first() {
         query.run(&paged, source, &[target]);
     }
@@ -272,9 +287,21 @@ fn main() {
         }
     }
     let full = report("after the queries and the ways", at);
+    println!(
+        "  the queue came to {:.1} MiB, which no budget bounds",
+        query.bytes() as f64 / MIB
+    );
 
     let faults = paged.faults();
     let tables = paged.pinned_bytes() as u64 + faults.held as u64;
+    let pool = paged.pool().faults();
+    println!(
+        "\nthe pool: {:.1} MiB of {:.1} MiB held, most ever {:.1} MiB, {} let go of",
+        pool.held as f64 / MIB,
+        paged.pool().budget() as f64 / MIB,
+        pool.highest as f64 / MIB,
+        pool.evicted,
+    );
     println!();
     println!(
         "budget {:.0} MiB: {:.1} MiB held outright, {:.1} MiB for the cache, opened in {open:.1?}",

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -16,9 +16,11 @@ use toolbox_rs::{
     block_map::BlockMap,
     block_store::BlockStore,
     cell_tree::CellTree,
+    customization::Customization,
     graph::{Arcs, NodeID},
     io,
-    mld_query::SparseMldQuery,
+    level_directory::LevelDirectory,
+    mld_query::{MldQuery, SparseMldQuery},
     node_ordering::NodeOrdering,
     overlay::Overlay,
     packed_partition::PackedPartition,
@@ -26,6 +28,7 @@ use toolbox_rs::{
     paged_overlay::{Budget, Footing, PagedOverlay},
     path_unpacking::Unpacker,
     pool::Pool,
+    static_graph::StaticGraph,
 };
 
 const MIB: f64 = (1024 * 1024) as f64;
@@ -111,7 +114,7 @@ fn report(step: &str, before: u64) -> u64 {
     now
 }
 
-fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
+fn pairs_of(path: &str) -> Vec<(NodeID, NodeID, u64)> {
     std::fs::read_to_string(path)
         .expect("a file of pairs")
         .lines()
@@ -120,7 +123,11 @@ fn pairs_of(path: &str) -> Vec<(NodeID, NodeID)> {
             let mut fields = line.split(',');
             let source = fields.next()?.trim().parse().ok()?;
             let target = fields.next()?.trim().parse().ok()?;
-            Some((source, target))
+            let rank = fields
+                .next()
+                .and_then(|at| at.trim().parse().ok())
+                .unwrap_or(0);
+            Some((source, target, rank))
         })
         .collect()
 }
@@ -337,20 +344,119 @@ fn main() {
     let mut query = SparseMldQuery::new();
     // the ways go into the same pool the arcs and the tables draw on
     let mut unpacker = Unpacker::sharing(Arc::clone(paged.pool()));
-    if let Some(&(source, target)) = pairs.first() {
+    let mut reads_of = String::new();
+    if let Some(&(source, target, _)) = pairs.first() {
         query.run(&paged, source, &[target]);
     }
     at = report("what a search and an unpacker want", at);
 
+    // A reference to answer against, where one is asked for: the same query
+    // over an instance that holds everything. It costs what an offline
+    // instance was built not to, which is why it is a switch and not the
+    // default -- what it is here for is to say that the answers are the same.
+    let reference = std::env::var("TOOLBOX_VERIFY").ok().map(|at| {
+        let edges = io::read_edges_from_file(&at);
+        let directory: LevelDirectory = io::read_from_file(&_directory_path);
+        println!("a reference instance is being built to answer against");
+        Customization::new(StaticGraph::new(edges), directory)
+    });
+    if let Some(held) = &reference {
+        for level in 0..held.directory().levels() {
+            held.level(level);
+        }
+        println!("the reference is customized");
+    }
+
     let mut ways = 0_usize;
-    for &(source, target) in &pairs {
+    let mut wrong = 0_usize;
+    let mut wrong_way = 0_usize;
+    let mut timings = String::new();
+    let writing = std::env::var("TOOLBOX_TIMINGS").ok();
+    let mut over_memory = MldQuery::new();
+    let mut memory_unpacker = reference
+        .as_ref()
+        .map_or_else(Unpacker::default, Unpacker::for_instance);
+
+    for &(source, target, rank) in &pairs {
+        let before = paged.pool().faults().reads;
         query.clear();
+        let started = Instant::now();
         query.run(&paged, source, &[target]);
+        let offline_nanos = started.elapsed().as_nanos() as u64;
+        let offline = query.distance(target);
+
+        let mut way = None;
+        let started = Instant::now();
         if let Some(packed) = query.retrieve_packed_path(target)
-            && unpacker.unpack(&paged, &packed).is_ok()
+            && let Ok(put_back) = unpacker.unpack(&paged, &packed)
         {
+            way = Some(put_back);
             ways += 1;
         }
+        let unpack_nanos = started.elapsed().as_nanos() as u64;
+        // every read the whole instance made for this pair, of every kind
+        let reads = paged.pool().faults().reads - before;
+
+        if let Some(held) = &reference {
+            over_memory.clear();
+            let started = Instant::now();
+            over_memory.run(held, source, &[target]);
+            let memory_nanos = started.elapsed().as_nanos() as u64;
+            if over_memory.distance(target) != offline {
+                wrong += 1;
+            }
+            // and the way, which has to be the same way and not merely as long
+            if let Some(packed) = over_memory.retrieve_packed_path(target)
+                && let Ok(theirs) = memory_unpacker.unpack(held, &packed)
+                && way.as_ref() != Some(&theirs)
+            {
+                wrong_way += 1;
+            }
+            if writing.is_some() {
+                use std::fmt::Write as _;
+                let _ = writeln!(
+                    timings,
+                    "mld,{source},{target},{rank},{memory_nanos},{}",
+                    over_memory.distance(target)
+                );
+            }
+        }
+        if writing.is_some() {
+            use std::fmt::Write as _;
+            let _ = writeln!(
+                timings,
+                "offline,{source},{target},{rank},{offline_nanos},{offline}"
+            );
+            let _ = writeln!(
+                timings,
+                "offline-unpack,{source},{target},{rank},{unpack_nanos},{offline}"
+            );
+            let _ = writeln!(
+                reads_of,
+                "offline,{source},{target},{rank},{reads},{offline}"
+            );
+        }
+    }
+    if let Some(at) = &writing {
+        use std::io::Write as _;
+        let mut out = std::fs::File::create(format!("{at}.times.csv")).expect("a file");
+        writeln!(out, "engine,source,target,rank,nanos,distance").expect("a header");
+        out.write_all(timings.as_bytes()).expect("the timings");
+        let mut out = std::fs::File::create(format!("{at}.reads.csv")).expect("a file");
+        writeln!(out, "engine,source,target,rank,nanos,distance").expect("a header");
+        out.write_all(reads_of.as_bytes()).expect("the reads");
+        println!("wrote {at}.times.csv and {at}.reads.csv");
+    }
+    if reference.is_some() {
+        println!(
+            "{} pairs answered against a reference: {wrong} wrong distances, {wrong_way} wrong ways",
+            pairs.len()
+        );
+        assert_eq!(
+            wrong, 0,
+            "the offline instance answered a different distance"
+        );
+        assert_eq!(wrong_way, 0, "the offline instance found a different way");
     }
     let full = report("after the queries and the ways", at);
     println!(

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -162,7 +162,11 @@ fn main() {
     // was packed, and building it from a directory means reading seventy one
     // mebibytes of one to throw it away again -- which puts the high-water
     // mark of the process above anything it goes on to hold.
-    let early = Pool::of(4 * toolbox_rs::paged_array::BLOCK_BYTES);
+    // One pool, made before anything is opened, because everything draws on
+    // it: the arcs, the tables, the ways, and the partition and tree arrays
+    // that are pinned into it. What stands outside it is the footing, which is
+    // a third of a mebibyte, so the budget less a mebibyte is the pool's.
+    let early = Pool::of(bytes.saturating_sub(MIB as usize));
     let partition = PackedPartition::open(
         Path::new(&format!(
             "{}.partition",
@@ -228,10 +232,13 @@ fn main() {
         bytes,
         // levels held outright are read at open and never let go of, so a run
         // that must never exceed its budget while starting up may want none
+        // Nothing is held outside the pool by default: a level held outright
+        // is room the pool does not have, and the pool is where the pinning
+        // that matters now happens.
         pinned_share: std::env::var("TOOLBOX_PIN_SHARE")
             .ok()
             .and_then(|share| share.parse().ok())
-            .unwrap_or(0.5),
+            .unwrap_or(0.0),
     };
     // Where a pack of the arcs is at hand, the graph pages too and the footing
     // stands for its index rather than for its arcs.
@@ -257,9 +264,9 @@ fn main() {
             // nothing: the queue keeps only what a run touched
             searches: 0,
         };
-        let pool = budget.pool_for(&tree, &footing);
+        let pool = Arc::clone(&early);
         println!(
-            "one pool of {:.1} MiB for the arcs, the tables and the ways alike",
+            "one pool of {:.1} MiB for the arcs, the tables, the ways and the pins",
             pool.budget() as f64 / MIB
         );
         let read = PagedGraph::open(Path::new(at), arc_map, &first_edges, Arc::clone(&pool))
@@ -475,6 +482,10 @@ fn main() {
         std::thread::sleep(std::time::Duration::from_secs(seconds));
     }
 
+    println!(
+        "  of the pool, {:.1} MiB is pinned: the partition and the tree arrays",
+        paged.pool().pinned() as f64 / MIB
+    );
     let faults = paged.faults();
     let tables = paged.pinned_bytes() as u64 + faults.held as u64;
     let pool = paged.pool().faults();

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -504,8 +504,9 @@ fn main() {
         cache as f64 / MIB,
     );
     println!(
-        "{} pairs asked, {ways} ways put back, {} blocks read",
+        "{} pairs asked, {ways} ways put back, {} blocks read in all ({} of them tables)",
         pairs.len(),
+        paged.pool().faults().reads,
         faults.reads
     );
 

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -184,8 +184,16 @@ fn main() {
     }
 
     let map: BlockMap = io::read_from_file(&format!("{blocks_path}.map"));
-    let tree: CellTree = io::read_from_file(&format!("{blocks_path}.tree"));
+    let mut tree: CellTree = io::read_from_file(&format!("{blocks_path}.tree"));
+    // A query asks a tree where a cell's nodes begin and how wide it is, and
+    // nothing else. The children, the parents and the boxes are for building
+    // one and for asking what lies where, and an instance that only answers
+    // routes has no use for them.
+    tree.trim_for_queries();
     at = report("the block map and the cell tree", at);
+    for (part, bytes) in tree.bytes_by_part() {
+        println!("    the tree's {part:<12} {:>7.1} MiB", bytes as f64 / MIB);
+    }
 
     let map_bytes = (map.len() * size_of::<toolbox_rs::block_map::BlockEntry>()) as u64;
     // what every cell of every level would come to unpacked, which is what the

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -10,7 +10,7 @@
 //! The steps are cumulative: each line is what the process holds once that
 //! step is done, and the difference between two lines is what the step added.
 
-use std::{env::args, path::Path, process, sync::Arc, time::Instant};
+use std::{env::args, path::Path, sync::Arc, time::Instant};
 
 use toolbox_rs::{
     block_map::BlockMap,
@@ -30,15 +30,65 @@ use toolbox_rs::{
 
 const MIB: f64 = (1024 * 1024) as f64;
 
-/// The resident set of this process, in bytes.
+/// What this process is holding, in bytes.
 ///
-/// Read from the operating system rather than added up from what was
-/// allocated: what is wanted is what the machine is holding, which includes
-/// the allocator's own slack and excludes whatever it has handed back.
+/// # Not the resident set
+///
+/// `ps` reports a resident set, and on a Mac that counts pages the process
+/// does not own: the text and constant data of every library it links, which
+/// are file backed and shared with every other process using them, and pages
+/// the allocator has freed but not yet handed back, which the kernel may take
+/// at any time. Measured that way this instance reads at four hundred and
+/// sixty megabytes, of which two hundred and seventeen is shared library and
+/// a hundred and forty is memory nobody is using.
+///
+/// What a budget means is what the process would have to be given if it were
+/// alone, which is the physical footprint: dirty private pages plus its share
+/// of what it compresses to. It is the number a memory limit is enforced
+/// against, and it reads a hundred and thirty six against the same run.
+#[cfg(target_os = "macos")]
+fn resident() -> u64 {
+    // rusage_info_v2 is the first with a footprint in it
+    #[repr(C)]
+    #[derive(Default)]
+    struct RUsageV2 {
+        uuid: [u8; 16],
+        user_time: u64,
+        system_time: u64,
+        pkg_idle_wkups: u64,
+        interrupt_wkups: u64,
+        pageins: u64,
+        wired_size: u64,
+        resident_size: u64,
+        phys_footprint: u64,
+        proc_start_abstime: u64,
+        proc_exit_abstime: u64,
+        child_user_time: u64,
+        child_system_time: u64,
+        child_pkg_idle_wkups: u64,
+        child_interrupt_wkups: u64,
+        child_pageins: u64,
+        child_elapsed_abstime: u64,
+        diskio_bytesread: u64,
+        diskio_byteswritten: u64,
+    }
+
+    let mut held = RUsageV2::default();
+    let got = unsafe {
+        libc::proc_pid_rusage(
+            std::process::id() as i32,
+            2,
+            std::ptr::from_mut(&mut held).cast(),
+        )
+    };
+    if got == 0 { held.phys_footprint } else { 0 }
+}
+
+/// Everywhere else, the resident set out of the operating system.
+#[cfg(not(target_os = "macos"))]
 fn resident() -> u64 {
     #[cfg(target_os = "linux")]
     {
-        // statm is in pages, and the second field is the resident set
         let statm = std::fs::read_to_string("/proc/self/statm").unwrap_or_default();
         let pages: u64 = statm
             .split_whitespace()
@@ -48,18 +98,7 @@ fn resident() -> u64 {
         return pages * 4096;
     }
     #[cfg(not(target_os = "linux"))]
-    {
-        // ps reports kibibytes
-        let out = process::Command::new("ps")
-            .args(["-o", "rss=", "-p", &process::id().to_string()])
-            .output();
-        let kib: u64 = out
-            .ok()
-            .and_then(|out| String::from_utf8(out.stdout).ok())
-            .and_then(|text| text.trim().parse().ok())
-            .unwrap_or(0);
-        kib * 1024
-    }
+    0
 }
 
 fn report(step: &str, before: u64) -> u64 {
@@ -184,12 +223,7 @@ fn main() {
             // nothing: the levels ride in the arc blocks
             border_levels: 0,
             block_map: (map.len() * size_of::<toolbox_rs::block_map::BlockEntry>()) as u64,
-            cell_tree: (0..tree.levels())
-                .map(|level| {
-                    (tree.cells_on_level(level) * size_of::<toolbox_rs::cell_tree::CellFacts>())
-                        as u64
-                })
-                .sum(),
+            cell_tree: tree.bytes() as u64,
             // nothing: the queue keeps only what a run touched
             searches: 0,
         };
@@ -301,6 +335,17 @@ fn main() {
         query.bytes() as f64 / MIB
     );
 
+    // A run held open, so that vmmap and heap can be pointed at it: the
+    // resident set says how much there is and neither of those has to be
+    // guessed at afterwards.
+    if let Ok(seconds) = std::env::var("TOOLBOX_HOLD") {
+        let seconds: u64 = seconds.parse().unwrap_or(120);
+        println!("HOLDING pid {} for {seconds}s", std::process::id());
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        std::thread::sleep(std::time::Duration::from_secs(seconds));
+    }
+
     let faults = paged.faults();
     let tables = paged.pinned_bytes() as u64 + faults.held as u64;
     let pool = paged.pool().faults();
@@ -348,14 +393,18 @@ fn main() {
         "nothing: they ride in the arc blocks",
     );
     line("the block map", map_bytes, "one entry a block");
-    line("the cell tree", tree_bytes, "one entry a cell");
+    line(
+        "the cell tree",
+        tree_bytes,
+        "children, parents, boxes and facts",
+    );
     line("the cell tables", tables, "<- the budget governs this one");
     println!("  {:-<34} {:->13}", "", "");
     let accounted = footing.total() - footing.searches + tables;
     line("accounted for", accounted, "");
-    line("resident", full, "");
+    line("the footprint", full, "");
     println!(
-        "  {:<34} {:>8.1} MiB   the search's arrays, the unpacker's",
+        "  {:<34} {:>8.1} MiB   the search's arrays and what the",
         "the difference",
         (full - accounted.min(full)) as f64 / MIB
     );

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -106,7 +106,11 @@ THIN <- 5
 counts <- table(timings$exponent)
 thin <- as.integer(names(counts)[counts < THIN * length(engines)])
 
-palette <- c("#3060c0", "#c05030", "#309050", "#9050b0")
+# enough for a sweep of block sizes with the engine they are measured against
+palette <- c(
+  "#3060c0", "#c05030", "#309050", "#9050b0",
+  "#c09030", "#30909c", "#a03060", "#606060"
+)
 colour_of <- setNames(palette[seq_along(engines)], engines)
 
 png(output, width = 1400, height = 1000, res = 130)

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -29,6 +29,10 @@ output <- if (length(args) >= 2) args[2] else "ranks.png"
 denominator <- if (length(args) >= 3) args[3] else "mld"
 # what the rows are timings of; only the wording changes with it
 measuring <- if (length(args) >= 4) args[4] else "query time"
+# What the `nanos` column actually holds. Times are the usual case and are
+# drawn in milliseconds; a count -- blocks read for a query, say -- is drawn as
+# it stands, since there is no unit to convert it into.
+counting <- length(args) >= 5 && args[5] == "count"
 
 timings <- read.csv(input, stringsAsFactors = FALSE)
 for (column in c("engine", "rank", "nanos")) {
@@ -44,7 +48,10 @@ if (nrow(timings) == 0) {
 
 # milliseconds read better than nanoseconds, and the rank axis is drawn at the
 # exponent so the ticks say 2^10 rather than 1024
-timings$millis <- timings$nanos / 1e6
+# A query that read nothing is a real answer and a log axis has nowhere to put
+# it, so counts are floored at a half: everything drawn at the bottom of the
+# axis read nothing at all.
+timings$millis <- if (counting) pmax(timings$nanos, 0.5) else timings$nanos / 1e6
 timings$exponent <- round(log2(timings$rank))
 engines <- sort(unique(timings$engine))
 exponents <- sort(unique(timings$exponent))
@@ -65,6 +72,12 @@ name_of <- function(engine) ifelse(engine %in% names(display), display[engine], 
 decades_over <- function(values) {
   values <- values[is.finite(values) & values > 0]
   10^(floor(log10(min(values))):ceiling(log10(max(values))))
+}
+
+# a count reads better in ones and tens than in powers of ten alone
+counts_over <- function(values) {
+  wanted <- c(0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000)
+  wanted[wanted >= min(values) * 0.9 & wanted <= max(values) * 1.1]
 }
 
 # The lower panel is a ratio, and a ratio worth reading is usually within a
@@ -97,8 +110,16 @@ palette <- c("#3060c0", "#c05030", "#309050", "#9050b0")
 colour_of <- setNames(palette[seq_along(engines)], engines)
 
 png(output, width = 1400, height = 1000, res = 130)
-layout(matrix(c(1, 2), nrow = 2), heights = c(2, 1))
-par(mar = c(1.5, 4.5, 2.5, 1), las = 1)
+# The lower panel is a ratio, and there is no ratio to draw where only one
+# engine wrote to the file: it gets the whole device instead of two thirds of
+# it and a line of apology.
+ratio_panel <- length(engines) > 1 && denominator %in% engines
+if (ratio_panel) {
+  layout(matrix(c(1, 2), nrow = 2), heights = c(2, 1))
+  par(mar = c(1.5, 4.5, 2.5, 1), las = 1)
+} else {
+  par(mar = c(4.5, 4.5, 2.5, 1), las = 1)
+}
 
 # what each engine costs, as a box per bucket
 groups <- list()
@@ -117,13 +138,18 @@ for (index in seq_along(exponents)) {
 
 boxplot(groups,
   at = at, boxwex = width * 0.9, col = fill, log = "y",
-  xaxt = "n", yaxt = "n", xlab = "", ylab = "milliseconds",
+  xaxt = "n", yaxt = "n", xlab = "",
+  ylab = if (counting) measuring else "milliseconds",
   main = sprintf("%s by Dijkstra rank (%s)", measuring, basename(input)),
   outcex = 0.3, whisklty = 1, staplewex = 0.5
 )
 axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
-ticks <- decades_over(timings$millis)
-axis(2, at = ticks, labels = plainly(ticks))
+ticks <- if (counting) counts_over(timings$millis) else decades_over(timings$millis)
+axis(2, at = ticks, labels = if (counting) {
+  ifelse(ticks < 1, "none", formatC(ticks, format = "d", big.mark = ","))
+} else {
+  plainly(ticks)
+})
 abline(v = exponents[-1] - 0.5, col = "#00000012")
 # the searches climb from left to right, so the top left corner is the one
 # nothing is drawn in
@@ -135,6 +161,16 @@ if (length(thin) > 0) {
 }
 
 # and what one is worth against another, which is the curve to read
+if (!ratio_panel) {
+  mtext("Dijkstra rank", side = 1, line = 3.2)
+  invisible(dev.off())
+  cat(sprintf(
+    "wrote %s: %d timings, %d engines, ranks 2^%d to 2^%d\n",
+    output, nrow(timings), length(engines), min(exponents), max(exponents)
+  ))
+  quit(status = 0)
+}
+
 par(mar = c(4.5, 4.5, 1, 1))
 medians <- sapply(engines, function(engine) {
   sapply(exponents, function(exponent) {

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -306,6 +306,10 @@ impl CellTree {
     /// The box a cell's nodes lie in.
     #[must_use]
     pub fn bounds(&self, level: usize, cell: CellId) -> &BoundingBox {
+        assert!(
+            !self.bounds.is_empty(),
+            "the boxes were let go of: this tree was trimmed for queries"
+        );
         &self.bounds[level][cell as usize]
     }
 
@@ -316,6 +320,10 @@ impl CellTree {
         if level == 0 {
             return &[];
         }
+        assert!(
+            !self.children.is_empty(),
+            "the children were let go of: this tree was trimmed for queries"
+        );
         let held = &self.children[level - 1];
         let starts = &self.starts[level - 1];
         let from = starts[cell as usize] as usize;
@@ -354,6 +362,68 @@ impl CellTree {
     #[must_use]
     pub fn nodes_begin(&self, level: usize, cell: CellId) -> u32 {
         self.begins_node[level][cell as usize]
+    }
+
+    /// Lets go of everything only the build wanted.
+    ///
+    /// # What a query asks a tree
+    ///
+    /// Where a cell's nodes begin, and how wide it is. That is all: the store
+    /// reads a table by asking [`facts`](Self::facts) how many border nodes
+    /// the cell has and [`nodes_begin`](Self::nodes_begin) what its first node
+    /// is numbered.
+    ///
+    /// The rest is for building one. The children and the parents lay out the
+    /// hierarchy and give a cell its key, which is what a *packer* needs to
+    /// file a block; the boxes are for asking what lies where, which is a map
+    /// question and not a routing one. On a continent they come to fourteen
+    /// mebibytes against the seven the query half takes.
+    ///
+    /// After this the accessors for them refuse rather than answer wrongly.
+    pub fn trim_for_queries(&mut self) {
+        self.children = Vec::new();
+        self.parents = Vec::new();
+        self.bounds = Vec::new();
+        self.starts = Vec::new();
+    }
+
+    /// Whether this tree still has what only a build wants.
+    #[must_use]
+    pub fn whole(&self) -> bool {
+        !self.parents.is_empty() || self.levels() <= 1
+    }
+
+    /// What each part of the tree takes, so a caller can see which of them a
+    /// query is paying for and which only the build wanted.
+    #[must_use]
+    pub fn bytes_by_part(&self) -> [(&'static str, usize); 7] {
+        let deep = |held: &Vec<Vec<u32>>| held.iter().map(|l| l.capacity() * 4).sum::<usize>();
+        let cells = |held: &Vec<Vec<CellId>>| {
+            held.iter()
+                .map(|l| l.capacity() * size_of::<CellId>())
+                .sum::<usize>()
+        };
+        [
+            ("begins_at", self.begins_at.capacity() * 4),
+            ("starts", deep(&self.starts)),
+            ("children", cells(&self.children)),
+            ("parents", cells(&self.parents)),
+            (
+                "facts",
+                self.facts
+                    .iter()
+                    .map(|l| l.capacity() * size_of::<CellFacts>())
+                    .sum(),
+            ),
+            (
+                "bounds",
+                self.bounds
+                    .iter()
+                    .map(|l| l.capacity() * size_of::<BoundingBox>())
+                    .sum(),
+            ),
+            ("begins_node", deep(&self.begins_node)),
+        ]
     }
 
     /// What the tree takes once read back.
@@ -446,6 +516,10 @@ impl CellTree {
     /// Panics on the topmost level, whose cells have nothing above them.
     #[must_use]
     pub fn parent_of(&self, level: usize, cell: CellId) -> CellId {
+        assert!(
+            !self.parents.is_empty(),
+            "the parents were let go of: this tree was trimmed for queries"
+        );
         self.parents[level][cell as usize]
     }
 
@@ -646,5 +720,60 @@ mod tests {
         let (mut tree, _, _) = tree_of(4);
         tree.version = VERSION + 1;
         assert_eq!(tree.check_version(), Err(VERSION + 1));
+    }
+
+    /// A tree trimmed for queries answers everything a query asks and nothing
+    /// a build does, and takes a fraction of the room.
+    #[test]
+    fn a_trimmed_tree_still_answers_what_a_query_asks() {
+        let (graph, directory, coordinates) = grid(16);
+        let partition = PackedPartition::of(&directory);
+        let whole = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+        let mut trimmed = CellTree::of(&directory, &partition, &graph, &coordinates);
+        trimmed.trim_for_queries();
+        assert!(whole.whole());
+        assert!(!trimmed.whole());
+        assert!(
+            trimmed.bytes() * 2 < whole.bytes(),
+            "trimmed {} bytes against {}",
+            trimmed.bytes(),
+            whole.bytes()
+        );
+
+        // the two a query asks, over every cell of every level
+        assert_eq!(trimmed.levels(), whole.levels());
+        for level in 0..whole.levels() {
+            assert_eq!(trimmed.cells_on_level(level), whole.cells_on_level(level));
+            for cell in 0..whole.cells_on_level(level) as CellId {
+                assert_eq!(trimmed.facts(level, cell), whole.facts(level, cell));
+                assert_eq!(
+                    trimmed.nodes_begin(level, cell),
+                    whole.nodes_begin(level, cell)
+                );
+            }
+            assert_eq!(
+                trimmed.unpacked_bytes(level),
+                whole.unpacked_bytes(level),
+                "level {level}"
+            );
+        }
+        for node in 0..directory.number_of_nodes() {
+            assert_eq!(
+                trimmed.cell_holding_node(0, node),
+                whole.cell_holding_node(0, node)
+            );
+        }
+    }
+
+    /// And refuses what it no longer has, rather than answering wrongly.
+    #[test]
+    #[should_panic(expected = "trimmed for queries")]
+    fn a_trimmed_tree_refuses_what_only_a_build_wanted() {
+        let (graph, directory, coordinates) = grid(16);
+        let partition = PackedPartition::of(&directory);
+        let mut trimmed = CellTree::of(&directory, &partition, &graph, &coordinates);
+        trimmed.trim_for_queries();
+        let _ = trimmed.parent_of(0, 0);
     }
 }

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -580,8 +580,8 @@ impl CellTree {
 
         let at = 8 + length as u64;
         self.paged = Some(Arc::new(PagedCells {
-            facts: PagedArray::open(path, at, cells as usize, 8, Arc::clone(pool))?,
-            begins_node: PagedArray::open(
+            facts: PagedArray::open_pinned(path, at, cells as usize, 8, Arc::clone(pool))?,
+            begins_node: PagedArray::open_pinned(
                 path,
                 at + cells * 8,
                 begins as usize,

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -36,13 +36,32 @@
 
 use rkyv::{Archive, Deserialize, Serialize};
 
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    sync::Arc,
+};
+
 use crate::{
     bounding_box::BoundingBox,
     geometry::FPCoordinate,
     graph::{Graph, NodeID},
     level_directory::{CellId, LevelDirectory},
     packed_partition::PackedPartition,
+    paged_array::PagedArray,
+    pool::Pool,
 };
+
+/// What a written pair of cell arrays says about itself before them.
+#[derive(Archive, Serialize, Deserialize)]
+struct CellsHead {
+    version: u16,
+    /// how many cells each level has
+    counts: Vec<u32>,
+    /// what each level's tables come to unpacked
+    unpacked: Vec<u64>,
+}
 
 /// The version this is written under. A reader that does not know a version
 /// refuses the file rather than reading it as though it were another one.
@@ -93,7 +112,11 @@ pub struct CellFacts {
 }
 
 /// The assembled partition, with the parts of it a store has to ask about.
-#[derive(Clone, Debug, PartialEq, Eq, Archive, Serialize, Deserialize)]
+/// Cloned, compared and printed by what it holds. The arrays it may read
+/// instead are a way of getting at the same answers and not part of what it
+/// is, so two trees over the same cells are the same tree whether either of
+/// them is reading or keeping.
+#[derive(Debug, Archive, Serialize, Deserialize)]
 pub struct CellTree {
     version: u16,
     /// where each level's bits begin in a key, finest first; the last entry is
@@ -114,18 +137,102 @@ pub struct CellTree {
     parents: Vec<Vec<CellId>>,
     /// per level, what each of its cells holds
     facts: Vec<Vec<CellFacts>>,
-    /// per level, the box each of its cells lies in, and an invalid box for a
-    /// cell holding no node with a coordinate
-    bounds: Vec<Vec<BoundingBox>>,
     /// Per level, where each cell's nodes begin, with one past the end last.
     ///
     /// The running total of what the cells hold, which is where their nodes
-    /// begin only when the nodes are numbered by cell path: then a cell is one
-    /// run and the runs follow one another in the order the cells are in. Under
-    /// any other numbering these are counts and nothing more, which is why
-    /// [`nodes_begin`](Self::nodes_begin) says what it assumes.
+    /// begin only when the nodes are numbered by cell path.
     begins_node: Vec<Vec<u32>>,
+    /// The same two read off a file instead, where there are any.
+    ///
+    /// Never written: a tree is serialized as what it holds, and a tree that
+    /// holds nothing is opened from the arrays beside it rather than read.
+    #[rkyv(with = rkyv::with::Skip)]
+    paged: Option<Arc<PagedCells>>,
+    /// per level, the box each of its cells lies in, and an invalid box for a
+    /// cell holding no node with a coordinate
+    bounds: Vec<Vec<BoundingBox>>,
 }
+
+/// Where the two arrays a query asks for live.
+///
+/// # Why they are the last thing to page
+///
+/// Everything else an instance holds is either bounded by its budget or gone.
+/// These two are one entry a cell, and a cell is one per thirty-odd nodes, so
+/// on a continent they come to seven mebibytes and on a planet to eighty --
+/// which is a budget spent before a single block is read.
+///
+/// Read, what stands in their place is an offset a level: the logarithm of the
+/// nodes rather than the nodes.
+/// The two arrays a query asks for, read off a file rather than kept.
+///
+/// # Why they are the last thing to page
+///
+/// Everything else an instance holds is either bounded by its budget or gone.
+/// These two are one entry a cell, and a cell is one per thirty-odd nodes, so
+/// on a continent they come to seven mebibytes and on a planet to eighty --
+/// which is a budget spent before a single block is read.
+///
+/// What stands in their place is an offset a level: the logarithm of the nodes
+/// rather than the nodes.
+#[derive(Debug)]
+pub struct PagedCells {
+    /// the two, laid end to end across the levels
+    facts: PagedArray,
+    begins_node: PagedArray,
+    /// where each level begins in each of them, and how many cells it has
+    facts_at: Vec<u64>,
+    nodes_at: Vec<u64>,
+    counts: Vec<u32>,
+    /// what each level's tables come to unpacked, worked out when this was
+    /// written rather than by reading every cell of it back
+    unpacked: Vec<u64>,
+}
+
+impl PagedCells {
+    /// What it costs standing still: an entry a level, and two file handles.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        self.facts.bytes()
+            + self.begins_node.bytes()
+            + (self.facts_at.capacity() + self.nodes_at.capacity() + self.unpacked.capacity()) * 8
+            + self.counts.capacity() * 4
+    }
+}
+
+impl Clone for CellTree {
+    fn clone(&self) -> Self {
+        Self {
+            paged: self.paged.clone(),
+            ..Self {
+                version: self.version,
+                begins_at: self.begins_at.clone(),
+                starts: self.starts.clone(),
+                children: self.children.clone(),
+                parents: self.parents.clone(),
+                facts: self.facts.clone(),
+                bounds: self.bounds.clone(),
+                begins_node: self.begins_node.clone(),
+                paged: None,
+            }
+        }
+    }
+}
+
+impl PartialEq for CellTree {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version
+            && self.begins_at == other.begins_at
+            && self.starts == other.starts
+            && self.children == other.children
+            && self.parents == other.parents
+            && self.facts == other.facts
+            && self.bounds == other.bounds
+            && self.begins_node == other.begins_node
+    }
+}
+
+impl Eq for CellTree {}
 
 impl CellTree {
     /// Works the tree out from the assembly's answer and the graph it was cut
@@ -265,6 +372,7 @@ impl CellTree {
 
         Self {
             version: VERSION,
+            paged: None,
             begins_node,
             begins_at: partition.level_layout().to_vec(),
             starts,
@@ -277,12 +385,17 @@ impl CellTree {
 
     #[must_use]
     pub fn levels(&self) -> usize {
-        self.facts.len()
+        self.paged
+            .as_ref()
+            .map_or_else(|| self.facts.len(), |read| read.counts.len())
     }
 
     #[must_use]
     pub fn cells_on_level(&self, level: usize) -> usize {
-        self.facts[level].len()
+        self.paged.as_ref().map_or_else(
+            || self.facts[level].len(),
+            |read| read.counts[level] as usize,
+        )
     }
 
     /// How wide a key is, in bits. The whole path fits in this many.
@@ -300,7 +413,15 @@ impl CellTree {
     /// What a cell holds.
     #[must_use]
     pub fn facts(&self, level: usize, cell: CellId) -> CellFacts {
-        self.facts[level][cell as usize]
+        let Some(read) = &self.paged else {
+            return self.facts[level][cell as usize];
+        };
+        let at = read.facts_at[level] as usize + cell as usize;
+        let held = read.facts.get::<8>(at).expect("a cell the tree has");
+        CellFacts {
+            nodes: u32::from_le_bytes(held[0..4].try_into().expect("four bytes")),
+            on_border: u32::from_le_bytes(held[4..8].try_into().expect("four bytes")),
+        }
     }
 
     /// The box a cell's nodes lie in.
@@ -340,6 +461,9 @@ impl CellTree {
     /// bounded by what it holds unpacked, not by what it downloaded.
     #[must_use]
     pub fn unpacked_bytes(&self, level: usize) -> u64 {
+        if let Some(read) = &self.paged {
+            return read.unpacked[level];
+        }
         self.facts[level]
             .iter()
             .map(|cell| {
@@ -361,7 +485,124 @@ impl CellTree {
     /// Panics if there is no such cell on that level.
     #[must_use]
     pub fn nodes_begin(&self, level: usize, cell: CellId) -> u32 {
-        self.begins_node[level][cell as usize]
+        let Some(read) = &self.paged else {
+            return self.begins_node[level][cell as usize];
+        };
+        let at = read.nodes_at[level] as usize + cell as usize;
+        u32::from_le_bytes(read.begins_node.get::<4>(at).expect("a cell the tree has"))
+    }
+
+    /// Writes the two arrays a query asks for, for [`open_cells`](Self::open_cells).
+    ///
+    /// What a query wants of a tree is one entry a cell, twice over, and a
+    /// cell is one per thirty-odd nodes: seven mebibytes of a continent and
+    /// eighty of a planet. Written here they are read a block at a time and
+    /// what stands in their place is an offset a level.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong writing them.
+    pub fn save_cells(&self, path: &Path) -> std::io::Result<()> {
+        let head = CellsHead {
+            version: VERSION,
+            counts: (0..self.levels())
+                .map(|level| u32::try_from(self.facts[level].len()).expect("a level in four bytes"))
+                .collect(),
+            // worked out here so that a budget does not have to read every
+            // cell of every level back to ask how wide they are
+            unpacked: (0..self.levels())
+                .map(|level| self.unpacked_bytes(level))
+                .collect(),
+        };
+        let head = rkyv::to_bytes::<rkyv::rancor::Error>(&head)
+            .map_err(|why| std::io::Error::other(format!("a tree will not serialize: {why}")))?;
+
+        let mut out = BufWriter::new(File::create(path)?);
+        out.write_all(&(head.len() as u64).to_le_bytes())?;
+        out.write_all(&head)?;
+        for level in &self.facts {
+            for cell in level {
+                out.write_all(&cell.nodes.to_le_bytes())?;
+                out.write_all(&cell.on_border.to_le_bytes())?;
+            }
+        }
+        for level in &self.begins_node {
+            for &begins in level {
+                out.write_all(&begins.to_le_bytes())?;
+            }
+        }
+        out.flush()
+    }
+
+    /// Reads those two back, holding neither.
+    ///
+    /// The tree is otherwise whatever it already was: this only says where the
+    /// per-cell answers come from. A tree opened this way holds an offset a
+    /// level and two file handles.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong reading them, and refuses a version this
+    /// does not know.
+    pub fn open_cells(&mut self, path: &Path, pool: &Arc<Pool>) -> std::io::Result<()> {
+        let file = File::open(path)?;
+        let mut length = [0_u8; 8];
+        crate::block_store::read_at(&file, 0, &mut length)?;
+        let length = u64::from_le_bytes(length) as usize;
+        let mut head = vec![0_u8; length];
+        crate::block_store::read_at(&file, 8, &mut head)?;
+        let head: CellsHead = rkyv::from_bytes::<CellsHead, rkyv::rancor::Error>(&head)
+            .map_err(|why| std::io::Error::other(format!("a tree will not read: {why}")))?;
+        if head.version != VERSION {
+            return Err(std::io::Error::other(format!(
+                "a tree written under version {}",
+                head.version
+            )));
+        }
+
+        // where each level begins in each array, which is the running total of
+        // the ones before it: an entry a level, and there are a handful
+        let mut facts_at = Vec::with_capacity(head.counts.len());
+        let mut running = 0_u64;
+        for &count in &head.counts {
+            facts_at.push(running);
+            running += u64::from(count);
+        }
+        let cells = running;
+        // the second array has one past the end for each level
+        let mut nodes_at = Vec::with_capacity(head.counts.len());
+        let mut running = 0_u64;
+        for &count in &head.counts {
+            nodes_at.push(running);
+            running += u64::from(count) + 1;
+        }
+        let begins = running;
+
+        let at = 8 + length as u64;
+        self.paged = Some(Arc::new(PagedCells {
+            facts: PagedArray::open(path, at, cells as usize, 8, Arc::clone(pool))?,
+            begins_node: PagedArray::open(
+                path,
+                at + cells * 8,
+                begins as usize,
+                4,
+                Arc::clone(pool),
+            )?,
+            facts_at,
+            nodes_at,
+            counts: head.counts,
+            unpacked: head.unpacked,
+        }));
+        // and the kept arrays go, since nothing will ask them again
+        self.facts = Vec::new();
+        self.begins_node = Vec::new();
+        Ok(())
+    }
+
+    /// Whether this tree reads its per-cell answers rather than keeping them.
+    #[must_use]
+    pub fn reads_cells(&self) -> bool {
+        self.paged.is_some()
     }
 
     /// Lets go of everything only the build wanted.
@@ -461,6 +702,7 @@ impl CellTree {
                 .map(|l| l.capacity() * size_of::<BoundingBox>())
                 .sum::<usize>()
             + apiece(&self.begins_node)
+            + self.paged.as_ref().map_or(0, |read| read.bytes())
     }
 
     /// Which cell of a level a node is in, and nothing where none is.
@@ -775,5 +1017,76 @@ mod tests {
         let mut trimmed = CellTree::of(&directory, &partition, &graph, &coordinates);
         trimmed.trim_for_queries();
         let _ = trimmed.parent_of(0, 0);
+    }
+
+    /// The one that matters: a tree that reads its cells answers what the one
+    /// that keeps them does, and costs an entry a level rather than a cell.
+    #[test]
+    fn a_tree_that_reads_its_cells_answers_what_one_that_keeps_them_does() {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        for side in [8_usize, 16, 32] {
+            let (graph, directory, coordinates) = grid(side);
+            let partition = PackedPartition::of(&directory);
+            let whole = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+            let path = held.path().join(format!("cells{side}"));
+            whole.save_cells(&path).expect("the cells to write");
+
+            let mut read = CellTree::of(&directory, &partition, &graph, &coordinates);
+            read.trim_for_queries();
+            read.open_cells(&path, &Pool::of(2 * crate::paged_array::BLOCK_BYTES))
+                .expect("the cells to read");
+            assert!(read.reads_cells());
+
+            assert_eq!(read.levels(), whole.levels());
+            for level in 0..whole.levels() {
+                assert_eq!(read.cells_on_level(level), whole.cells_on_level(level));
+                assert_eq!(
+                    read.unpacked_bytes(level),
+                    whole.unpacked_bytes(level),
+                    "level {level} of {side}"
+                );
+                for cell in 0..whole.cells_on_level(level) as CellId {
+                    assert_eq!(
+                        read.facts(level, cell),
+                        whole.facts(level, cell),
+                        "cell {cell} of level {level} of {side}"
+                    );
+                    assert_eq!(
+                        read.nodes_begin(level, cell),
+                        whole.nodes_begin(level, cell),
+                        "cell {cell} of level {level} of {side}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// And what it costs goes with the levels and not with the cells.
+    #[test]
+    fn a_tree_that_reads_its_cells_costs_the_same_however_many_there_are() {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let pool = Pool::of(1 << 20);
+        let mut sizes = Vec::new();
+        for side in [16_usize, 64] {
+            let (graph, directory, coordinates) = grid(side);
+            let partition = PackedPartition::of(&directory);
+            let path = held.path().join(format!("cells{side}"));
+            let whole = CellTree::of(&directory, &partition, &graph, &coordinates);
+            whole.save_cells(&path).expect("the cells to write");
+
+            let mut read = CellTree::of(&directory, &partition, &graph, &coordinates);
+            read.trim_for_queries();
+            read.open_cells(&path, &pool).expect("the cells to read");
+            let cells: usize = (0..read.levels()).map(|l| read.cells_on_level(l)).sum();
+            sizes.push((cells, read.bytes()));
+        }
+        assert!(sizes[1].0 > sizes[0].0 * 8, "the two are the same size");
+        for &(cells, bytes) in &sizes {
+            assert!(
+                bytes < 4096,
+                "a tree over {cells} cells costs {bytes} bytes standing still"
+            );
+        }
     }
 }

--- a/src/cell_tree.rs
+++ b/src/cell_tree.rs
@@ -356,6 +356,43 @@ impl CellTree {
         self.begins_node[level][cell as usize]
     }
 
+    /// What the tree takes once read back.
+    ///
+    /// Every one of its arrays, not the cell facts alone: the children, the
+    /// parents, the boxes and where each cell's nodes begin come to several
+    /// times what the facts do, and a footing that counts only the facts is a
+    /// footing that is wrong by that much.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        let apiece = |held: &Vec<Vec<u32>>| -> usize {
+            held.iter().map(|level| level.capacity() * 4).sum::<usize>()
+        };
+        size_of::<Self>()
+            + self.begins_at.capacity() * 4
+            + apiece(&self.starts)
+            + self
+                .children
+                .iter()
+                .map(|l| l.capacity() * size_of::<CellId>())
+                .sum::<usize>()
+            + self
+                .parents
+                .iter()
+                .map(|l| l.capacity() * size_of::<CellId>())
+                .sum::<usize>()
+            + self
+                .facts
+                .iter()
+                .map(|l| l.capacity() * size_of::<CellFacts>())
+                .sum::<usize>()
+            + self
+                .bounds
+                .iter()
+                .map(|l| l.capacity() * size_of::<BoundingBox>())
+                .sum::<usize>()
+            + apiece(&self.begins_node)
+    }
+
     /// Which cell of a level a node is in, and nothing where none is.
     ///
     /// Found by searching where the cells begin rather than by asking the

--- a/src/graph_block.rs
+++ b/src/graph_block.rs
@@ -413,6 +413,44 @@ impl HeldArcs {
             .then(|| usize::from(self.borders[(edge - self.first_edge) as usize]) > level)
     }
 
+    /// How much room it is holding that nothing is in, which is what makes a
+    /// recycled buffer worth having.
+    #[cfg(test)]
+    #[must_use]
+    pub fn spare(&self) -> usize {
+        self.targets.capacity() - self.targets.len()
+    }
+
+    /// Fills it with nothing in particular, for a test that wants a block of a
+    /// size rather than a block of anything.
+    #[cfg(test)]
+    pub fn pretend(&mut self, edges: usize) {
+        self.starts.clear();
+        self.starts.push(0);
+        self.targets.clear();
+        self.weights.clear();
+        self.borders.clear();
+        for at in 0..edges {
+            self.targets.push(at as u32);
+            self.weights.push(1);
+            self.borders.push(0);
+        }
+        self.starts.push(edges as u32);
+    }
+
+    /// Empties it, keeping the room, so it can be filled again.
+    ///
+    /// This is what makes a block read cheap the second time round: the
+    /// vectors are the same vectors, and nothing is asked of the allocator.
+    pub fn empty(&mut self) {
+        self.starts.clear();
+        self.targets.clear();
+        self.weights.clear();
+        self.borders.clear();
+        self.first_node = 0;
+        self.first_edge = 0;
+    }
+
     /// What this takes.
     #[must_use]
     pub fn bytes(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub mod one_to_many_dijkstra;
 pub mod overlay;
 pub mod packed_distances;
 pub mod packed_partition;
+pub mod paged_array;
 pub mod paged_graph;
 pub mod paged_overlay;
 pub mod partition_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod partition_id;
 pub mod path_based_scc;
 pub mod path_unpacking;
 pub mod polyline;
+pub mod pool;
 pub mod prim_complete_graph;
 pub mod r_tree;
 pub mod rdx_sort;

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -593,9 +593,10 @@ impl PackedPartition {
         }
         let runs = head.runs as usize;
         let at = 8 + length as u64;
-        let begins = PagedArray::open(path, at, runs + 1, 4, Arc::clone(pool))?;
-        let words = PagedArray::open(path, at + (runs as u64 + 1) * 4, runs, 16, Arc::clone(pool))?;
-        let buckets = PagedArray::open(
+        let begins = PagedArray::open_pinned(path, at, runs + 1, 4, Arc::clone(pool))?;
+        let words =
+            PagedArray::open_pinned(path, at + (runs as u64 + 1) * 4, runs, 16, Arc::clone(pool))?;
+        let buckets = PagedArray::open_pinned(
             path,
             at + (runs as u64 + 1) * 4 + runs as u64 * 16,
             (head.nodes as usize >> head.shift) + 2,

--- a/src/packed_partition.rs
+++ b/src/packed_partition.rs
@@ -33,16 +33,127 @@
 
 use std::{
     cell::Cell,
-    sync::atomic::{AtomicUsize, Ordering},
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
+use rkyv::{Archive, Deserialize, Serialize};
+
 use crate::{
+    block_store::read_at,
     graph::NodeID,
     level_directory::{CellId, LevelDirectory},
+    paged_array::PagedArray,
+    pool::Pool,
 };
 
 /// How many bits a word has to spend, and the most a partition may ask for.
 const BITS: u32 = 128;
+
+/// The version a written partition is under.
+pub const VERSION: u16 = 1;
+
+/// What a written partition says about itself before its runs.
+#[derive(Archive, Serialize, Deserialize)]
+struct Head {
+    version: u16,
+    nodes: u64,
+    runs: u64,
+    width: u32,
+    shift: u32,
+    levels: u32,
+    begins_at: Vec<u32>,
+    level_of_bit: Vec<u8>,
+}
+
+/// Where a partition's runs live.
+///
+/// Kept, which is what a build makes and what a server with room wants, or
+/// read off a file a block at a time, which is what an instance with a budget
+/// for the whole of it wants: read, the runs cost it a file handle apiece and
+/// a share of the pool, whatever the graph.
+enum Runs {
+    Held {
+        /// where each run begins, in order, with one past the last node on the
+        /// end so that a run is `begins[r]..begins[r + 1]`
+        begins: Vec<u32>,
+        /// the word of each run, laid end to end at `width` bits apiece
+        words: Vec<u8>,
+        /// which run was current where each block of `1 << shift` nodes began
+        buckets: Vec<u32>,
+    },
+    Paged {
+        /// the same three, read rather than kept. A word takes a whole sixteen
+        /// bytes here rather than the bits its levels ask for: the packing was
+        /// to save room in memory, and a run that is not in memory has none to
+        /// save, while a fixed width is what lets an entry's place be worked
+        /// out instead of looked up.
+        begins: PagedArray,
+        words: PagedArray,
+        buckets: PagedArray,
+    },
+}
+
+impl Runs {
+    /// Where a run begins.
+    #[inline]
+    fn begins(&self, at: usize) -> u32 {
+        match self {
+            Self::Held { begins, .. } => begins[at],
+            Self::Paged { begins, .. } => {
+                u32::from_le_bytes(begins.get::<4>(at).expect("a run the partition has"))
+            }
+        }
+    }
+
+    /// Which run was current where a block of nodes began.
+    #[inline]
+    fn bucket(&self, at: usize) -> u32 {
+        match self {
+            Self::Held { buckets, .. } => buckets[at],
+            Self::Paged { buckets, .. } => {
+                u32::from_le_bytes(buckets.get::<4>(at).expect("a bucket the partition has"))
+            }
+        }
+    }
+
+    /// The word every node of a run has.
+    #[inline]
+    fn word(&self, run: usize, width: u32) -> u128 {
+        match self {
+            Self::Held { words, .. } => read_word(words, run as u64 * u64::from(width), width),
+            Self::Paged { words, .. } => {
+                u128::from_le_bytes(words.get::<16>(run).expect("a run the partition has"))
+            }
+        }
+    }
+
+    /// What the runs cost standing still.
+    fn bytes(&self) -> usize {
+        match self {
+            Self::Held {
+                begins,
+                words,
+                buckets,
+            } => {
+                begins.capacity() * size_of::<u32>()
+                    + words.capacity()
+                    + buckets.capacity() * size_of::<u32>()
+            }
+            // a handle and four numbers apiece, whatever they hold
+            Self::Paged {
+                begins,
+                words,
+                buckets,
+            } => begins.bytes() + words.bytes() + buckets.bytes(),
+        }
+    }
+}
 
 /// Tells one partition from another, so a thread's memo of the last run it
 /// wanted is not offered to a partition it did not come from.
@@ -168,13 +279,8 @@ fn read_word(packed: &[u8], at: u64, width: u32) -> u128 {
 /// run, so the next node is very often in the run just used. Each thread keeps
 /// the last run it wanted, which turns the common case into two comparisons.
 pub struct PackedPartition {
-    /// where each run begins, in order, with one past the last node on the end
-    /// so that a run is `begins[r]..begins[r + 1]`
-    begins: Vec<u32>,
-    /// the word of each run, laid end to end at `width` bits apiece
-    words: Vec<u8>,
-    /// which run was current where each block of `1 << shift` nodes began
-    buckets: Vec<u32>,
+    /// the runs, kept or read
+    runs_held: Runs,
     /// how wide a block of nodes a bucket stands for, as a power of two
     shift: u32,
     /// how many runs there are
@@ -296,9 +402,11 @@ impl PackedPartition {
         }
 
         Self {
-            begins,
-            words,
-            buckets,
+            runs_held: Runs::Held {
+                begins,
+                words,
+                buckets,
+            },
             shift,
             runs,
             nodes,
@@ -337,9 +445,7 @@ impl PackedPartition {
     /// not a word a node.
     #[must_use]
     pub fn bytes(&self) -> usize {
-        self.begins.capacity() * size_of::<u32>()
-            + self.words.capacity()
-            + self.buckets.capacity() * size_of::<u32>()
+        self.runs_held.bytes()
             + self.level_of_bit.capacity()
             + self.begins_at.capacity() * size_of::<u32>()
     }
@@ -379,18 +485,139 @@ impl PackedPartition {
 
         // otherwise the bucket this node's block of nodes falls in, and then
         // forward over whichever runs began inside that block
-        let mut run = self.buckets[(node >> self.shift) as usize] as usize;
-        while run + 1 < self.runs && self.begins[run + 1] <= node {
+        let mut run = self.runs_held.bucket((node >> self.shift) as usize) as usize;
+        while run + 1 < self.runs && self.runs_held.begins(run + 1) <= node {
             run += 1;
         }
-        let word = read_word(&self.words, run as u64 * u64::from(self.width), self.width);
+        let word = self.runs_held.word(run, self.width);
         RECENT.set(Some((
             self.which,
-            self.begins[run],
-            self.begins[run + 1],
+            self.runs_held.begins(run),
+            self.runs_held.begins(run + 1),
             word,
         )));
         word
+    }
+
+    /// Writes the partition out for [`open`](Self::open) to read.
+    ///
+    /// # What preprocessing this is for
+    ///
+    /// A partition is worked out from a [`LevelDirectory`], and a directory of
+    /// a continent is seventy one mebibytes. An instance that builds its
+    /// partition at startup reads all of that, keeps it long enough to walk
+    /// the parents, and throws it away -- which puts the high-water mark of
+    /// the process well above anything it goes on to hold. A budget that is
+    /// only met once the startup is over is not met.
+    ///
+    /// So the partition is settled when the store is packed and read back
+    /// whole. Nothing about it depends on the query, and it cannot change
+    /// without the store changing.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong writing it.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        let Runs::Held {
+            begins,
+            words,
+            buckets,
+        } = &self.runs_held
+        else {
+            return Err(std::io::Error::other(
+                "this partition is read off a file and cannot be written back",
+            ));
+        };
+
+        let head = Head {
+            version: VERSION,
+            nodes: self.nodes as u64,
+            runs: self.runs as u64,
+            width: self.width,
+            shift: self.shift,
+            levels: self.levels as u32,
+            begins_at: self.begins_at.clone(),
+            level_of_bit: self.level_of_bit.clone(),
+        };
+        let head = rkyv::to_bytes::<rkyv::rancor::Error>(&head).map_err(|why| {
+            std::io::Error::other(format!("a partition will not serialize: {why}"))
+        })?;
+
+        let mut out = BufWriter::new(File::create(path)?);
+        out.write_all(&(head.len() as u64).to_le_bytes())?;
+        out.write_all(&head)?;
+        // the three runs, one after another, each entry a fixed width so that
+        // where it sits is worked out rather than looked up
+        for &begins in &begins[..=self.runs] {
+            out.write_all(&begins.to_le_bytes())?;
+        }
+        for run in 0..self.runs {
+            let word = read_word(words, run as u64 * u64::from(self.width), self.width);
+            out.write_all(&word.to_le_bytes())?;
+        }
+        for &bucket in buckets {
+            out.write_all(&bucket.to_le_bytes())?;
+        }
+        out.flush()
+    }
+
+    /// Reads a partition back, holding none of it.
+    ///
+    /// What stands is the head -- a few numbers and a byte a bit of a word --
+    /// and three file handles. The runs themselves come out of the pool as
+    /// they are asked for, so what this costs is the same for a town and a
+    /// continent.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong reading it, and refuses a partition written
+    /// under a version this does not know.
+    pub fn open(path: &Path, pool: &Arc<Pool>) -> std::io::Result<Self> {
+        // only the head, and not the file it is at the front of: reading the
+        // whole thing to parse a few hundred bytes would put ten mebibytes of
+        // a continent's partition through the process on the way to holding
+        // none of it
+        let file = File::open(path)?;
+        let mut length = [0_u8; 8];
+        read_at(&file, 0, &mut length)?;
+        let length = u64::from_le_bytes(length) as usize;
+        let mut head = vec![0_u8; length];
+        read_at(&file, 8, &mut head)?;
+        let head: Head = rkyv::from_bytes::<Head, rkyv::rancor::Error>(&head)
+            .map_err(|why| std::io::Error::other(format!("a partition will not read: {why}")))?;
+        if head.version != VERSION {
+            return Err(std::io::Error::other(format!(
+                "a partition written under version {}",
+                head.version
+            )));
+        }
+        let runs = head.runs as usize;
+        let at = 8 + length as u64;
+        let begins = PagedArray::open(path, at, runs + 1, 4, Arc::clone(pool))?;
+        let words = PagedArray::open(path, at + (runs as u64 + 1) * 4, runs, 16, Arc::clone(pool))?;
+        let buckets = PagedArray::open(
+            path,
+            at + (runs as u64 + 1) * 4 + runs as u64 * 16,
+            (head.nodes as usize >> head.shift) + 2,
+            4,
+            Arc::clone(pool),
+        )?;
+
+        Ok(Self {
+            runs_held: Runs::Paged {
+                begins,
+                words,
+                buckets,
+            },
+            shift: head.shift,
+            runs,
+            nodes: head.nodes as usize,
+            width: head.width,
+            which: NEXT_PARTITION.fetch_add(1, Ordering::Relaxed),
+            begins_at: head.begins_at,
+            level_of_bit: head.level_of_bit,
+            levels: head.levels as usize,
+        })
     }
 
     /// How many runs the partition came to.
@@ -685,5 +912,95 @@ mod tests {
                 assert_eq!(packed.cell_of(node, level), directory.cell_of(node, level));
             }
         }
+    }
+
+    /// The one that matters: a partition written and read back answers what it
+    /// answered, and costs the same whatever it holds.
+    #[test]
+    fn a_partition_read_off_a_file_answers_what_the_one_it_came_from_does() {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        for side in [8_usize, 16, 32] {
+            let path = held.path().join(format!("partition{side}"));
+            let directory = grid_directory(side);
+            let whole = PackedPartition::of(&directory);
+            whole.save(&path).expect("a partition to write");
+
+            let pool = Pool::of(4 * crate::paged_array::BLOCK_BYTES);
+            let read = PackedPartition::open(&path, &pool).expect("a partition to read");
+
+            assert_eq!(read.number_of_nodes(), whole.number_of_nodes());
+            assert_eq!(read.levels(), whole.levels());
+            assert_eq!(read.runs(), whole.runs());
+            assert_eq!(read.level_layout(), whole.level_layout());
+
+            // asked out of order and twice over, so the thread's memo is both
+            // used and missed
+            let nodes = directory.number_of_nodes();
+            for node in (0..nodes).rev().chain(0..nodes) {
+                assert_eq!(read.word(node), whole.word(node), "node {node} of {side}");
+                for level in 0..directory.levels() {
+                    assert_eq!(
+                        read.cell_of(node, level),
+                        whole.cell_of(node, level),
+                        "node {node} on level {level} of {side}"
+                    );
+                }
+            }
+            // and the questions a query actually asks, over pairs
+            for first in (0..nodes).step_by(3) {
+                for second in (0..nodes).step_by(5) {
+                    assert_eq!(
+                        read.highest_different_level(read.word(first), read.word(second)),
+                        whole.highest_different_level(whole.word(first), whole.word(second)),
+                    );
+                }
+            }
+        }
+    }
+
+    /// What the whole thing is for: a partition that is read costs a handful
+    /// of bytes however many nodes it is over.
+    #[test]
+    fn a_partition_read_off_a_file_costs_the_same_however_large_it_is() {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let pool = Pool::of(1 << 20);
+        let mut sizes = Vec::new();
+        for side in [16_usize, 64] {
+            let path = held.path().join(format!("partition{side}"));
+            PackedPartition::of(&grid_directory(side))
+                .save(&path)
+                .expect("a partition to write");
+            let read = PackedPartition::open(&path, &pool).expect("a partition to read");
+            sizes.push((read.number_of_nodes(), read.bytes()));
+        }
+        assert!(sizes[1].0 > sizes[0].0 * 8, "the two are the same size");
+        // Not equal to the byte: the head carries a level's worth of layout
+        // and a byte for each bit of a word, so it grows with the levels --
+        // which is the logarithm of the nodes, and a deeper hierarchy over
+        // sixteen times the graph is a few dozen bytes more. What it must not
+        // do is grow with the nodes.
+        for &(nodes, bytes) in &sizes {
+            assert!(
+                bytes < 1024,
+                "a partition over {nodes} nodes costs {bytes} bytes standing still"
+            );
+        }
+        assert!(
+            sizes[1].1 < sizes[0].1 + 128,
+            "{} bytes against {} for sixteen times the graph",
+            sizes[1].1,
+            sizes[0].1
+        );
+    }
+
+    #[test]
+    fn a_partition_that_is_read_cannot_be_written_back() {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("partition");
+        PackedPartition::of(&grid_directory(8))
+            .save(&path)
+            .expect("a partition to write");
+        let read = PackedPartition::open(&path, &Pool::of(1 << 20)).expect("a partition to read");
+        assert!(read.save(&held.path().join("again")).is_err());
     }
 }

--- a/src/paged_array.rs
+++ b/src/paged_array.rs
@@ -168,6 +168,7 @@ impl PagedArray {
             &mut into,
         )?;
         self.reads.fetch_add(1, Ordering::Relaxed);
+        self.pool.note_read();
         let held = Arc::new(into);
         self.pool.put(key, Held::Bytes(Arc::clone(&held)));
         Ok(held)

--- a/src/paged_array.rs
+++ b/src/paged_array.rs
@@ -55,6 +55,7 @@ pub const BLOCK_BYTES: usize = 64 * 1024;
 static NEXT_ARRAY: AtomicUsize = AtomicUsize::new(0);
 
 /// A run of fixed-width entries on a file.
+#[derive(Debug)]
 pub struct PagedArray {
     held: File,
     /// where the entries begin in the file

--- a/src/paged_array.rs
+++ b/src/paged_array.rs
@@ -1,0 +1,271 @@
+//! A fixed-width array read off a file, holding nothing but where it is.
+//!
+//! # Why there is no index
+//!
+//! Every array an instance was still keeping whole -- what each cell holds,
+//! where each cell's nodes begin, the runs of the partition and the buckets
+//! over them, where each block of arcs starts -- is asked the same question:
+//! give me the entry at this number. Not *find* it. The number is worked out
+//! from a cell, or a node, or a block, and the entry is at that place.
+//!
+//! So there is nothing to search and nothing to search with. The block an
+//! entry is in is its number divided by how many go in a block, and where that
+//! block sits in the file is that block's number times how long one is. Both
+//! are arithmetic. What stays resident is a file handle, four numbers and a
+//! share of the pool: the same however many entries there are.
+//!
+//! That is the whole of the difference from a B-tree, which is what a sorted
+//! array wants when the question is *find the entry at or before this key*.
+//! One of those keeps its root resident and reads its way down. This keeps
+//! nothing and computes.
+//!
+//! # Why the blocks are not compressed
+//!
+//! A block's place in the file has to be arithmetic, and a compressed block is
+//! only as long as it turned out to be, so where the next one starts is a
+//! thing you have to be told. Being told means an offset an entry, which is
+//! the resident array this was written to abolish.
+//!
+//! These arrays are the small ones -- a continent's come to fifteen mebibytes
+//! against four hundred of arcs -- so the room a codec would save is worth
+//! less than the index it would cost.
+
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use crate::{
+    block_store::{NotRead, read_at},
+    pool::{Held, Key, Pool},
+};
+
+/// How many bytes a block of an array holds.
+///
+/// The same sixty four kibibytes the cell tables are packed into, for the same
+/// reason: it is what a read costs least per entry brought back.
+pub const BLOCK_BYTES: usize = 64 * 1024;
+
+/// Tells one array from another, so their blocks do not collide in the pool.
+static NEXT_ARRAY: AtomicUsize = AtomicUsize::new(0);
+
+/// A run of fixed-width entries on a file.
+pub struct PagedArray {
+    held: File,
+    /// where the entries begin in the file
+    at: u64,
+    /// how many entries there are, and how wide one is
+    entries: usize,
+    wide: usize,
+    /// how many go in a block
+    apiece: usize,
+    /// which array this is, for the pool
+    which: u16,
+    pool: Arc<Pool>,
+    reads: AtomicUsize,
+}
+
+impl PagedArray {
+    /// Opens an array of `entries` entries of `wide` bytes, beginning at `at`.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong opening the file.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an entry wider than a block, which no array here has.
+    pub fn open(
+        path: &Path,
+        at: u64,
+        entries: usize,
+        wide: usize,
+        pool: Arc<Pool>,
+    ) -> std::io::Result<Self> {
+        assert!(wide > 0 && wide <= BLOCK_BYTES, "an entry of {wide} bytes");
+        Ok(Self {
+            held: File::open(path)?,
+            at,
+            entries,
+            wide,
+            apiece: BLOCK_BYTES / wide,
+            which: u16::try_from(NEXT_ARRAY.fetch_add(1, Ordering::Relaxed))
+                .expect("more arrays than a short counts"),
+            pool,
+            reads: AtomicUsize::new(0),
+        })
+    }
+
+    /// How many entries it holds.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries == 0
+    }
+
+    /// How many blocks were read off the file.
+    #[must_use]
+    pub fn reads(&self) -> usize {
+        self.reads.load(Ordering::Relaxed)
+    }
+
+    /// What this costs standing still, whatever it holds.
+    ///
+    /// The blocks are the pool's; this is the handle and the four numbers, and
+    /// it is the same for an array of ten entries and one of ten million.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<Self>()
+    }
+
+    /// The entry at a number, and nothing past the end.
+    ///
+    /// `N` is how wide an entry is and has to be the width the array was
+    /// opened with.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `N` is not that width, which is a caller reading an array as
+    /// something it is not.
+    #[must_use]
+    pub fn get<const N: usize>(&self, index: usize) -> Option<[u8; N]> {
+        assert_eq!(N, self.wide, "an entry read at the wrong width");
+        if index >= self.entries {
+            return None;
+        }
+        let block = index / self.apiece;
+        let held = self.block(block).ok()?;
+        let at = (index % self.apiece) * self.wide;
+        held.get(at..at + N)?.try_into().ok()
+    }
+
+    /// The block at an ordinal, read if the pool is not holding it.
+    fn block(&self, which: usize) -> Result<Arc<Vec<u8>>, NotRead> {
+        let key = Key::Array(
+            self.which,
+            u32::try_from(which).map_err(|_| NotRead::NotHere)?,
+        );
+        if let Some(Held::Bytes(held)) = self.pool.get(&key) {
+            return Ok(held);
+        }
+        // the last block is short where the entries do not fill it
+        let first = which * self.apiece;
+        let held = (self.entries - first).min(self.apiece) * self.wide;
+        let mut into = vec![0_u8; held];
+        read_at(
+            &self.held,
+            self.at + (which * self.apiece * self.wide) as u64,
+            &mut into,
+        )?;
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        let held = Arc::new(into);
+        self.pool.put(key, Held::Bytes(Arc::clone(&held)));
+        Ok(held)
+    }
+}
+
+/// Writes a run of fixed-width entries out for [`PagedArray`] to read.
+///
+/// The entries go down one after another with nothing between them, since
+/// where each one sits is worked out and not looked up.
+///
+/// # Errors
+///
+/// Returns whatever went wrong writing them.
+pub fn write<const N: usize>(
+    out: &mut BufWriter<File>,
+    entries: &[[u8; N]],
+) -> std::io::Result<()> {
+    for entry in entries {
+        out.write_all(entry)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An array of a known pattern, so a wrong entry is obvious.
+    fn written(entries: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+        let held = tempfile::tempdir().expect("a directory to write in");
+        let path = held.path().join("array");
+        let mut out = BufWriter::new(File::create(&path).expect("a file"));
+        let all: Vec<[u8; 8]> = (0..entries)
+            .map(|at| (at as u64).wrapping_mul(0x9E37_79B9).to_le_bytes())
+            .collect();
+        write(&mut out, &all).expect("the entries");
+        out.flush().expect("flushed");
+        (held, path)
+    }
+
+    fn wanted(at: usize) -> [u8; 8] {
+        (at as u64).wrapping_mul(0x9E37_79B9).to_le_bytes()
+    }
+
+    /// The one that matters: every entry, over more blocks than the pool can
+    /// hold at once, so it is reading and letting go throughout.
+    #[test]
+    fn every_entry_reads_back_whatever_the_pool_is_holding() {
+        let entries = 40_000;
+        let (_held, path) = written(entries);
+        let pool = Pool::of(3 * BLOCK_BYTES);
+        let array = PagedArray::open(&path, 0, entries, 8, Arc::clone(&pool)).expect("an array");
+
+        assert_eq!(array.len(), entries);
+        // forwards, so the blocks come in order, and backwards, so they do not
+        for at in (0..entries).chain((0..entries).rev()) {
+            assert_eq!(array.get::<8>(at), Some(wanted(at)), "entry {at}");
+        }
+        assert_eq!(array.get::<8>(entries), None, "past the end");
+        assert!(pool.faults().evicted > 0, "the pool never had to let go");
+        assert!(
+            array.reads() > entries * 8 / BLOCK_BYTES,
+            "nothing was read"
+        );
+    }
+
+    /// What the whole thing is for: what it costs does not go with what it
+    /// holds.
+    #[test]
+    fn what_it_costs_standing_still_does_not_go_with_how_much_it_holds() {
+        let pool = Pool::of(1 << 20);
+        let (_small, small) = written(16);
+        let (_large, large) = written(400_000);
+        let small = PagedArray::open(&small, 0, 16, 8, Arc::clone(&pool)).expect("an array");
+        let large = PagedArray::open(&large, 0, 400_000, 8, Arc::clone(&pool)).expect("an array");
+        assert_eq!(small.bytes(), large.bytes());
+        assert!(large.len() > small.len() * 1000);
+    }
+
+    #[test]
+    fn a_block_already_held_is_not_read_again() {
+        let (_held, path) = written(8_000);
+        let pool = Pool::of(1 << 20);
+        let array = PagedArray::open(&path, 0, 8_000, 8, pool).expect("an array");
+        for _ in 0..4 {
+            for at in 0..8_000 {
+                assert_eq!(array.get::<8>(at), Some(wanted(at)));
+            }
+        }
+        let blocks = (8_000 * 8usize).div_ceil(BLOCK_BYTES);
+        assert_eq!(array.reads(), blocks, "a block was read more than once");
+    }
+
+    #[test]
+    #[should_panic(expected = "the wrong width")]
+    fn an_entry_read_at_the_wrong_width_is_refused() {
+        let (_held, path) = written(8);
+        let array = PagedArray::open(&path, 0, 8, 8, Pool::of(1 << 20)).expect("an array");
+        let _ = array.get::<4>(0);
+    }
+}

--- a/src/paged_array.rs
+++ b/src/paged_array.rs
@@ -67,6 +67,9 @@ pub struct PagedArray {
     apiece: usize,
     /// which array this is, for the pool
     which: u16,
+    /// whether its blocks are pinned, for an array asked something on every
+    /// step of every search
+    stuck: bool,
     pool: Arc<Pool>,
     reads: AtomicUsize,
 }
@@ -97,9 +100,36 @@ impl PagedArray {
             apiece: BLOCK_BYTES / wide,
             which: u16::try_from(NEXT_ARRAY.fetch_add(1, Ordering::Relaxed))
                 .expect("more arrays than a short counts"),
+            stuck: false,
             pool,
             reads: AtomicUsize::new(0),
         })
+    }
+
+    /// The same, for an array whose blocks are not to be let go of.
+    ///
+    /// The partition and the cell tree are asked something for every node a
+    /// search settles and every cell it touches. Left to take their chances
+    /// against the arcs -- which are read once, walked, and not wanted again
+    /// until the next query -- they are pushed out constantly, so the hottest
+    /// lookups in the engine pay a block read apiece.
+    ///
+    /// What is pinned is still the budget's. It is the letting go it is exempt
+    /// from, not the accounting.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong opening the file.
+    pub fn open_pinned(
+        path: &Path,
+        at: u64,
+        entries: usize,
+        wide: usize,
+        pool: Arc<Pool>,
+    ) -> std::io::Result<Self> {
+        let mut held = Self::open(path, at, entries, wide, pool)?;
+        held.stuck = true;
+        Ok(held)
     }
 
     /// How many entries it holds.
@@ -170,7 +200,11 @@ impl PagedArray {
         self.reads.fetch_add(1, Ordering::Relaxed);
         self.pool.note_read();
         let held = Arc::new(into);
-        self.pool.put(key, Held::Bytes(Arc::clone(&held)));
+        if self.stuck {
+            self.pool.pin(key, Held::Bytes(Arc::clone(&held)));
+        } else {
+            self.pool.put(key, Held::Bytes(Arc::clone(&held)));
+        }
         Ok(held)
     }
 }

--- a/src/paged_graph.rs
+++ b/src/paged_graph.rs
@@ -220,18 +220,27 @@ impl PagedGraph {
 
     /// Reads a block off the file and unpacks it.
     fn read(&self, entry: &BlockEntry) -> Result<HeldArcs, NotRead> {
-        let mut stored = vec![0_u8; entry.stored as usize];
-        read_at(&self.arcs, entry.at, &mut stored)?;
-        let codec = Codec::of(entry.codec).map_err(|_| NotRead::UnknownCodec(entry.codec))?;
-        let bytes = codec
-            .decode(&stored, entry.unpacked as usize)
-            .map_err(NotRead::Corrupt)?;
+        // the room comes out of the free list rather than off the allocator,
+        // which over a run of a few hundred thousand reads is the difference
+        // between a process the size of its budget and one several times that
+        let mut stored = self.pool.take_bytes(entry.stored as usize);
+        let read = read_at(&self.arcs, entry.at, &mut stored);
+        let unpacked = read.and_then(|()| {
+            let codec = Codec::of(entry.codec)
+                .map_err(|_| std::io::Error::other("a codec this does not know"))?;
+            codec
+                .decode(&stored, entry.unpacked as usize)
+                .map_err(std::io::Error::other)
+        });
+        self.pool.give_bytes(stored);
+        let bytes = unpacked.map_err(|why| NotRead::Corrupt(why.to_string()))?;
+
         let block = rkyv::from_bytes::<GraphBlock, rkyv::rancor::Error>(&bytes)
             .map_err(|why| NotRead::Corrupt(why.to_string()))?;
         block
             .check_version()
             .map_err(|found| NotRead::Corrupt(format!("a block written under version {found}")))?;
-        let mut held = HeldArcs::default();
+        let mut held = self.pool.take_arcs();
         block.unpack_into(&mut held);
         Ok(held)
     }

--- a/src/paged_graph.rs
+++ b/src/paged_graph.rs
@@ -36,7 +36,7 @@ use std::{
     fs::File,
     path::Path,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
 };
@@ -49,7 +49,7 @@ use crate::{
     cell_tree::CellTree,
     graph::{Arcs, EdgeID, Graph, NodeID},
     graph_block::{GraphBlock, HeldArcs},
-    lru::LRU,
+    pool::{Held, Key, Pool},
 };
 
 /// What a graph's blocks are filed under, since they are not cells.
@@ -163,32 +163,17 @@ impl GraphIndex {
     }
 }
 
-/// What the blocks held cost and how often they were wanted.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ArcFaults {
-    pub hits: usize,
-    pub misses: usize,
-    pub evicted: usize,
-    pub reads: usize,
-    /// what the blocks held come to, unpacked
-    pub held: usize,
-}
-
-struct Kept {
-    blocks: LRU<usize, Arc<HeldArcs>>,
-    bytes: usize,
-    faults: ArcFaults,
-}
-
 /// A graph whose arcs are read off a file as they are wanted.
 pub struct PagedGraph {
     arcs: File,
     map: BlockMap,
     index: GraphIndex,
-    budget: usize,
+    /// the one cache, shared with the tables and the ways
+    pool: Arc<Pool>,
     /// which graph this is, for the thread's memo
     which: usize,
-    kept: Mutex<Kept>,
+    /// how many blocks were read off the file
+    reads: AtomicUsize,
 }
 
 impl PagedGraph {
@@ -203,20 +188,16 @@ impl PagedGraph {
         arcs: &Path,
         map: BlockMap,
         first_edges: &[u64],
-        budget: usize,
+        pool: Arc<Pool>,
     ) -> std::io::Result<Self> {
         let index = GraphIndex::of(&map, first_edges);
         Ok(Self {
             arcs: File::open(arcs)?,
             map,
             index,
-            budget,
+            pool,
             which: NEXT_GRAPH.fetch_add(1, Ordering::Relaxed),
-            kept: Mutex::new(Kept {
-                blocks: LRU::new_with_capacity(1 << 14),
-                bytes: 0,
-                faults: ArcFaults::default(),
-            }),
+            reads: AtomicUsize::new(0),
         })
     }
 
@@ -225,21 +206,16 @@ impl PagedGraph {
         &self.index
     }
 
-    /// How the blocks held have been faring.
+    /// How many blocks of arcs were read off the file.
     #[must_use]
-    pub fn faults(&self) -> ArcFaults {
-        let kept = self.kept.lock().expect("the blocks held");
-        ArcFaults {
-            held: kept.bytes,
-            ..kept.faults
-        }
+    pub fn reads(&self) -> usize {
+        self.reads.load(Ordering::Relaxed)
     }
 
-    /// Lets go of every block held.
-    pub fn forget(&self) {
-        let mut kept = self.kept.lock().expect("the blocks held");
-        kept.blocks.clear();
-        kept.bytes = 0;
+    /// The cache it shares with everything else that reads.
+    #[must_use]
+    pub fn pool(&self) -> &Arc<Pool> {
+        &self.pool
     }
 
     /// Reads a block off the file and unpacks it.
@@ -260,34 +236,16 @@ impl PagedGraph {
         Ok(held)
     }
 
-    /// The block at an ordinal, read if it is not held.
+    /// The block at an ordinal, read if the pool is not holding it.
     fn block(&self, which: usize) -> Result<Arc<HeldArcs>, NotRead> {
-        {
-            let mut kept = self.kept.lock().expect("the blocks held");
-            if let Some(held) = kept.blocks.get(&which) {
-                let held = Arc::clone(held);
-                kept.faults.hits += 1;
-                return Ok(held);
-            }
-            kept.faults.misses += 1;
+        let key = Key::Arcs(u32::try_from(which).map_err(|_| NotRead::NotHere)?);
+        if let Some(Held::Arcs(held)) = self.pool.get(&key) {
+            return Ok(held);
         }
-
         let entry = *self.map.entries().get(which).ok_or(NotRead::NotHere)?;
         let held = Arc::new(self.read(&entry)?);
-        let cost = held.bytes();
-
-        let mut kept = self.kept.lock().expect("the blocks held");
-        kept.faults.reads += 1;
-        // room is made before the block is put down, so the budget bounds what
-        // is held rather than what was held a moment ago
-        while kept.bytes + cost > self.budget
-            && let Some((_, gone)) = kept.blocks.pop_lru()
-        {
-            kept.bytes -= gone.bytes();
-            kept.faults.evicted += 1;
-        }
-        kept.blocks.push(&which, Arc::clone(&held));
-        kept.bytes += cost;
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        self.pool.put(key, Held::Arcs(Arc::clone(&held)));
         Ok(held)
     }
 
@@ -689,7 +647,8 @@ mod tests {
             3,
         )
         .expect("a graph to pack");
-        let read = PagedGraph::open(&path, map, &first_edges, budget).expect("a graph to open");
+        let read =
+            PagedGraph::open(&path, map, &first_edges, Pool::of(budget)).expect("a graph to open");
         (held, read)
     }
 
@@ -720,7 +679,7 @@ mod tests {
                 );
             }
         }
-        let faults = read.faults();
+        let faults = read.pool().faults();
         assert!(faults.evicted > 0, "the budget was never binding");
         assert!(faults.held <= 16 * 1024, "the budget was exceeded");
     }
@@ -736,10 +695,9 @@ mod tests {
                 }
             }
         }
-        let faults = read.faults();
-        assert_eq!(faults.evicted, 0, "nothing was let go of");
+        assert_eq!(read.pool().faults().evicted, 0, "nothing was let go of");
         assert_eq!(
-            faults.reads,
+            read.reads(),
             read.index().blocks(),
             "a block was read more than once"
         );
@@ -849,7 +807,10 @@ mod tests {
             }
         }
         assert!(asked > 100, "the sweep is worth running");
-        assert!(read.faults().evicted > 0, "the budget was never binding");
+        assert!(
+            read.pool().faults().evicted > 0,
+            "the budget was never binding"
+        );
     }
 
     /// The blocks of arcs go into a store keyed the way the cell tables are, so
@@ -899,7 +860,8 @@ mod tests {
         }
 
         // and it still answers as the graph does
-        let read = PagedGraph::open(&path, map, &first_edges, 1 << 20).expect("a graph to open");
+        let read =
+            PagedGraph::open(&path, map, &first_edges, Pool::of(1 << 20)).expect("a graph to open");
         for node in Graph::node_range(&graph) {
             assert_eq!(
                 Arcs::edge_range(&read, node),

--- a/src/paged_graph.rs
+++ b/src/paged_graph.rs
@@ -254,6 +254,7 @@ impl PagedGraph {
         let entry = *self.map.entries().get(which).ok_or(NotRead::NotHere)?;
         let held = Arc::new(self.read(&entry)?);
         self.reads.fetch_add(1, Ordering::Relaxed);
+        self.pool.note_read();
         self.pool.put(key, Held::Arcs(Arc::clone(&held)));
         Ok(held)
     }

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -28,31 +28,28 @@
 //! depending on which ones a search happened to want.
 
 use rayon::prelude::*;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 /// How many blocks are kept in hand while their cells are unpacked.
 ///
-/// A block is wanted only while the cells around it are being read; a few is
-/// enough to keep a search walking cells side by side from reading the same
-/// block twice, and more would be room better given to the tables.
-const BLOCKS_IN_HAND: usize = 8;
-
 use crate::{
     block_map::BlockEntry,
     block_store::{BlockStore, NotRead},
     border_levels::{BorderLevels, Borders},
-    cell_block::CellBlock,
     cell_tree::{CellFacts, CellTree},
     graph::{Arcs, NodeID},
     level_directory::CellId,
-    lru::LRU,
     overlay::{CellTable, Overlay},
     packed_partition::PackedPartition,
+    pool::{Held, Key, Pool},
     static_graph::StaticGraph,
 };
 
 /// One cell's table, as it is once read off the file.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct HeldTable {
     /// the table, row by row
     matrix: Vec<u32>,
@@ -333,6 +330,16 @@ impl Budget {
         from
     }
 
+    /// The pool a budget leaves room for, once the footing and the levels held
+    /// outright are paid for.
+    ///
+    /// A caller that pages its arcs makes this first and hands it to the graph
+    /// and to the overlay alike.
+    #[must_use]
+    pub fn pool_for(&self, tree: &CellTree, footing: &Footing) -> Arc<Pool> {
+        Pool::of(self.split(tree, footing).1)
+    }
+
     /// What the held levels come to, and what is left for the cache.
     ///
     /// Both are out of what the tables were left, so the two and the footing
@@ -357,29 +364,16 @@ pub struct PagedOverlay<G = StaticGraph<u32>, B = BorderLevels> {
     graph: G,
     partition: PackedPartition,
     borders: B,
-    kept: Mutex<Kept>,
-    budget: usize,
+    /// the one cache, shared with the arcs and the ways
+    pool: Arc<Pool>,
+    /// how many blocks were read off the file, and how many tables came out of
+    /// a block already in the pool
+    reads: AtomicUsize,
+    unpacked: AtomicUsize,
     /// the lowest level held outright, and the level count when none is
     pin_from: usize,
     /// the held levels, from `pin_from` up, and nothing for a cell with no table
     pinned: Vec<Vec<Option<Arc<HeldTable>>>>,
-}
-
-struct Kept {
-    tables: LRU<(u8, CellId), Arc<HeldTable>>,
-    bytes: usize,
-    /// The blocks a table was last unpacked out of.
-    ///
-    /// A read is of a block and a table is of a cell, and a block holds many
-    /// cells. Without this, two cells of one block are two reads of that block
-    /// and two passes of the codec over it, which for a search walking cells
-    /// side by side is nearly every read it makes.
-    ///
-    /// Held apart from the tables and given a fixed few, since a block is
-    /// wanted only while the cells around it are being unpacked and a table is
-    /// wanted for as long as the search keeps coming back to it.
-    blocks: LRU<(u8, CellId), Arc<CellBlock>>,
-    faults: Faults,
 }
 
 impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
@@ -390,24 +384,18 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
         graph: G,
         partition: PackedPartition,
         borders: B,
-        budget: usize,
+        pool: Arc<Pool>,
     ) -> Self {
         Self {
             store,
             graph,
             partition,
             borders,
-            // room for the entries, which the budget in bytes bounds; the
-            // count is only what the map is made large enough for
             pin_from: usize::MAX,
             pinned: Vec::new(),
-            kept: Mutex::new(Kept {
-                tables: LRU::new_with_capacity(1 << 16),
-                bytes: 0,
-                blocks: LRU::new_with_capacity(BLOCKS_IN_HAND),
-                faults: Faults::default(),
-            }),
-            budget,
+            pool,
+            reads: AtomicUsize::new(0),
+            unpacked: AtomicUsize::new(0),
         }
     }
 
@@ -429,6 +417,35 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
         borders: B,
         budget: Budget,
     ) -> Self {
+        let cache = {
+            let footing = Footing::with_partition(
+                &graph,
+                partition.bytes() as u64,
+                store.tree(),
+                store.map().len(),
+                1,
+            );
+            budget.split(store.tree(), &footing).1
+        };
+        Self::sharing(store, graph, partition, borders, budget, Pool::of(cache))
+    }
+
+    /// The same, over a pool that something else is drawing on too.
+    ///
+    /// This is what an instance whose arcs also page uses: the graph is opened
+    /// over the pool, the overlay is opened over the same one, and the ways an
+    /// unpacker keeps go into it as well, so one number bounds the lot. Given
+    /// a pool apiece they would each respect their own and together respect
+    /// nothing.
+    #[must_use]
+    pub fn sharing(
+        store: BlockStore,
+        graph: G,
+        partition: PackedPartition,
+        borders: B,
+        budget: Budget,
+        pool: Arc<Pool>,
+    ) -> Self {
         let footing = Footing::with_partition(
             &graph,
             partition.bytes() as u64,
@@ -437,10 +454,9 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
             1,
         );
         let pin_from = budget.pin_from(store.tree(), &footing);
-        let (_, cache) = budget.split(store.tree(), &footing);
         let levels = store.tree().levels();
 
-        let mut held = Self::new(store, graph, partition, borders, cache);
+        let mut held = Self::new(store, graph, partition, borders, pool);
         held.pinned = (pin_from..levels)
             .map(|level| {
                 (0..held.store.tree().cells_on_level(level) as CellId)
@@ -482,11 +498,21 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
     /// Panics if another thread failed while holding the cache.
     #[must_use]
     pub fn faults(&self) -> Faults {
-        let kept = self.kept.lock().expect("the cache is poisoned");
+        let pool = self.pool.faults();
         Faults {
-            held: kept.bytes,
-            ..kept.faults
+            hits: pool.hits as u64,
+            misses: pool.misses as u64,
+            evicted: pool.evicted as u64,
+            reads: self.reads.load(Ordering::Relaxed) as u64,
+            unpacked: self.unpacked.load(Ordering::Relaxed) as u64,
+            held: pool.held,
         }
+    }
+
+    /// The cache it shares with everything else that reads.
+    #[must_use]
+    pub fn pool(&self) -> &Arc<Pool> {
+        &self.pool
     }
 
     /// Throws everything away, which a run that measures a cold store wants.
@@ -495,9 +521,7 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
     ///
     /// Panics if another thread failed while holding the cache.
     pub fn forget(&self) {
-        let mut kept = self.kept.lock().expect("the cache is poisoned");
-        kept.tables.clear();
-        kept.bytes = 0;
+        self.pool.forget();
     }
 
     /// Reads a cell off the file, or hands back the one already held.
@@ -521,32 +545,12 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
                 .ok_or(NotRead::NotHere);
         }
 
-        let key = (u8::try_from(level).map_err(|_| NotRead::NotHere)?, cell);
-        {
-            let mut kept = self.kept.lock().expect("the cache is poisoned");
-            if let Some(held) = kept.tables.get(&key) {
-                let held = held.clone();
-                kept.faults.hits += 1;
-                return Ok(held);
-            }
+        let key = Key::Table(u8::try_from(level).map_err(|_| NotRead::NotHere)?, cell);
+        if let Some(Held::Table(held)) = self.pool.get(&key) {
+            return Ok(held);
         }
-
         let held = self.read(level, cell)?;
-
-        let mut kept = self.kept.lock().expect("the cache is poisoned");
-        kept.faults.misses += 1;
-        kept.bytes += held.bytes();
-        if let Some((_, was)) = kept.tables.push(&key, held.clone()) {
-            kept.bytes -= was.bytes();
-        }
-        // and then down to the budget, oldest first
-        while kept.bytes > self.budget && kept.tables.len() > 1 {
-            let Some((_, was)) = kept.tables.pop_lru() else {
-                break;
-            };
-            kept.bytes -= was.bytes();
-            kept.faults.evicted += 1;
-        }
+        self.pool.put(key, Held::Table(Arc::clone(&held)));
         Ok(held)
     }
 
@@ -556,30 +560,24 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
     /// through it would stop every other thread.
     fn read(&self, level: usize, cell: CellId) -> Result<Arc<HeldTable>, NotRead> {
         let entry = self.store.entry_of(level, cell).ok_or(NotRead::NotHere)?;
-        let key = (
+        let key = Key::Block(
             u8::try_from(level).map_err(|_| NotRead::NotHere)?,
             entry.first_cell,
         );
 
-        // the block this cell is in, off the file or out of the few in hand
-        let block = {
-            let mut kept = self.kept.lock().expect("the cache is poisoned");
-            kept.blocks.get(&key).cloned()
-        };
-        let block = match block {
-            Some(block) => {
-                self.kept
-                    .lock()
-                    .expect("the cache is poisoned")
-                    .faults
-                    .unpacked += 1;
+        // the block this cell is in, off the file or out of the pool: a read
+        // is of a block and a table is of a cell, and a block holds many, so
+        // two cells of one block would otherwise be two reads and two passes
+        // of the codec
+        let block = match self.pool.get(&key) {
+            Some(Held::Block(block)) => {
+                self.unpacked.fetch_add(1, Ordering::Relaxed);
                 block
             }
-            None => {
+            _ => {
                 let read = Arc::new(self.store.block_at(&entry)?);
-                let mut kept = self.kept.lock().expect("the cache is poisoned");
-                kept.faults.reads += 1;
-                kept.blocks.push(&key, read.clone());
+                self.reads.fetch_add(1, Ordering::Relaxed);
+                self.pool.put(key, Held::Block(Arc::clone(&read)));
                 read
             }
         };
@@ -816,7 +814,7 @@ mod tests {
             PackedPartition::of(&directory),
             BorderLevels::of(&graph, &partition),
             // deliberately small, so that tables are thrown away and read again
-            8 * 1024,
+            Pool::of(8 * 1024),
         );
 
         let mut over_memory = MldQuery::new();
@@ -947,8 +945,8 @@ mod tests {
 
         // both under budgets too small to hold what they are for, so both are
         // reading throughout rather than reading once and running in memory
-        let paged_graph =
-            PagedGraph::open(&arcs, arc_map, &first_edges, 8 * 1024).expect("a graph to open");
+        let paged_graph = PagedGraph::open(&arcs, arc_map, &first_edges, Pool::of(8 * 1024))
+            .expect("a graph to open");
         let footing = Footing::of(&paged_graph, &tree, 4, 1);
         assert!(
             footing.graph < (crate::graph::Graph::number_of_edges(&graph) * 8) as u64 / 4,
@@ -988,7 +986,7 @@ mod tests {
         }
         assert!(asked > 100, "the sweep is worth running");
         assert!(
-            paged.graph().faults().reads > 0,
+            paged.graph().reads() > 0,
             "the arcs were never read off the file"
         );
     }
@@ -1143,7 +1141,7 @@ mod tests {
             StaticGraph::new(edges),
             PackedPartition::of(&directory),
             BorderLevels::of(&graph, &partition),
-            1 << 20,
+            Pool::of(1 << 20),
         );
         assert!(paged.distances_of(0, 0).is_none());
     }

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -60,6 +60,13 @@ pub struct HeldTable {
 }
 
 impl HeldTable {
+    /// Empties it, keeping the room, so it can be filled again.
+    pub fn empty(&mut self) {
+        self.matrix.clear();
+        self.transposed.clear();
+        self.nodes.clear();
+    }
+
     /// What it takes up, which is what the budget counts.
     #[must_use]
     pub fn bytes(&self) -> usize {
@@ -584,30 +591,32 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
 
         let widths = self.store.widths_of(&entry, level);
         let which = (cell - entry.first_cell) as usize;
-        let mut matrix = Vec::new();
-        let mut nodes = Vec::new();
-        block.unpack_into(which, &widths, &mut matrix);
-        block.places_into(which, &widths, &mut nodes);
+        // the room comes out of the free list rather than off the allocator
+        let mut held = self.pool.take_table();
+        let HeldTable {
+            matrix,
+            transposed,
+            nodes,
+        } = &mut held;
+        block.unpack_into(which, &widths, matrix);
+        block.places_into(which, &widths, nodes);
         let begins = self.store.tree().nodes_begin(level, cell);
         if nodes.is_empty() {
             nodes.extend((0..widths[which] as u32).map(|at| begins + at));
         } else {
-            for node in &mut nodes {
+            for node in nodes.iter_mut() {
                 *node += begins;
             }
         }
         let wide = nodes.len();
-        let mut transposed = vec![u32::MAX; matrix.len()];
+        transposed.clear();
+        transposed.resize(matrix.len(), u32::MAX);
         for source in 0..wide {
             for target in 0..wide {
                 transposed[target * wide + source] = matrix[source * wide + target];
             }
         }
-        Ok(Arc::new(HeldTable {
-            matrix,
-            transposed,
-            nodes,
-        }))
+        Ok(Arc::new(held))
     }
 }
 

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -39,7 +39,7 @@ use crate::{
     block_map::BlockEntry,
     block_store::{BlockStore, NotRead},
     border_levels::{BorderLevels, Borders},
-    cell_tree::{CellFacts, CellTree},
+    cell_tree::CellTree,
     graph::{Arcs, NodeID},
     level_directory::CellId,
     overlay::{CellTable, Overlay},
@@ -228,9 +228,10 @@ impl Footing {
             // graph does not carry them says so with `with_borders`.
             border_levels: 0,
             block_map: blocks as u64 * size_of::<BlockEntry>() as u64,
-            cell_tree: (0..tree.levels())
-                .map(|level| tree.cells_on_level(level) as u64 * size_of::<CellFacts>() as u64)
-                .sum(),
+            // what the whole tree takes, and not the cell facts alone: the
+            // children, the parents, the boxes and where each cell's nodes
+            // begin come to several times what the facts do
+            cell_tree: tree.bytes() as u64,
             // four bytes a node for the table a queue reads in one look; what
             // the heap itself takes goes with the widest run and not with the
             // graph, and is not standing room

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -585,6 +585,7 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
             _ => {
                 let read = Arc::new(self.store.block_at(&entry)?);
                 self.reads.fetch_add(1, Ordering::Relaxed);
+                self.pool.note_read();
                 self.pool.put(key, Held::Block(Arc::clone(&read)));
                 read
             }

--- a/src/path_unpacking.rs
+++ b/src/path_unpacking.rs
@@ -41,6 +41,8 @@
 
 use std::{cmp::Reverse, collections::BinaryHeap};
 
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -48,7 +50,17 @@ use crate::{
     level_directory::CellId,
     lru::LRU,
     overlay::{CellTable, Overlay},
+    pool::{Held, Key, Pool},
 };
+
+/// A step across a cell, as the pool names it.
+fn way_key(key: (NodeID, NodeID, usize)) -> Key {
+    Key::Way(
+        u32::try_from(key.0).unwrap_or(u32::MAX),
+        u32::try_from(key.1).unwrap_or(u32::MAX),
+        u8::try_from(key.2).unwrap_or(u8::MAX),
+    )
+}
 
 /// What a held way costs beyond its nodes: the key it is filed under, the
 /// vector heading its nodes, and what the cache and its list keep per entry.
@@ -139,6 +151,14 @@ pub fn unpack<O: Overlay>(overlay: &O, packed: &[NodeID]) -> Result<Vec<NodeID>,
 /// what it has crossed, and a caller that wants the room back asks for it with
 /// [`clear`](Self::clear).
 pub struct Unpacker {
+    /// Where the ways go when the unpacker is drawing on the one cache an
+    /// instance keeps, rather than on a budget of its own.
+    ///
+    /// A way put back is worth keeping for exactly the same reason a block of
+    /// arcs is, and given its own budget it takes room the arcs may want more.
+    /// So an instance with a budget for the whole of it hands the same pool to
+    /// the graph, the tables and this.
+    pool: Option<Arc<Pool>>,
     ways: LRU<(NodeID, NodeID, usize), Vec<NodeID>>,
     /// what the ways held come to, kept as they go in and out rather than
     /// walked, since it is asked after every insert
@@ -147,6 +167,17 @@ pub struct Unpacker {
     hits: usize,
     misses: usize,
     evicted: usize,
+}
+
+impl Unpacker {
+    /// An unpacker that keeps its ways in the pool everything else reads from.
+    #[must_use]
+    pub fn sharing(pool: Arc<Pool>) -> Self {
+        Self {
+            pool: Some(pool),
+            ..Self::with_budget(0)
+        }
+    }
 }
 
 impl Default for Unpacker {
@@ -188,6 +219,7 @@ impl Unpacker {
         // is the room that binds and not this.
         let entries = (bytes / (PER_WAY + 2 * size_of::<NodeID>())).max(1);
         Self {
+            pool: None,
             ways: LRU::new_with_capacity(entries),
             bytes: 0,
             budget: bytes,
@@ -247,7 +279,37 @@ impl Unpacker {
 
     /// Files a way, letting go of whatever was used longest ago until what is
     /// held is back inside the room it was given.
+    /// The way already put back for this step, where anything has it.
+    fn held(&mut self, key: (NodeID, NodeID, usize)) -> Option<Vec<NodeID>> {
+        if let Some(pool) = &self.pool {
+            return match pool.get(&way_key(key)) {
+                Some(Held::Way(way)) => {
+                    self.hits += 1;
+                    Some(way.as_ref().clone())
+                }
+                _ => {
+                    self.misses += 1;
+                    None
+                }
+            };
+        }
+        match self.ways.get(&key) {
+            Some(held) => {
+                self.hits += 1;
+                Some(held.clone())
+            }
+            None => {
+                self.misses += 1;
+                None
+            }
+        }
+    }
+
     fn keep(&mut self, key: (NodeID, NodeID, usize), way: &[NodeID]) {
+        if let Some(pool) = &self.pool {
+            pool.put(way_key(key), Held::Way(Arc::new(way.to_vec())));
+            return;
+        }
         let cost = PER_WAY + size_of_val(way);
         if cost > self.budget {
             // a way that would not leave room for itself is not worth holding
@@ -327,11 +389,9 @@ impl Unpacker {
         to: NodeID,
         level: usize,
     ) -> Result<Vec<NodeID>, Unpacking> {
-        if let Some(held) = self.ways.get(&(from, to, level)) {
-            self.hits += 1;
-            return Ok(held.clone());
+        if let Some(held) = self.held((from, to, level)) {
+            return Ok(held);
         }
-        self.misses += 1;
         let partition = overlay.partition();
         let cell = partition.cell_of(from, level);
         let found = within_cell(overlay, from, to, level, cell).ok_or(Unpacking::NoWayAcross {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -141,7 +141,22 @@ impl std::fmt::Debug for Pool {
 }
 
 struct Inside {
+    /// what may be let go of, oldest first
     kept: LRU<Key, Held>,
+    /// What may not.
+    ///
+    /// The partition and the tree are asked something for every node a search
+    /// settles and every cell it touches, and they are small: seven mebibytes
+    /// of a hundred and twenty eight. Left to take their chances in the list
+    /// they are pushed out by the arcs, which are read once and walked, and
+    /// then read again for the next query -- so the hottest lookups in the
+    /// engine pay a block read and the coldest keep the room.
+    ///
+    /// Held here they are still the budget's: what is pinned is counted, and
+    /// a pool whose pins fill it has nothing left to cache with. It is the
+    /// letting go that they are exempt from, not the accounting.
+    stuck: rustc_hash::FxHashMap<Key, Held>,
+    pinned: usize,
     bytes: usize,
     faults: Faults,
     scrap: Scrap,
@@ -163,6 +178,8 @@ impl Pool {
                 // room for the entries, which the budget in bytes bounds; the
                 // count is only what the index is made large enough for
                 kept: LRU::new_with_capacity(1 << 18),
+                stuck: rustc_hash::FxHashMap::default(),
+                pinned: 0,
                 bytes: 0,
                 faults: Faults::default(),
                 scrap: Scrap::default(),
@@ -181,7 +198,7 @@ impl Pool {
     pub fn faults(&self) -> Faults {
         let inside = self.inside.lock().expect("the pool");
         Faults {
-            held: inside.bytes,
+            held: inside.bytes + inside.pinned,
             ..inside.faults
         }
     }
@@ -190,6 +207,11 @@ impl Pool {
     #[must_use]
     pub fn get(&self, key: &Key) -> Option<Held> {
         let mut inside = self.inside.lock().expect("the pool");
+        if let Some(held) = inside.stuck.get(key) {
+            let held = held.clone();
+            inside.faults.hits += 1;
+            return Some(held);
+        }
         match inside.kept.get(key) {
             Some(held) => {
                 let held = held.clone();
@@ -215,16 +237,49 @@ impl Pool {
             return;
         }
         let mut inside = self.inside.lock().expect("the pool");
-        while inside.bytes + cost > self.budget
+        while inside.bytes + inside.pinned + cost > self.budget
             && let Some((_, gone)) = inside.kept.pop_lru()
         {
             inside.bytes -= gone.bytes();
             inside.faults.evicted += 1;
             recycle(&mut inside.scrap, gone);
         }
-        inside.kept.push(&key, held);
-        inside.bytes += cost;
-        inside.faults.highest = inside.faults.highest.max(inside.bytes);
+        // a pool whose pins leave no room keeps nothing else
+        if inside.bytes + inside.pinned + cost <= self.budget {
+            inside.kept.push(&key, held);
+            inside.bytes += cost;
+        }
+        inside.faults.highest = inside.faults.highest.max(inside.bytes + inside.pinned);
+    }
+
+    /// Puts something in that will not be let go of.
+    ///
+    /// It counts against the budget like anything else; what it is exempt from
+    /// is eviction. A caller that pins more than the budget gets a pool with
+    /// nothing left to cache with, which is a caller's mistake and not the
+    /// pool's, so it is allowed and reported rather than refused.
+    pub fn pin(&self, key: Key, held: Held) {
+        let cost = held.bytes();
+        let mut inside = self.inside.lock().expect("the pool");
+        // room first, out of what may be let go of
+        while inside.bytes + inside.pinned + cost > self.budget
+            && let Some((_, gone)) = inside.kept.pop_lru()
+        {
+            inside.bytes -= gone.bytes();
+            inside.faults.evicted += 1;
+            recycle(&mut inside.scrap, gone);
+        }
+        if inside.stuck.insert(key, held).is_none() {
+            inside.pinned += cost;
+        }
+        let held = inside.bytes + inside.pinned;
+        inside.faults.highest = inside.faults.highest.max(held);
+    }
+
+    /// What is pinned, in bytes.
+    #[must_use]
+    pub fn pinned(&self) -> usize {
+        self.inside.lock().expect("the pool").pinned
     }
 
     /// Notes that a block was read off a file.
@@ -411,5 +466,46 @@ mod tests {
         pool.forget();
         assert_eq!(pool.faults().held, 0);
         assert!(pool.get(&Key::Way(0, 0, 0)).is_none());
+    }
+
+    /// The one this is for: what is pinned stays however much else goes
+    /// through the pool.
+    #[test]
+    fn what_is_pinned_is_not_let_go_of() {
+        let pool = Pool::of(16 * 1024);
+        pool.pin(Key::Way(1, 1, 0), way(64));
+        let stuck = pool.pinned();
+        assert!(stuck > 0, "nothing was pinned");
+
+        // enough of everything else to have emptied the list many times over
+        for at in 0..256 {
+            pool.put(Key::Way(at + 2, at + 2, 0), way(128));
+        }
+        assert!(pool.faults().evicted > 0, "nothing was let go of");
+        assert!(
+            pool.get(&Key::Way(1, 1, 0)).is_some(),
+            "what was pinned went anyway"
+        );
+        assert_eq!(pool.pinned(), stuck, "what is pinned changed size");
+        assert!(
+            pool.faults().held <= 16 * 1024,
+            "held {} bytes",
+            pool.faults().held
+        );
+    }
+
+    /// And it is the budget's: a pool whose pins fill it caches nothing.
+    #[test]
+    fn what_is_pinned_is_counted_against_the_budget() {
+        let pool = Pool::of(4 * 1024);
+        for at in 0..64 {
+            pool.pin(Key::Way(at, at, 0), way(64));
+        }
+        assert!(pool.pinned() > 0);
+        pool.put(Key::Arcs(0), way(64));
+        assert!(
+            pool.get(&Key::Arcs(0)).is_none(),
+            "a pool with no room left kept something anyway"
+        );
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -123,6 +123,18 @@ struct Scrap {
     bytes: Vec<Vec<u8>>,
 }
 
+impl std::fmt::Debug for Pool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // what it is holding and what it may, and not the contents: a pool
+        // printed entry by entry is a hundred thousand lines
+        let faults = self.faults();
+        f.debug_struct("Pool")
+            .field("budget", &self.budget)
+            .field("held", &faults.held)
+            .finish()
+    }
+}
+
 struct Inside {
     kept: LRU<Key, Held>,
     bytes: usize,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -43,6 +43,8 @@ pub enum Key {
     Block(u8, CellId),
     /// a way already put back, by its ends and the level it crosses
     Way(u32, u32, u8),
+    /// a block of a fixed-width array, by which array and which block
+    Array(u16, u32),
 }
 
 /// What one thing in the pool is.
@@ -52,6 +54,8 @@ pub enum Held {
     Table(Arc<HeldTable>),
     Block(Arc<CellBlock>),
     Way(Arc<Vec<NodeID>>),
+    /// a run of bytes read off a file, as a paged array holds them
+    Bytes(Arc<Vec<u8>>),
 }
 
 impl Held {
@@ -71,6 +75,7 @@ impl Held {
             // hundred bytes and the pool holds many times its budget.
             Self::Block(block) => block.bytes(),
             Self::Way(way) => way.capacity() * size_of::<NodeID>(),
+            Self::Bytes(held) => held.capacity(),
         };
         held + size_of::<Key>() + size_of::<Self>() + PER_ENTRY
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -90,6 +90,11 @@ pub struct Faults {
     pub hits: usize,
     pub misses: usize,
     pub evicted: usize,
+    /// how many blocks were read off a file, of every kind: arcs, tables, the
+    /// blocks tables come out of, and the fixed-width arrays. Everything that
+    /// reads goes through the pool, so this is what an instance costs in reads
+    /// however many structures it is made of.
+    pub reads: usize,
     /// what the pool is holding, in bytes
     pub held: usize,
     /// the most it has ever held
@@ -220,6 +225,15 @@ impl Pool {
         inside.kept.push(&key, held);
         inside.bytes += cost;
         inside.faults.highest = inside.faults.highest.max(inside.bytes);
+    }
+
+    /// Notes that a block was read off a file.
+    ///
+    /// Called by whatever did the reading rather than by the pool, which never
+    /// reads anything itself: it is asked for a block and told when one had to
+    /// be fetched.
+    pub fn note_read(&self) {
+        self.inside.lock().expect("the pool").faults.reads += 1;
     }
 
     /// Lets go of everything, keeping the room for what comes next.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -65,7 +65,11 @@ impl Held {
         let held = match self {
             Self::Arcs(arcs) => arcs.bytes(),
             Self::Table(table) => table.bytes(),
-            Self::Block(block) => block.framing_bytes(),
+            // `bytes` and not `framing_bytes`: the framing is what a block
+            // costs beyond its entries, and the entries are nearly all of it.
+            // Counted the other way a sixty four kibibyte block reads as a few
+            // hundred bytes and the pool holds many times its budget.
+            Self::Block(block) => block.bytes(),
             Self::Way(way) => way.capacity() * size_of::<NodeID>(),
         };
         held + size_of::<Key>() + size_of::<Self>() + PER_ENTRY
@@ -87,10 +91,38 @@ pub struct Faults {
     pub highest: usize,
 }
 
+/// How many buffers of each kind to keep for the next read.
+///
+/// A free list and not a cache: it holds nothing anybody wants, only room
+/// somebody is about to want again. A few is enough, since what it is for is
+/// the gap between letting one block go and reading the next.
+const SPARE: usize = 16;
+
+/// Buffers kept to be filled again.
+///
+/// # Why the room is kept when the contents are not
+///
+/// A block read builds three or four vectors, fills them, and gives them back
+/// when the block is let go of. Over a run of a few hundred thousand reads
+/// that is a million allocations of up to sixty four kibibytes apiece, and an
+/// allocator handed that pattern fragments and does not give the pages back:
+/// a pool that never holds more than its budget can still sit inside a process
+/// several times that size.
+///
+/// So the vectors are not dropped. On the way out of the cache they are
+/// emptied and put here, and the next read fills them again.
+#[derive(Default)]
+struct Scrap {
+    arcs: Vec<HeldArcs>,
+    tables: Vec<HeldTable>,
+    bytes: Vec<Vec<u8>>,
+}
+
 struct Inside {
     kept: LRU<Key, Held>,
     bytes: usize,
     faults: Faults,
+    scrap: Scrap,
 }
 
 /// A byte-budgeted cache shared by everything that reads.
@@ -111,6 +143,7 @@ impl Pool {
                 kept: LRU::new_with_capacity(1 << 18),
                 bytes: 0,
                 faults: Faults::default(),
+                scrap: Scrap::default(),
             }),
         })
     }
@@ -165,17 +198,80 @@ impl Pool {
         {
             inside.bytes -= gone.bytes();
             inside.faults.evicted += 1;
+            recycle(&mut inside.scrap, gone);
         }
         inside.kept.push(&key, held);
         inside.bytes += cost;
         inside.faults.highest = inside.faults.highest.max(inside.bytes);
     }
 
-    /// Lets go of everything.
+    /// Lets go of everything, keeping the room for what comes next.
     pub fn forget(&self) {
         let mut inside = self.inside.lock().expect("the pool");
+        while let Some((_, gone)) = inside.kept.pop_lru() {
+            recycle(&mut inside.scrap, gone);
+        }
         inside.kept.clear();
         inside.bytes = 0;
+    }
+
+    /// A block of arcs to fill, emptied and with whatever room it had kept.
+    #[must_use]
+    pub fn take_arcs(&self) -> HeldArcs {
+        let mut inside = self.inside.lock().expect("the pool");
+        inside.scrap.arcs.pop().unwrap_or_default()
+    }
+
+    /// A table to fill, on the same terms.
+    #[must_use]
+    pub fn take_table(&self) -> HeldTable {
+        let mut inside = self.inside.lock().expect("the pool");
+        inside.scrap.tables.pop().unwrap_or_default()
+    }
+
+    /// A run of bytes at least this long, for reading a block off the file.
+    ///
+    /// It comes back the length asked for and holding nothing worth reading.
+    #[must_use]
+    pub fn take_bytes(&self, want: usize) -> Vec<u8> {
+        let mut held = {
+            let mut inside = self.inside.lock().expect("the pool");
+            inside.scrap.bytes.pop().unwrap_or_default()
+        };
+        held.clear();
+        held.resize(want, 0);
+        held
+    }
+
+    /// Hands a run of bytes back, where there is room to keep it.
+    pub fn give_bytes(&self, mut held: Vec<u8>) {
+        let mut inside = self.inside.lock().expect("the pool");
+        if inside.scrap.bytes.len() < SPARE {
+            held.clear();
+            inside.scrap.bytes.push(held);
+        }
+    }
+}
+
+/// Empties what is being let go of into the free list, where there is room.
+///
+/// Only what nobody else is holding: a caller may still have the thing that
+/// was evicted, and the room is not free until it is done with it.
+fn recycle(scrap: &mut Scrap, gone: Held) {
+    match gone {
+        Held::Arcs(arcs) if scrap.arcs.len() < SPARE => {
+            if let Some(mut held) = Arc::into_inner(arcs) {
+                held.empty();
+                scrap.arcs.push(held);
+            }
+        }
+        Held::Table(table) if scrap.tables.len() < SPARE => {
+            if let Some(mut held) = Arc::into_inner(table) {
+                held.empty();
+                scrap.tables.push(held);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -229,6 +325,41 @@ mod tests {
             pool.get(&Key::Arcs(0)).is_none(),
             "the ways did not push the arcs out"
         );
+    }
+
+    /// The one this is for: a run of reads asks the allocator for the room
+    /// once and then keeps handing the same buffers round.
+    #[test]
+    fn the_room_a_read_wants_comes_back_from_the_one_before_it() {
+        let pool = Pool::of(4 * 1024);
+
+        // a run of blocks, each pushing the last out
+        let mut seen = Vec::new();
+        for at in 0..32 {
+            let mut held = pool.take_arcs();
+            held.pretend(64);
+            seen.push(held.bytes());
+            pool.put(Key::Arcs(at), Held::Arcs(Arc::new(held)));
+        }
+        assert!(pool.faults().evicted > 0, "nothing was let go of");
+
+        // and the room comes back rather than being asked for again
+        let recycled = pool.take_arcs();
+        assert!(recycled.spare() > 0, "a buffer came back with no room kept");
+        assert_eq!(recycled.edges(), 0, "and it came back holding something");
+    }
+
+    #[test]
+    fn a_run_of_bytes_comes_back_the_length_asked_for_and_empty() {
+        let pool = Pool::of(1 << 20);
+        let mut first = pool.take_bytes(100);
+        assert_eq!(first.len(), 100);
+        first[0] = 7;
+        pool.give_bytes(first);
+
+        let second = pool.take_bytes(40);
+        assert_eq!(second.len(), 40, "a different length than was asked for");
+        assert!(second.iter().all(|&byte| byte == 0), "it held something");
     }
 
     #[test]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,253 @@
+//! One cache, for everything an instance reads.
+//!
+//! # Why one and not four
+//!
+//! An instance that pages holds four kinds of thing it did not have to keep: a
+//! block of arcs, a cell's table, the block a table was read out of, and a way
+//! it has already put back. Given a budget apiece, each of them respects its
+//! own number and together they respect nothing: three caches of a hundred
+//! megabytes are three hundred megabytes, and a device with a budget for the
+//! whole of an instance has no way to say so.
+//!
+//! So there is one, and what it holds is whatever was wanted most recently
+//! whatever kind it is. That is also the right answer and not only the
+//! measurable one: a query that is walking arcs is not reading tables, and one
+//! that is putting a way back is doing neither, so the three want the room at
+//! different moments and a fixed split gives each of them less than it needs
+//! at the moment it needs it.
+//!
+//! # What is not in here
+//!
+//! The levels an instance holds outright. Those are read once when the store
+//! opens and never let go of, so they are a footing rather than a cache, and
+//! the budget is split between the two before this is given what is left.
+
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    cell_block::CellBlock, graph::NodeID, graph_block::HeldArcs, level_directory::CellId, lru::LRU,
+    paged_overlay::HeldTable,
+};
+
+/// What names one thing in the pool.
+///
+/// The kinds cannot collide: two of them may hold the same numbers and mean
+/// different things, and the kind is part of the name rather than a hope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Key {
+    /// a block of arcs, by its place in the pack
+    Arcs(u32),
+    /// a cell's table, by the level and the cell
+    Table(u8, CellId),
+    /// the block a run of tables was read out of, by the level and its first cell
+    Block(u8, CellId),
+    /// a way already put back, by its ends and the level it crosses
+    Way(u32, u32, u8),
+}
+
+/// What one thing in the pool is.
+#[derive(Clone, Debug)]
+pub enum Held {
+    Arcs(Arc<HeldArcs>),
+    Table(Arc<HeldTable>),
+    Block(Arc<CellBlock>),
+    Way(Arc<Vec<NodeID>>),
+}
+
+impl Held {
+    /// What it costs the budget.
+    ///
+    /// What the thing itself takes, and what the pool takes to keep it: a key,
+    /// an entry in the list and an entry in the index. Left out, a pool of
+    /// small things is a pool that overruns its budget by more than it holds.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        let held = match self {
+            Self::Arcs(arcs) => arcs.bytes(),
+            Self::Table(table) => table.bytes(),
+            Self::Block(block) => block.framing_bytes(),
+            Self::Way(way) => way.capacity() * size_of::<NodeID>(),
+        };
+        held + size_of::<Key>() + size_of::<Self>() + PER_ENTRY
+    }
+}
+
+/// What the list and the index take for an entry, beyond the entry itself.
+const PER_ENTRY: usize = 64;
+
+/// How the pool has been faring.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Faults {
+    pub hits: usize,
+    pub misses: usize,
+    pub evicted: usize,
+    /// what the pool is holding, in bytes
+    pub held: usize,
+    /// the most it has ever held
+    pub highest: usize,
+}
+
+struct Inside {
+    kept: LRU<Key, Held>,
+    bytes: usize,
+    faults: Faults,
+}
+
+/// A byte-budgeted cache shared by everything that reads.
+pub struct Pool {
+    budget: usize,
+    inside: Mutex<Inside>,
+}
+
+impl Pool {
+    /// A pool that may hold so many bytes.
+    #[must_use]
+    pub fn of(budget: usize) -> Arc<Self> {
+        Arc::new(Self {
+            budget,
+            inside: Mutex::new(Inside {
+                // room for the entries, which the budget in bytes bounds; the
+                // count is only what the index is made large enough for
+                kept: LRU::new_with_capacity(1 << 18),
+                bytes: 0,
+                faults: Faults::default(),
+            }),
+        })
+    }
+
+    /// What it may hold.
+    #[must_use]
+    pub fn budget(&self) -> usize {
+        self.budget
+    }
+
+    /// What it is holding, and how it has been faring.
+    #[must_use]
+    pub fn faults(&self) -> Faults {
+        let inside = self.inside.lock().expect("the pool");
+        Faults {
+            held: inside.bytes,
+            ..inside.faults
+        }
+    }
+
+    /// Whatever is under this name, where anything is.
+    #[must_use]
+    pub fn get(&self, key: &Key) -> Option<Held> {
+        let mut inside = self.inside.lock().expect("the pool");
+        match inside.kept.get(key) {
+            Some(held) => {
+                let held = held.clone();
+                inside.faults.hits += 1;
+                Some(held)
+            }
+            None => {
+                inside.faults.misses += 1;
+                None
+            }
+        }
+    }
+
+    /// Puts something under a name, letting go of whatever it has to.
+    ///
+    /// Room is made before the thing is put down, so the budget bounds what is
+    /// held rather than what was held a moment ago. A thing too large for the
+    /// whole budget is not kept at all: it is handed back to the caller either
+    /// way, and keeping it would empty the pool to hold one entry.
+    pub fn put(&self, key: Key, held: Held) {
+        let cost = held.bytes();
+        if cost > self.budget {
+            return;
+        }
+        let mut inside = self.inside.lock().expect("the pool");
+        while inside.bytes + cost > self.budget
+            && let Some((_, gone)) = inside.kept.pop_lru()
+        {
+            inside.bytes -= gone.bytes();
+            inside.faults.evicted += 1;
+        }
+        inside.kept.push(&key, held);
+        inside.bytes += cost;
+        inside.faults.highest = inside.faults.highest.max(inside.bytes);
+    }
+
+    /// Lets go of everything.
+    pub fn forget(&self) {
+        let mut inside = self.inside.lock().expect("the pool");
+        inside.kept.clear();
+        inside.bytes = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn way(nodes: usize) -> Held {
+        Held::Way(Arc::new(vec![0 as NodeID; nodes]))
+    }
+
+    #[test]
+    fn what_is_put_in_comes_back_out() {
+        let pool = Pool::of(1 << 20);
+        pool.put(Key::Way(1, 2, 0), way(8));
+        match pool.get(&Key::Way(1, 2, 0)) {
+            Some(Held::Way(held)) => assert_eq!(held.len(), 8),
+            other => panic!("a way went in and {other:?} came out"),
+        }
+        assert!(pool.get(&Key::Way(9, 9, 0)).is_none());
+        let faults = pool.faults();
+        assert_eq!((faults.hits, faults.misses), (1, 1));
+    }
+
+    /// Two kinds may hold the same numbers, and must not be each other.
+    #[test]
+    fn a_name_of_one_kind_is_not_a_name_of_another() {
+        let pool = Pool::of(1 << 20);
+        pool.put(
+            Key::Table(1, 2),
+            Held::Table(Arc::new(HeldTable::default())),
+        );
+        assert!(pool.get(&Key::Block(1, 2)).is_none());
+        assert!(pool.get(&Key::Arcs(1)).is_none());
+        assert!(pool.get(&Key::Table(1, 2)).is_some());
+    }
+
+    /// The one that matters: the budget is over everything at once, so a run
+    /// of one kind pushes out another kind rather than each keeping its own.
+    #[test]
+    fn one_budget_is_kept_across_every_kind_at_once() {
+        let pool = Pool::of(16 * 1024);
+        pool.put(Key::Arcs(0), Held::Arcs(Arc::new(HeldArcs::default())));
+        for at in 0..64 {
+            pool.put(Key::Way(at, at, 0), way(256));
+        }
+        let faults = pool.faults();
+        assert!(faults.held <= 16 * 1024, "held {} bytes", faults.held);
+        assert!(faults.evicted > 0, "nothing was let go of");
+        assert!(
+            pool.get(&Key::Arcs(0)).is_none(),
+            "the ways did not push the arcs out"
+        );
+    }
+
+    #[test]
+    fn something_larger_than_the_whole_budget_is_not_kept() {
+        let pool = Pool::of(1024);
+        pool.put(Key::Way(0, 0, 0), way(4096));
+        assert!(pool.get(&Key::Way(0, 0, 0)).is_none());
+        assert_eq!(pool.faults().held, 0, "the pool kept what it cannot hold");
+    }
+
+    #[test]
+    fn forgetting_leaves_nothing_and_costs_nothing() {
+        let pool = Pool::of(1 << 20);
+        for at in 0..32 {
+            pool.put(Key::Way(at, at, 0), way(16));
+        }
+        assert!(pool.faults().held > 0);
+        pool.forget();
+        assert_eq!(pool.faults().held, 0);
+        assert!(pool.get(&Key::Way(0, 0, 0)).is_none());
+    }
+}


### PR DESCRIPTION
Based on #614. This is what brings an instance inside a budget for the whole of
it rather than for its cell tables.

# One cache

An instance that pages held four kinds of thing it did not have to keep: a
block of arcs, a cell's table, the block a table came out of, and a way already
put back. Given a budget apiece, each respected its own number and together
they respected nothing.

```rust
pub struct Pool { /* ... */ }
pub enum Key { Arcs(u32), Table(u8, CellId), Block(u8, CellId), Way(u32, u32, u8), Array(u16, u32) }
pub enum Held { Arcs(..), Table(..), Block(..), Way(..), Bytes(..) }

pub fn of(budget) -> Arc<Self>
pub fn get(&self, key) -> Option<Held>
pub fn put(&self, key, held)
pub fn pin(&self, key, held)
pub fn note_read(&self)
```

What it holds is whatever was wanted most recently whatever kind it is, which
is also the right answer and not only the measurable one: a query walking arcs
is not reading tables, and a fixed split gives each of them less than it needs
at the moment it needs it. `Held::bytes` counts the key and the entry as well
as the thing, since a pool of small things otherwise overruns by more than it
holds. A pool also keeps a few emptied buffers to fill again rather than
dropping them.

`pin` is for what is asked something on every step of every search -- the
partition and the tree. It counts against the budget; it is the eviction it is
exempt from, not the accounting.

`note_read` counts every read of every kind, since everything that reads goes
through the pool.

# A fixed-width array that holds nothing but where it is

Every array still held whole is asked "give me entry `i`", never "find the
entry at or before key k". The number is computed from a cell, a node or a
block, so there is nothing to search and nothing to search with:

```rust
pub struct PagedArray { /* ... */ }
pub fn open(path, at, entries, wide, pool) -> io::Result<Self>
pub fn open_pinned(...) -> io::Result<Self>
pub fn get<const N: usize>(&self, index: usize) -> Option<[u8; N]>
pub fn bytes(&self) -> usize        // the same for ten entries and ten million
```

The block an entry is in is its number divided by how many go in a block, and
where that block sits is arithmetic too. The blocks are not compressed, because
a compressed block is only as long as it turned out to be and where the next
one starts would have to be written down -- which is the resident array this
abolishes.

# The level information is settled when the store is packed

```rust
PackedPartition::save / ::open
CellTree::save_cells / ::open_cells / ::reads_cells
CellTree::trim_for_queries / ::whole / ::bytes_by_part
```

A partition was worked out from a `LevelDirectory`, and a continent's is 71 MiB
read, walked and thrown away, which put the peak above anything the process
went on to hold. It is written once and read back, and only its head is read at
open.

A query asks a tree two things -- what a cell holds and where its nodes begin.
The children, the parents and the boxes are for building one and for asking
what lies where; nothing outside `cell_tree.rs` calls them at query time.
Trimmed, the tree goes from 22.0 MiB to 7.2 MiB; with its two arrays paged as
well, to an offset a level.

# The measurement was wrong

Every memory figure here had been a resident set out of `ps`, which on a Mac
counts library text shared with every other process and pages the allocator has
freed but not returned. `vmmap` on a run at a 128 MiB budget: 594.4M resident
set, 217M of it shared library, 139.8M resident and 0K dirty, **66.1M physical
footprint**. `paged_rss` reads the footprint through `proc_pid_rusage`.

`Footing` also counted the cell tree as one `CellFacts` a cell where it is also
the children, the parents and the boxes: 4.8 MiB counted against 22 MiB real.

# What it comes to

europe.ptv, 128 MiB budget, 4,800 pairs, every way put back, **0 wrong
distances and 0 wrong ways** against an instance holding everything:

```
the footing      756.3 MiB -> 0.3 MiB
steady state                  52.7 MiB
peak            167.9 MiB -> 127.8 MiB
```

Both inside the budget. `paged_rss` takes `TOOLBOX_VERIFY` to answer against a
reference and writes times and reads a query; `rank_plot` takes a fifth
argument saying the value column is a count rather than a time.

The query is 20.1x the in-memory engine at the median with the partition and
tree pinned, against 34.5x without. With room to spare it is 3.3x, so the
budget is what the rest of the gap is made of rather than the paging.