### PR TITLE
Add a PostToolUse hook running cargo fmt and clippy

### DIFF
--- a/.claude/hooks/rust-checks.sh
+++ b/.claude/hooks/rust-checks.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Formats and lints after a change to a Rust file.
+#
+# Run as a PostToolUse hook on Edit, Write and MultiEdit. It does the two
+# things this repository asks of every change before it is committed, at the
+# moment the change is made rather than at the end of a long session, so that a
+# lint is fixed while the reason for the code is still in mind.
+#
+# What it does:
+#   * nothing at all unless a .rs file was written
+#   * cargo fmt --all, and says so where it moved something, because the file
+#     on disk is then not the file the editor just wrote
+#   * cargo clippy --all-targets, and refuses the change where it complains,
+#     handing the complaints back to be fixed
+#
+# --all-targets and not --lib: the examples and the tests are where several
+# real mistakes have been caught, and a lint that only reads the library is a
+# lint that misses them.
+#
+# Set TOOLBOX_SKIP_CLIPPY=1 to keep the formatting and drop the lint, for a run
+# of many small edits where waiting ten seconds each time is worse than waiting
+# once at the end.
+
+set -uo pipefail
+
+payload=$(cat)
+file=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+case "$file" in
+*.rs) ;;
+*) exit 0 ;;
+esac
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$root" || exit 0
+
+notes=""
+
+before=$(git diff --name-only 2>/dev/null)
+if ! fmt=$(cargo fmt --all 2>&1); then
+    printf 'cargo fmt could not run:\n%s\n' "$fmt" >&2
+    exit 2
+fi
+after=$(git diff --name-only 2>/dev/null)
+if [ "$before" != "$after" ]; then
+    notes="cargo fmt reformatted files: what is on disk is not exactly what was written, so read before editing again."
+fi
+
+if [ "${TOOLBOX_SKIP_CLIPPY:-0}" != "1" ]; then
+    if ! lint=$(cargo clippy --all-targets --quiet 2>&1); then
+        printf 'cargo clippy is unhappy with this change:\n\n%s\n' "$lint" >&2
+        exit 2
+    fi
+    if printf '%s' "$lint" | grep -qE '^(warning|error)'; then
+        printf 'cargo clippy warns about this change:\n\n%s\n' "$lint" >&2
+        exit 2
+    fi
+fi
+
+if [ -n "$notes" ]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$notes"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rust-checks.sh",
+            "timeout": 300,
+            "statusMessage": "Formatting and linting the change"
+          }
+        ]
+      }
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,5 +103,13 @@ the change itself — the signatures, the fields, the behaviour — and put the
 motivation after; a reviewer opens a diff already knowing they want to see
 what moved.
 
+A hook formats and lints every change to a `.rs` file as it is made:
+`.claude/hooks/rust-checks.sh` runs `cargo fmt --all` and then
+`cargo clippy --all-targets`, and refuses the change where clippy complains, so
+a lint is fixed while the reason for the code is still in mind rather than in a
+sweep at the end. It says so when the formatter moved something, since what is
+then on disk is not what was written. `TOOLBOX_SKIP_CLIPPY=1` keeps the
+formatting and drops the lint, for a run of many small edits.
+
 Releases are cut by release-plz from `main`; do not bump the version in
 `Cargo.toml` by hand.


### PR DESCRIPTION
`.claude/hooks/rust-checks.sh`, registered as a PostToolUse hook in
`.claude/settings.json` for `Edit`, `Write`, `MultiEdit` and `Bash`.

Where a `.rs` file was written it runs `cargo fmt --all`, then
`cargo clippy --all-targets`, and exits 2 with the diagnostics if clippy has
any, so the change is refused and the lint is fixed while the reason for the
code is still at hand rather than in a sweep at the end of a session. For
`Bash` it checks `git status --porcelain -- '*.rs'`, since a shell command can
write Rust too.

`--all-targets` and not `--lib`: the examples and the tests are where several
real mistakes have been caught here, and a lint that only reads the library
misses them.

It reports when the formatter moved something, since what is on disk is then
not what was written and a further edit against the old text will not apply.
`TOOLBOX_SKIP_CLIPPY=1` keeps the formatting and drops the lint, for a run of
many small edits where waiting ten seconds each time is worse than waiting once
at the end.

Nothing runs for a file that is not Rust.

First of four. `feat/customization-update` is stacked on this.