### PR TITLE
Write NearestIndex through BlockWriter, and give PagedArray a block-backed form

### DIFF
--- a/examples/nearest_browse.rs
+++ b/examples/nearest_browse.rs
@@ -73,10 +73,15 @@ fn main() {
         .save(Path::new(&segments_at))
         .expect("a segment index to write");
     for (what, at) in [("nodes", &nodes_at), ("segments", &segments_at)] {
-        let held = std::fs::metadata(at).expect("a file").len();
+        // the head names the blocks, and the blocks are the index
+        let head = std::fs::metadata(at).expect("a file").len();
+        let blocks = std::fs::metadata(toolbox_rs::nearest::blocks_beside(Path::new(at)))
+            .expect("the blocks")
+            .len();
         println!(
-            "the {what} index is {:.1} MiB on the file",
-            held as f64 / MIB as f64
+            "the {what} index is {:.1} MiB on the file, of which {:.1} MiB is the head",
+            (head + blocks) as f64 / MIB as f64,
+            head as f64 / MIB as f64,
         );
     }
 

--- a/src/block_store.rs
+++ b/src/block_store.rs
@@ -109,6 +109,13 @@ impl BlockWriter {
         )
     }
 
+    /// The blocks written so far, for a caller keeping more than one run in
+    /// one file and wanting a map of each.
+    #[must_use]
+    pub fn written(&self) -> &[BlockEntry] {
+        &self.entries
+    }
+
     /// Writes a block that has already been serialized.
     ///
     /// This is what [`push`](Self::push) is written on, and what anything else

