### PR TITLE
Add Customization::update to drop only the tables a changed arc dirties

### DIFF
--- a/.claude/hooks/rust-checks.sh
+++ b/.claude/hooks/rust-checks.sh
@@ -25,15 +25,27 @@
 set -uo pipefail
 
 payload=$(cat)
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null)
 file=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
-
-case "$file" in
-*.rs) ;;
-*) exit 0 ;;
-esac
 
 root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$root" || exit 0
+
+# An editing tool says which file it wrote. A shell command does not, and a
+# good deal of the editing here is done by a shell command -- a heredoc, a
+# script, sed -- so for those the question is asked of the working tree
+# instead: has any Rust file changed since the last commit.
+case "$tool" in
+Bash)
+    git status --porcelain -- '*.rs' 2>/dev/null | grep -q . || exit 0
+    ;;
+*)
+    case "$file" in
+    *.rs) ;;
+    *) exit 0 ;;
+    esac
+    ;;
+esac
 
 notes=""
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write|MultiEdit|Bash",
         "hooks": [
           {
             "type": "command",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,10 @@ the change itself — the signatures, the fields, the behaviour — and put the
 motivation after; a reviewer opens a diff already knowing they want to see
 what moved.
 
-A hook formats and lints every change to a `.rs` file as it is made:
+A hook formats and lints every change to a `.rs` file as it is made, whether
+it was written by an editing tool or by a shell command -- a heredoc, a script,
+`sed` -- since a good deal of the editing here is the latter and a hook that
+only watches `Edit` watches half of it:
 `.claude/hooks/rust-checks.sh` runs `cargo fmt --all` and then
 `cargo clippy --all-targets`, and refuses the change where clippy complains, so
 a lint is fixed while the reason for the code is still in mind rather than in a

--- a/examples/on_device.rs
+++ b/examples/on_device.rs
@@ -1,0 +1,126 @@
+//! What it costs to customize again when some weights change.
+//!
+//!   on_device <graph> <directory> [share ...]
+//!
+//! A device holding a map is told that some roads are slower than the map
+//! says: a jam, a closure, a fresh traffic feed. What that costs is not a
+//! customization -- the tables that do not depend on those roads are still
+//! right -- and the point of this is to say how much less it is, against the
+//! full run it is being spared.
+//!
+//! A share is a percentage of the arcs of the graph, so `0.1 1 10 100` asks
+//! about a thousandth, a hundredth, a tenth and all of them.
+//!
+//! The arcs are drawn at random from the whole graph, which is the worst case
+//! for this: a real feed names roads that are near each other, and roads near
+//! each other share cells, so the same count of them dirties fewer tables.
+
+use std::{env::args, time::Instant};
+
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use toolbox_rs::{
+    customization::Customization,
+    graph::EdgeID,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    static_graph::StaticGraph,
+};
+
+/// Works out every table there is, which is what a customization comes to.
+fn customize(held: &Customization, levels: usize) -> usize {
+    let mut tables = 0;
+    for level in 0..levels {
+        for cell in 0..held.cells_on_level(level) as CellId {
+            if held.distances_of(level, cell).is_some() {
+                tables += 1;
+            }
+        }
+    }
+    tables
+}
+
+fn main() {
+    let mut argv = args().skip(1);
+    let mut next = |what: &str| {
+        argv.next().unwrap_or_else(|| {
+            panic!("usage: on_device <graph> <directory> [share ...]: missing {what}")
+        })
+    };
+    let graph_path = next("graph");
+    let directory_path = next("directory");
+    let shares: Vec<f64> = argv
+        .map(|share| share.parse::<f64>().expect("a share in per cent"))
+        .collect();
+    let shares = if shares.is_empty() {
+        vec![0.1, 1.0, 10.0, 100.0]
+    } else {
+        shares
+    };
+
+    let edges = io::read_edges_from_file(&graph_path);
+    let directory: LevelDirectory = io::read_from_file(&directory_path);
+    let levels = directory.levels();
+    let arcs = edges.len();
+    println!(
+        "{} nodes, {arcs} arcs, {levels} levels",
+        directory.number_of_nodes()
+    );
+
+    // The full run, which is what everything else is measured against. It is
+    // also what leaves a customization in the state an update starts from, so
+    // it is done once and then updated over and over.
+    let started = Instant::now();
+    let mut held = Customization::new(StaticGraph::new(edges.clone()), directory.clone());
+    let tables = customize(&held, levels);
+    let whole = started.elapsed();
+    println!("customized {tables} tables in {whole:.1?}, which is the run an update is spared\n");
+
+    println!(
+        "{:>10} {:>8} {:>12} {:>10} {:>12} {:>10} {:>10}",
+        "drawn", "share", "arcs", "dirty", "of tables", "took", "of a run"
+    );
+    let mut rng = StdRng::seed_from_u64(0x0DE7);
+    for share in shares {
+        let how_many = ((arcs as f64) * share / 100.0).round() as usize;
+        let how_many = how_many.clamp(1, arcs);
+
+        // Twice over: once from the whole graph, which is the worst this can
+        // be asked to do, and once from one run of it. The nodes were
+        // renumbered so that a cell's nodes are a run, so a run of arcs is
+        // roads near each other -- which is what a jam is, and what a feed
+        // naming one part of a city is.
+        for scattered in [true, false] {
+            let changes: Vec<(EdgeID, u32)> = if scattered {
+                (0..how_many)
+                    .map(|_| (rng.random_range(0..arcs), 1 + rng.random_range(0..1000)))
+                    .collect()
+            } else {
+                let first = if how_many >= arcs {
+                    0
+                } else {
+                    rng.random_range(0..arcs - how_many)
+                };
+                (first..(first + how_many).min(arcs))
+                    .map(|edge| (edge, 1 + rng.random_range(0..1000)))
+                    .collect()
+            };
+
+            let started = Instant::now();
+            let dirty = held.update(&changes);
+            let marked = started.elapsed();
+            let started = Instant::now();
+            customize(&held, levels);
+            let took = marked + started.elapsed();
+
+            println!(
+                "{:>10} {:>7.1}% {:>12} {dirty:>10} {:>11.1}% {:>10} {:>9.1}%",
+                if scattered { "scattered" } else { "together" },
+                share,
+                changes.len(),
+                100.0 * dirty as f64 / tables as f64,
+                format!("{took:.1?}"),
+                100.0 * took.as_secs_f64() / whole.as_secs_f64(),
+            );
+        }
+    }
+}

--- a/src/customization.rs
+++ b/src/customization.rs
@@ -17,7 +17,7 @@
 use crate::{
     border_levels::BorderLevels,
     edge::InputEdge,
-    graph::{Graph, NodeID},
+    graph::{EdgeID, Graph, NodeID},
     level_directory::{CellId, LevelDirectory},
     one_to_many_dijkstra::OneToManyDijkstra,
     overlay::{CellTable, Overlay},
@@ -26,7 +26,7 @@ use crate::{
 };
 use log::debug;
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     cell::RefCell,
     sync::{
@@ -639,6 +639,120 @@ impl Customization {
     /// everything else here does. Handing a table out is a borrow that lasts
     /// as long as the caller reads it, and dropping the tables underneath a
     /// reader is the one thing the slots cannot be asked to allow.
+    /// Takes new weights for some arcs and forgets only what depended on them.
+    ///
+    /// # What a changed arc costs
+    ///
+    /// A cell's table says what it costs to cross the cell, which is worked
+    /// out from what is inside it: at the finest level the arcs of the graph,
+    /// and above that the tables of the cells below plus the arcs between
+    /// them. So an arc that changes weight spoils the table of the cell it is
+    /// inside, and of every cell above that one, and no others. An arc that
+    /// leaves a cell is not inside it: it is inside the first cell that holds
+    /// both its ends, which is what decides where the spoiling starts.
+    ///
+    /// Everything else is still good and is kept. That is the whole of what
+    /// makes this affordable on a device: a hundredth of the arcs changing is
+    /// not a hundredth of the work of a customization, but it is a long way
+    /// from all of it.
+    ///
+    /// The tables are not worked out here. They are forgotten, and the next
+    /// caller to ask for one works it out -- which is what
+    /// [`distances_of`](Self::distances_of) has always done, and means a cell
+    /// nobody asks about is never paid for.
+    ///
+    /// Returns how many tables were marked dirty and forgotten.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an arc the graph does not have.
+    pub fn update(&mut self, changes: &[(EdgeID, u32)]) -> usize {
+        // The partition and the border levels are worked out from the shape of
+        // the graph and not from its weights, so they outlive a change of
+        // weight and are not touched here.
+        // Which tables the changes dirty is worked out before any weight is
+        // written, since the partition is read off `self` and the weights are
+        // written to it. The partition itself does not move: it is the shape
+        // of the graph and not its weights.
+        let levels = self.directory.levels();
+        let mut dirty: FxHashSet<(usize, CellId)> = FxHashSet::default();
+        {
+            let partition = self.partition();
+            for &(edge, _) in changes {
+                let target = self.graph.target(edge);
+                // where the arc leaves from, which is the row of the adjacency
+                // it sits in, and where it goes
+                let source = self.source_of(edge);
+                let (one, other) = (partition.word(source), partition.word(target));
+
+                // The cell the arc is inside, which is where the dirt starts.
+                //
+                // For an arc with both ends in one cell of the finest level
+                // that is the base layer, which is the ordinary case. For an
+                // arc that leaves its cell it is higher up: such an arc is
+                // inside no cell of the base layer -- neither end's table is
+                // worked out from it, since a cell's table is worked out from
+                // what is within it -- and is inside the first cell that holds
+                // both its ends. Starting at the base layer for those too
+                // would be right and would dirty two tables a border arc that
+                // do not depend on it.
+                let inside = partition
+                    .highest_different_level(one, other)
+                    .map_or(0, |level| level + 1);
+
+                // and up from there: a cell whose child changed is worked out
+                // from that child's table, so it is dirty too, and so is its
+                // own parent, to the top
+                for level in inside..levels {
+                    dirty.insert((level, partition.cell_of(source, level)));
+                }
+            }
+        }
+
+        for &(edge, weight) in changes {
+            *self.graph.data_mut(edge) = weight;
+        }
+
+        for &(level, cell) in &dirty {
+            if let Some(slot) = self
+                .tabulated
+                .get_mut(level)
+                .and_then(|level| level.get_mut(cell as usize))
+            {
+                slot.take();
+            }
+        }
+        dirty.len()
+    }
+
+    /// Which node an arc leaves.
+    ///
+    /// The adjacency holds where an arc goes and not where it came from, so
+    /// this is a search of the offsets: the last node whose arcs begin at or
+    /// before this one.
+    ///
+    /// # Panics
+    ///
+    /// Panics for an arc the graph does not have.
+    #[must_use]
+    pub fn source_of(&self, edge: EdgeID) -> NodeID {
+        assert!(
+            edge < self.graph.number_of_edges(),
+            "no arc {edge} in the graph"
+        );
+        let mut low = 0;
+        let mut high = self.graph.number_of_nodes();
+        while low + 1 < high {
+            let middle = low + (high - low) / 2;
+            if self.graph.begin_edges(middle) <= edge {
+                low = middle;
+            } else {
+                high = middle;
+            }
+        }
+        low
+    }
+
     pub fn forget(&mut self) {
         for level in &mut self.tabulated {
             for slot in level {
@@ -1672,5 +1786,126 @@ mod tests {
         assert_eq!(wrong.built, wrong.expected + 100);
         assert_eq!(wrong.from, border_nodes[0] as usize);
         assert_eq!(wrong.to, border_nodes[1] as usize);
+    }
+
+    /// The one that matters for an update: after changing some weights and
+    /// forgetting what depended on them, every table is the table a
+    /// customization built from scratch on the changed graph has.
+    #[test]
+    fn an_update_leaves_what_a_fresh_customization_would_have_built() {
+        use crate::graph::Graph;
+
+        let (graph, directory) = crate::grid_graph::grid(16, true);
+        let (again, _) = crate::grid_graph::grid(16, true);
+        let arcs = Graph::number_of_edges(&graph);
+        let mut held = Customization::new(graph, directory.clone());
+        // customized first, so the update is against tables that exist
+        for level in 0..directory.levels() {
+            for cell in 0..held.cells_on_level(level) as CellId {
+                let _ = held.distances_of(level, cell);
+            }
+        }
+
+        // a spread of arcs: some inside a cell, some crossing one
+        let changes: Vec<(EdgeID, u32)> = (0..arcs)
+            .step_by(7)
+            .map(|edge| (edge, 3 + (edge % 11) as u32))
+            .collect();
+        assert!(changes.len() > 20, "the update is worth making");
+        let dirty = held.update(&changes);
+        assert!(dirty > 0, "an update dirtied nothing");
+
+        // and the same changes made to a graph that is then customized whole
+        let mut fresh = again;
+        for &(edge, weight) in &changes {
+            *fresh.data_mut(edge) = weight;
+        }
+        let fresh = Customization::new(fresh, directory.clone());
+
+        for level in 0..directory.levels() {
+            for cell in 0..fresh.cells_on_level(level) as CellId {
+                match (
+                    held.distances_of(level, cell),
+                    fresh.distances_of(level, cell),
+                ) {
+                    (Some(one), Some(other)) => {
+                        assert_eq!(
+                            one.border_nodes_of(),
+                            other.border_nodes_of(),
+                            "cell {cell} of level {level} borders differently"
+                        );
+                        let wide = one.border_nodes_of().len();
+                        for source in 0..wide {
+                            assert_eq!(
+                                one.row(source),
+                                other.row(source),
+                                "cell {cell} of level {level}, row {source}"
+                            );
+                        }
+                    }
+                    (None, None) => {}
+                    (one, other) => panic!(
+                        "cell {cell} of level {level}: {} against {}",
+                        one.is_some(),
+                        other.is_some()
+                    ),
+                }
+            }
+        }
+    }
+
+    /// An update dirties what depends on the arcs and leaves the rest, which
+    /// is the whole of why it is worth doing.
+    #[test]
+    fn an_update_dirties_less_than_everything() {
+        let (graph, directory) = crate::grid_graph::grid(32, true);
+        let mut held = Customization::new(graph, directory.clone());
+        let all: usize = (0..directory.levels())
+            .map(|level| held.cells_on_level(level))
+            .sum();
+
+        // one arc, which is inside one cell of the base layer
+        let dirty = held.update(&[(0, 9)]);
+        assert!(
+            dirty <= directory.levels(),
+            "one arc dirtied {dirty} tables of {all}"
+        );
+        assert!(dirty >= 1, "one arc dirtied nothing");
+    }
+
+    /// An arc that leaves its cell is inside none of the base layer, so the
+    /// dirt starts above it.
+    #[test]
+    fn an_arc_that_leaves_its_cell_does_not_dirty_the_base_layer() {
+        use crate::graph::Graph;
+
+        let (graph, directory) = crate::grid_graph::grid(16, true);
+        let (again, _) = crate::grid_graph::grid(16, true);
+        let arcs = Graph::number_of_edges(&graph);
+        let held = Customization::new(graph, directory.clone());
+        let partition = held.partition();
+
+        // an arc whose ends are in different cells of the finest level
+        let crossing = (0..arcs).find(|&edge| {
+            let source = held.source_of(edge);
+            let target = Graph::target(held.graph(), edge);
+            partition.cell_of(source, 0) != partition.cell_of(target, 0)
+        });
+        let Some(crossing) = crossing else {
+            panic!("a grid of two hundred and fifty six has no arc leaving a cell");
+        };
+        let source = held.source_of(crossing);
+        let base = partition.cell_of(source, 0);
+
+        let mut held = held;
+        held.update(&[(crossing, 5)]);
+        // the base layer cell of that end still has whatever it had, since its
+        // table was never worked out from an arc that leaves it
+        let mut fresh = again;
+        *fresh.data_mut(crossing) = 5;
+        let fresh = Customization::new(fresh, directory);
+        let one = held.distances_of(0, base).map(|held| held.row(0).to_vec());
+        let other = fresh.distances_of(0, base).map(|held| held.row(0).to_vec());
+        assert_eq!(one, other);
     }
 }


### PR DESCRIPTION
    Customization::update(&mut self, changes: &[(EdgeID, u32)]) -> usize
    Customization::source_of(&self, edge: EdgeID) -> NodeID

`update` takes new weights for some arcs and forgets only what depended on
them, returning how many tables it dropped.

A cell's table says what it costs to cross the cell, worked out from what is
inside it: at the base layer the arcs of the graph, and above that the tables
of the cells below plus the arcs between them. So an arc whose weight changes
dirties the table of the cell it is inside, and every cell above that one, and
no others.

An arc that leaves its cell is inside none of the base layer — neither end's
table is worked out from it — and is inside the first cell that holds both its
ends, which is where its dirt starts. Marking the base layer for those too
would be correct and would dirty two tables a border arc that do not depend
on it.

Nothing is recomputed in `update`. The tables are dropped and the next caller
to ask for one works it out, which is what `distances_of` has always done: a
cell nobody asks about is never paid for. A test asserts that after an update
every table equals the table a customization built from scratch on the changed
graph has.

`source_of` searches the offsets for the node an arc leaves, since an adjacency
array holds where an arc goes and not where it came from.

## What it saves, and when it does not

`examples/on_device.rs`, europe.ptv, 18,010,173 nodes and 42,188,664 arcs over
six levels. A full customization is 623,435 tables in 24.6s.

| drawn | share | arcs | dirty | of tables | took | of a run |
|---|---|---|---|---|---|---|
| scattered | 0.1% | 42,189 | 92,758 | 14.9% | 11.7s | 47.6% |
| together | 0.1% | 42,189 | 594 | 0.1% | 35.3ms | 0.1% |
| scattered | 1.0% | 421,887 | 386,905 | 62.1% | 16.7s | 67.7% |
| together | 1.0% | 421,887 | 5,899 | 0.9% | 1.2s | 4.9% |
| scattered | 10.0% | 4,218,866 | 619,797 | 99.4% | 22.5s | 91.5% |
| together | 10.0% | 4,218,866 | 66,303 | 10.6% | 1.4s | 5.9% |
| scattered | 100.0% | 42,188,664 | 623,380 | 100.0% | 52.9s | 215.0% |
| together | 100.0% | 42,188,664 | 623,393 | 100.0% | 23.8s | 96.6% |

Where the arcs are near one another it is worth what it was built for: a
thousandth of the graph changing costs a thousandth of a customization, and a
tenth costs a seventeenth. Where they are scattered over a continent it is
worth little — a thousandth of the arcs dirties a seventh of the tables,
because each one dirties a cell at every level and the coarse levels have few
cells to dirty.

A feed naming one part of a city is the first; a feed naming every road at once
is the second, and for that a customization from scratch is quicker than an
update, which is what the last row says.

691 tests pass, clippy and fmt clean. Second of four, stacked on #619.