### PR TITLE
Add a weekly cargo upgrade workflow, and raise thirteen requirements

### DIFF
--- a/.github/workflows/cargo-upgrade.yml
+++ b/.github/workflows/cargo-upgrade.yml
@@ -1,0 +1,67 @@
+name: "cargo upgrade"
+
+# Dependabot only proposes a cargo update when the new version falls outside the
+# requirement, so a bare caret like `rkyv = "0.8.15"` never moves however many
+# 0.8.x are released. This raises the satisfied ones; dependabot keeps the
+# incompatible ones, which is why --incompatible is not passed here.
+#
+# The pull request is opened with GITHUB_TOKEN, which does not trigger the other
+# workflows, so this one builds and tests before opening it.
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: rustup update stable && rustup default stable
+      - run: cargo install cargo-edit --locked
+      - id: upgrade
+        run: |
+          cargo upgrade | tee upgraded.txt
+          if git diff --quiet -- Cargo.toml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.upgrade.outputs.changed == 'true'
+        run: cargo build --verbose
+      - if: steps.upgrade.outputs.changed == 'true'
+        run: cargo test --verbose
+      - if: steps.upgrade.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c deps/cargo-upgrade
+          git commit -m "Raise dependency requirements to the latest compatible versions" -- Cargo.toml
+          git push -f origin deps/cargo-upgrade
+          if gh pr view deps/cargo-upgrade --json state -q .state 2>/dev/null | grep -qx OPEN; then
+            echo "pull request already open, pushed to it"
+            exit 0
+          fi
+          {
+            echo "\`cargo upgrade\` raising requirements that the existing caret"
+            echo "already satisfied, which dependabot does not propose."
+            echo
+            echo '```'
+            cat upgraded.txt
+            echo '```'
+            echo
+            echo "\`cargo build\` and \`cargo test\` pass on this branch."
+          } > body.md
+          gh pr create --base main --head deps/cargo-upgrade \
+            --title "Raise dependency requirements to the latest compatible versions" \
+            --body-file body.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,23 +40,23 @@ name = "renumber"
 path = "src/renumber/bin/main.rs"
 
 [dependencies]
-rkyv = "0.8.15"
-bitvec = "1.0.1"
-clap = { version = "4.5.38", features = ["derive"] }
-env_logger = "0.11.8"
-rustc-hash = "2.1.1"
+rkyv = "0.8.18"
+bitvec = "1.1.1"
+clap = { version = "4.6.6", features = ["derive"] }
+env_logger = "0.11.11"
+rustc-hash = "2.1.3"
 geojson = "1.0.0"
-indicatif = "0.18.0"
+indicatif = "0.18.6"
 itertools = "0.15.0"
-log = "0.4.27"
+log = "0.4.34"
 num = "0.4.3"
-rand = "0.10.0"
-rayon = "1.10.0"
-tempfile = "3.20.0"
-thiserror = "2.0.12"
-xxhash-rust = {version = "0.8.15", features = ["xxh3"] }
+rand = "0.10.2"
+rayon = "1.12.0"
+tempfile = "3.27.0"
+thiserror = "2.0.20"
+xxhash-rust = {version = "0.8.18", features = ["xxh3"] }
 lz4_flex = "0.14.0"
-flate2 = "1.1.9"
+flate2 = "1.1.10"
 zstd = "0.13.3"
 libc = "0.2.189"
 


### PR DESCRIPTION
Two commits.

**`.github/workflows/cargo-upgrade.yml`** is new: weekly and on
`workflow_dispatch`, it runs `cargo upgrade`, and if `Cargo.toml` moved it
builds, tests, and opens or force-pushes `deps/cargo-upgrade`.

**`Cargo.toml`** has thirteen requirements raised to what cargo resolves today:

| | | | |
|---|---|---|---|
| rkyv | 0.8.15 → 0.8.18 | bitvec | 1.0.1 → 1.1.1 |
| clap | 4.5.38 → 4.6.6 | env_logger | 0.11.8 → 0.11.11 |
| rustc-hash | 2.1.1 → 2.1.3 | indicatif | 0.18.0 → 0.18.6 |
| log | 0.4.27 → 0.4.34 | rand | 0.10.0 → 0.10.2 |
| rayon | 1.10.0 → 1.12.0 | tempfile | 3.20.0 → 3.27.0 |
| thiserror | 2.0.12 → 2.0.20 | xxhash-rust | 0.8.15 → 0.8.18 |
| flate2 | 1.1.9 → 1.1.10 | | |

All inside the caret they were already under, so no API changes and no call
sites move.

## Why dependabot was not proposing these

Cargo.lock is not in the repository and every requirement is a bare caret, so
dependabot proposes a cargo update only when the new version falls outside the
requirement. Its entire history of cargo pull requests here is major bumps --
rand 0.9.1 to 0.10.0, bincode 1.3.3 to 2.0.0, geojson 0.24.1 to 1.0.0,
criterion 0.7.0 to 0.8.2 -- and the `cargo-minor-and-patch` group has never
fired once.

`versioning-strategy: increase` would cover it, but cargo accepts only
`lockfile-only` and `auto` for that property; the dependabot config check
rejects `increase`. `cargo upgrade` from cargo-edit is what rewrites a
satisfied requirement, hence the workflow. `--incompatible` is not passed,
since dependabot already handles those and they deserve their own pull request.

## Checks

`cargo test` clean in debug, which is what CI runs. clippy clean across all
targets, `cargo fmt --check` clean.

The workflow was rehearsed both ways: against main it reproduces exactly the
thirteen bumps above, and against this branch it finds nothing and exits
without opening anything.

Its pull requests are opened with `GITHUB_TOKEN`, which does not trigger other
workflows, so they will carry no check marks; the workflow builds and tests
before opening. If branch protection requires checks, this needs a PAT instead.

In release, `complete_graph::tests::test_get_mut_index_out_of_bounds` fails. It
fails identically on unmodified main and is unrelated to this change.
`CompleteGraph::new(3)` allocates `3 * 3` slots and `get_mut(0, 4)` indexes
`0 * 3 + 4 = 4`, which is in bounds, so the only check on `j` is the
`debug_assert!`. The test's comment claims the vector access panics in release;
it does not. CI runs `cargo test` in debug only.