--- a/src/nearest.rs
+++ b/src/nearest.rs
@@ -72,7 +72,9 @@ use std::{
 use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::{
-    block_store::read_at,
+    block_codec::Codec,
+    block_map::BlockMap,
+    block_store::{BlockWriter, read_at},
     bounding_box::BoundingBox,
     geometry::FPCoordinate,
     graph::Arcs,
@@ -313,7 +315,22 @@ struct Head {
     /// how many boxes each level has, the bottom row first
     counts: Vec<u32>,
     lon_scale: f64,
+    /// how many entries a block of each holds, and where every block is
+    apiece: u32,
+    boxes: BlockMap,
+    items: BlockMap,
 }
+
+/// How many entries go in a block of an index.
+///
+/// Enough that the block is worth a codec's while and few enough that reading
+/// one to answer a query is not reading a great deal that will not be looked
+/// at. Sixty four kibibytes of boxes is four thousand of them.
+pub const IN_A_BLOCK: usize = 4096;
+
+/// What the two runs of a written index are filed under.
+const BOXES: u8 = u8::MAX - 2;
+const THINGS: u8 = u8::MAX - 3;
 
 /// A nearest-first index over the nodes or the arcs of a graph.
 pub struct NearestIndex<T: Indexed> {
@@ -526,6 +543,28 @@ impl<T: Indexed> NearestIndex<T> {
                 "this index is read off a file and cannot be written back",
             ));
         };
+        // The two runs go through BlockWriter, which is what the cell tables
+        // and the arc blocks go through: the same codec, the same entry, the
+        // same map out the other end. An index over a continent's roads is
+        // three quarters of a gibibyte written plainly, which is far too much
+        // to leave to a codec that was never run.
+        let beside = blocks_beside(path);
+        let mut writer = BlockWriter::create(&beside)?;
+        let boxes_map = write_run(&mut writer, BOXES, boxes.len(), BOX_BYTES, |at, into| {
+            let (min, max) = boxes[at].corners();
+            into.extend_from_slice(&min.lat.to_le_bytes());
+            into.extend_from_slice(&min.lon.to_le_bytes());
+            into.extend_from_slice(&max.lat.to_le_bytes());
+            into.extend_from_slice(&max.lon.to_le_bytes());
+        })?;
+        let mut one = vec![0_u8; T::BYTES];
+        let items_map = write_run(&mut writer, THINGS, items.len(), T::BYTES, |at, into| {
+            items[at].write_to(&mut one);
+            into.extend_from_slice(&one);
+        })?;
+        let both = writer.finish()?;
+        debug_assert_eq!(both.len(), boxes_map.len() + items_map.len());
+
         let head = Head {
             version: VERSION,
             tag: T::TAG,
@@ -533,25 +572,15 @@ impl<T: Indexed> NearestIndex<T> {
             objects: self.objects as u64,
             counts: self.counts.clone(),
             lon_scale: self.plane.lon_scale,
+            apiece: u32::try_from(IN_A_BLOCK).expect("a block in four bytes"),
+            boxes: boxes_map,
+            items: items_map,
         };
         let head = rkyv::to_bytes::<rkyv::rancor::Error>(&head)
             .map_err(|why| std::io::Error::other(format!("an index will not serialize: {why}")))?;
-
         let mut out = BufWriter::new(File::create(path)?);
         out.write_all(&(head.len() as u64).to_le_bytes())?;
         out.write_all(&head)?;
-        for held in boxes {
-            let (min, max) = held.corners();
-            out.write_all(&min.lat.to_le_bytes())?;
-            out.write_all(&min.lon.to_le_bytes())?;
-            out.write_all(&max.lat.to_le_bytes())?;
-            out.write_all(&max.lon.to_le_bytes())?;
-        }
-        let mut into = vec![0_u8; T::BYTES];
-        for item in items {
-            item.write_to(&mut into);
-            out.write_all(&into)?;
-        }
         out.flush()
     }
 
@@ -596,24 +625,27 @@ impl<T: Indexed> NearestIndex<T> {
         }
         let boxes = running;
 
-        let at = 8 + length as u64;
+        let beside = blocks_beside(path);
+        let apiece = head.apiece as usize;
         Ok(Self {
             fan: head.fan as usize,
             objects: head.objects as usize,
             level_at,
             counts: head.counts,
-            boxes: Boxes::Paged(PagedArray::open(
-                path,
-                at,
+            boxes: Boxes::Paged(PagedArray::open_blocks(
+                &beside,
+                head.boxes,
                 boxes as usize,
                 BOX_BYTES,
+                apiece,
                 Arc::clone(pool),
             )?),
-            items: Items::Paged(PagedArray::open(
-                path,
-                at + boxes * BOX_BYTES as u64,
+            items: Items::Paged(PagedArray::open_blocks(
+                &beside,
+                head.items,
                 head.objects as usize,
                 T::BYTES,
+                apiece,
                 Arc::clone(pool),
             )?),
             plane: Scaled {
@@ -621,6 +653,65 @@ impl<T: Indexed> NearestIndex<T> {
             },
         })
     }
+}
+
+/// Where the blocks of an index go, beside the head that names them.
+///
+/// Appended rather than put in place of an extension the caller chose: two
+/// indexes written as `held.nodes` and `held.segments` would otherwise both
+/// want `held.blocks`, and the second would quietly write over the first.
+#[must_use]
+pub fn blocks_beside(path: &Path) -> std::path::PathBuf {
+    let mut beside = path.as_os_str().to_os_string();
+    beside.push(".blocks");
+    beside.into()
+}
+
+/// Writes a run of fixed-width entries as blocks of [`IN_A_BLOCK`] apiece.
+///
+/// A block holds a fixed count and not a fixed size, so which block an entry
+/// is in stays arithmetic and only how long the block turned out to be has to
+/// be written down.
+fn write_run(
+    out: &mut BlockWriter,
+    tag: u8,
+    entries: usize,
+    wide: usize,
+    mut one: impl FnMut(usize, &mut Vec<u8>),
+) -> std::io::Result<BlockMap> {
+    let mut into = Vec::new();
+    for block in 0..entries.div_ceil(IN_A_BLOCK) {
+        let first = block * IN_A_BLOCK;
+        let upto = (first + IN_A_BLOCK).min(entries);
+        into.clear();
+        for at in first..upto {
+            one(at, &mut into);
+        }
+        // by column, so the codec sees the high bytes of a coordinate as one
+        // run rather than interleaved with the low ones
+        let planed = crate::paged_array::for_writing(&into, wide);
+        out.push_bytes(
+            &planed,
+            tag,
+            (first as u128, (upto - 1) as u128),
+            (u32::try_from(block).expect("a block in four bytes"), 1),
+            (
+                u32::try_from(first).expect("an entry in four bytes"),
+                u32::try_from(upto - first).expect("a run in four bytes"),
+            ),
+            Codec::Lz4,
+            3,
+        )?;
+    }
+    // the writer holds every block of the file, and what is wanted here is the
+    // ones this run put in it
+    Ok(BlockMap::of(
+        out.written()
+            .iter()
+            .filter(|entry| entry.level == tag)
+            .copied()
+            .collect(),
+    ))
 }
 
 /// Four bytes of a written coordinate.

--- a/src/paged_array.rs
+++ b/src/paged_array.rs
@@ -41,6 +41,8 @@ use std::{
 };
 
 use crate::{
+    block_codec::Codec,
+    block_map::BlockMap,
     block_store::{NotRead, read_at},
     pool::{Held, Key, Pool},
 };
@@ -54,6 +56,70 @@ pub const BLOCK_BYTES: usize = 64 * 1024;
 /// Tells one array from another, so their blocks do not collide in the pool.
 static NEXT_ARRAY: AtomicUsize = AtomicUsize::new(0);
 
+/// Lays a block out by column instead of by row.
+///
+/// # Why a codec wants it this way
+///
+/// A block holds entries of a fixed width, one after another, and the same
+/// byte of consecutive entries is the one most like its neighbour: the high
+/// byte of a latitude does not change across a block of things that are near
+/// each other, while the low byte changes every time. Row by row those two are
+/// interleaved and a codec sees noise. Column by column the high bytes are one
+/// long run and the low bytes are their own, and only the low bytes are hard.
+///
+/// It is the ordering alone -- the same bytes, moved -- so it costs one pass
+/// each way and nothing in space.
+fn by_column(rows: &[u8], wide: usize) -> Vec<u8> {
+    let entries = rows.len() / wide;
+    let mut into = Vec::with_capacity(rows.len());
+    for byte in 0..wide {
+        for at in 0..entries {
+            into.push(rows[at * wide + byte]);
+        }
+    }
+    into
+}
+
+/// And back into rows.
+fn by_row(columns: &[u8], wide: usize) -> Vec<u8> {
+    let entries = columns.len() / wide;
+    let mut into = vec![0_u8; columns.len()];
+    for byte in 0..wide {
+        for at in 0..entries {
+            into[at * wide + byte] = columns[byte * entries + at];
+        }
+    }
+    into
+}
+
+/// Where the blocks are and what has to be done to them.
+#[derive(Debug)]
+enum Laid {
+    /// One after another, uncompressed, so where a block sits is arithmetic.
+    ///
+    /// Nothing stands: not an offset, not a length. This is what a small array
+    /// wants, where an entry a block of index would cost more than the codec
+    /// would save.
+    Flat,
+    /// Compressed, so where a block sits has to be looked up.
+    ///
+    /// A block still holds a fixed number of entries, so which block an entry
+    /// is in is still arithmetic -- it is only how long the block turned out
+    /// to be that has to be written down. That is an entry a block, which for
+    /// a big array is a rounding error against what the codec saves: three
+    /// quarters of a gibibyte of coordinates is ten thousand blocks.
+    Blocks(BlockMap),
+}
+
+/// Lays a run of entries out for writing: by column, so the codec has runs to
+/// work with rather than the interleaving of a row.
+///
+/// What [`PagedArray`] in its block form undoes on the way back.
+#[must_use]
+pub fn for_writing(rows: &[u8], wide: usize) -> Vec<u8> {
+    by_column(rows, wide)
+}
+
 /// A run of fixed-width entries on a file.
 #[derive(Debug)]
 pub struct PagedArray {
@@ -65,6 +131,7 @@ pub struct PagedArray {
     wide: usize,
     /// how many go in a block
     apiece: usize,
+    laid: Laid,
     /// which array this is, for the pool
     which: u16,
     /// whether its blocks are pinned, for an array asked something on every
@@ -98,12 +165,42 @@ impl PagedArray {
             entries,
             wide,
             apiece: BLOCK_BYTES / wide,
+            laid: Laid::Flat,
             which: u16::try_from(NEXT_ARRAY.fetch_add(1, Ordering::Relaxed))
                 .expect("more arrays than a short counts"),
             stuck: false,
             pool,
             reads: AtomicUsize::new(0),
         })
+    }
+
+    /// The same over blocks a codec has been through.
+    ///
+    /// `apiece` is how many entries a block holds, which has to be what they
+    /// were written with: it is what turns an entry's number into a block's,
+    /// and nothing in the file says it twice.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever went wrong opening the file.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an entry wider than a block, or for no entries in one.
+    pub fn open_blocks(
+        path: &Path,
+        map: BlockMap,
+        entries: usize,
+        wide: usize,
+        apiece: usize,
+        pool: Arc<Pool>,
+    ) -> std::io::Result<Self> {
+        assert!(wide > 0, "an entry of {wide} bytes");
+        assert!(apiece > 0, "a block of no entries");
+        let mut held = Self::open(path, 0, entries, wide, pool)?;
+        held.apiece = apiece;
+        held.laid = Laid::Blocks(map);
+        Ok(held)
     }
 
     /// The same, for an array whose blocks are not to be let go of.
@@ -216,15 +313,31 @@ impl PagedArray {
         if let Some(Held::Bytes(held)) = self.pool.get(&key) {
             return Ok(held);
         }
-        // the last block is short where the entries do not fill it
-        let first = which * self.apiece;
-        let held = (self.entries - first).min(self.apiece) * self.wide;
-        let mut into = vec![0_u8; held];
-        read_at(
-            &self.held,
-            self.at + (which * self.apiece * self.wide) as u64,
-            &mut into,
-        )?;
+        let into = match &self.laid {
+            Laid::Flat => {
+                // the last block is short where the entries do not fill it
+                let first = which * self.apiece;
+                let held = (self.entries - first).min(self.apiece) * self.wide;
+                let mut into = vec![0_u8; held];
+                read_at(
+                    &self.held,
+                    self.at + (which * self.apiece * self.wide) as u64,
+                    &mut into,
+                )?;
+                into
+            }
+            Laid::Blocks(map) => {
+                let entry = *map.entries().get(which).ok_or(NotRead::NotHere)?;
+                let mut stored = vec![0_u8; entry.stored as usize];
+                read_at(&self.held, entry.at, &mut stored)?;
+                let codec =
+                    Codec::of(entry.codec).map_err(|_| NotRead::UnknownCodec(entry.codec))?;
+                let held = codec
+                    .decode(&stored, entry.unpacked as usize)
+                    .map_err(NotRead::Corrupt)?;
+                by_row(&held, self.wide)
+            }
+        };
         self.reads.fetch_add(1, Ordering::Relaxed);
         self.pool.note_read();
         let held = Arc::new(into);


### PR DESCRIPTION
The nearest index went through neither of the crate's two storage paths
cleanly. It used `PagedArray`'s paging but not `BlockWriter`'s packing, so a
continent's roads were three quarters of a gibibyte written plainly with a
codec that was never run. The reasoning behind that -- no offsets written down,
so no compression possible -- is right for the partition and the cell arrays,
which are ten mebibytes, and wrong for an index a hundred times their size.

# A block-backed PagedArray

```rust
pub fn open_blocks(path, map: BlockMap, entries, wide, apiece, pool) -> io::Result<Self>
```

A block still holds a fixed *number* of entries, so which block an entry is in
is still arithmetic and the lookup stays O(1); only how long the block turned
out to be has to be written down, which is one entry a block. Ten thousand of
them for three quarters of a gibibyte of coordinates is a rounding error
against what the codec saves.

The flat form is unchanged and still what the partition and the cell arrays
use, where an entry a block of index would cost more than a codec would save.

# The packing

`NearestIndex::save` writes both its runs through `BlockWriter::push_bytes`
with `Codec::Lz4` -- the same path the cell tables and the arc blocks take --
and keeps the two `BlockMap`s in its head. `BlockWriter::written` hands back
what has been written so far, for a caller keeping more than one run in one
file.

A block is laid out by column before the codec sees it and put back into rows
after. The same byte of consecutive entries is the one most like its
neighbour: the high byte of a latitude does not change across a block of things
that are near each other, while the low byte changes every time. Row by row a
codec sees those two interleaved; column by column it sees runs. It is the
ordering alone, so it costs one pass each way and nothing in space.

```rust
pub fn blocks_beside(path: &Path) -> PathBuf
```

Appended rather than put in place of an extension the caller chose. Written as
`held.nodes` and `held.segments`, two indexes both wanted `held.blocks` and the
second wrote over the first. That bug was found by measuring, not by reading:
it needed a run that writes both indexes and then queries both.

# What it costs and what it saves

europe.ptv, 10,000 places drawn from the box the data lies in, every paged
answer identical to the held one:

```
index        plain      lz4   +column   saved
nodes       352.4M   206.7M    101.0M     71%
segments    412.7M   267.2M    210.5M     49%

slowdown at 64 MiB   plain    lz4   +column
nodes                4.69x  5.60x     7.91x
segments             3.80x  5.03x     6.73x
```

A trade and not a free win: two thirds off the nodes and a half off the
segments, against sixty per cent more time. The flat form remains a one-line
choice at `open` for a caller that would rather have the speed.

The segments compress less for a reason worth knowing. Their id is an arc
number, which the packing sort scatters; a node's id is its number in a graph
already laid out by cell, so node ids run with their neighbours and compress
where arc ids do not. Delta-coding the id column against the block's first
would likely close most of that gap, and is not done here.