### PR TITLE
Write measurement CSV from two examples, and draw rank plots as pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 Cargo.lock
 /.claude/settings.local.json
 .DS_Store
+
+# Scripts that re-run the measurements, and what they produce. Kept out of
+# the repository on purpose: they name paths on one machine and write large
+# files beside them.
+/experiments/

--- a/examples/on_device.rs
+++ b/examples/on_device.rs
@@ -75,6 +75,10 @@ fn main() {
     let whole = started.elapsed();
     println!("customized {tables} tables in {whole:.1?}, which is the run an update is spared\n");
 
+    // one row a measurement, for whatever draws the picture
+    let writing = std::env::var("TOOLBOX_TIMINGS").ok();
+    let mut rows = String::from("drawn,share,arcs,dirty,tables,seconds,whole_seconds\n");
+
     println!(
         "{:>10} {:>8} {:>12} {:>10} {:>12} {:>10} {:>10}",
         "drawn", "share", "arcs", "dirty", "of tables", "took", "of a run"
@@ -112,6 +116,17 @@ fn main() {
             customize(&held, levels);
             let took = marked + started.elapsed();
 
+            if writing.is_some() {
+                use std::fmt::Write as _;
+                let _ = writeln!(
+                    rows,
+                    "{},{share},{},{dirty},{tables},{:.6},{:.6}",
+                    if scattered { "scattered" } else { "together" },
+                    changes.len(),
+                    took.as_secs_f64(),
+                    whole.as_secs_f64(),
+                );
+            }
             println!(
                 "{:>10} {:>7.1}% {:>12} {dirty:>10} {:>11.1}% {:>10} {:>9.1}%",
                 if scattered { "scattered" } else { "together" },
@@ -122,5 +137,10 @@ fn main() {
                 100.0 * took.as_secs_f64() / whole.as_secs_f64(),
             );
         }
+    }
+
+    if let Some(at) = &writing {
+        std::fs::write(at, rows).expect("somewhere to write the measurements");
+        println!("\nwrote {at}");
     }
 }

--- a/examples/paged_rss.rs
+++ b/examples/paged_rss.rs
@@ -104,12 +104,21 @@ fn resident() -> u64 {
     0
 }
 
+/// Every step and what it cost, for whatever draws the picture.
+static STEPS: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
+
 fn report(step: &str, before: u64) -> u64 {
     let now = resident();
     println!(
         "{step:<38} {:>9.1} MiB   {:+9.1} MiB",
         now as f64 / MIB,
         (now as f64 - before as f64) / MIB
+    );
+    use std::fmt::Write as _;
+    let _ = writeln!(
+        STEPS.lock().expect("the steps"),
+        "\"{step}\",{now},{}",
+        now as i64 - before as i64
     );
     now
 }
@@ -474,6 +483,13 @@ fn main() {
     // A run held open, so that vmmap and heap can be pointed at it: the
     // resident set says how much there is and neither of those has to be
     // guessed at afterwards.
+    if let Ok(at) = std::env::var("TOOLBOX_STEPS") {
+        let mut held = String::from("step,footprint_bytes,added_bytes\n");
+        held.push_str(&STEPS.lock().expect("the steps"));
+        std::fs::write(&at, held).expect("somewhere to write the steps");
+        println!("wrote {at}");
+    }
+
     if let Ok(seconds) = std::env::var("TOOLBOX_HOLD") {
         let seconds: u64 = seconds.parse().unwrap_or(120);
         println!("HOLDING pid {} for {seconds}s", std::process::id());

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -107,22 +107,35 @@ counts <- table(timings$exponent)
 thin <- as.integer(names(counts)[counts < THIN * length(engines)])
 
 # enough for a sweep of block sizes with the engine they are measured against
+# Okabe and Ito's, which survive the common kinds of colour blindness and stay
+# distinct in grey; the same set experiments/paper.R uses, so a paper's figures
+# are told apart the same way throughout.
 palette <- c(
-  "#3060c0", "#c05030", "#309050", "#9050b0",
-  "#c09030", "#30909c", "#a03060", "#606060"
+  "#0072B2", "#D55E00", "#009E73", "#CC79A7",
+  "#E69F00", "#56B4E9", "#F0E442", "#000000"
 )
 colour_of <- setNames(palette[seq_along(engines)], engines)
 
-png(output, width = 1400, height = 1000, res = 130)
+# A figure that goes into a paper is vector and is drawn at the size it will be
+# printed, so that eight point text is eight point text. A `.png` name still
+# gives a raster, for a look on a screen.
+paper <- !grepl("\\.png$", output, ignore.case = TRUE)
+if (paper) {
+  pdf(output, width = 7.0, height = 4.6, pointsize = 8, family = "Times",
+      useDingbats = FALSE)
+  par(mgp = c(1.8, 0.5, 0), tcl = -0.25)
+} else {
+  png(output, width = 1400, height = 1000, res = 130)
+}
 # The lower panel is a ratio, and there is no ratio to draw where only one
 # engine wrote to the file: it gets the whole device instead of two thirds of
 # it and a line of apology.
 ratio_panel <- length(engines) > 1 && denominator %in% engines
 if (ratio_panel) {
   layout(matrix(c(1, 2), nrow = 2), heights = c(2, 1))
-  par(mar = c(1.5, 4.5, 2.5, 1), las = 1)
+  par(mar = if (paper) c(1.2, 3.6, 1.6, 0.6) else c(1.5, 4.5, 2.5, 1), las = 1)
 } else {
-  par(mar = c(4.5, 4.5, 2.5, 1), las = 1)
+  par(mar = if (paper) c(2.6, 3.6, 1.6, 0.6) else c(4.5, 4.5, 2.5, 1), las = 1)
 }
 
 # what each engine costs, as a box per bucket
@@ -144,7 +157,10 @@ boxplot(groups,
   at = at, boxwex = width * 0.9, col = fill, log = "y",
   xaxt = "n", yaxt = "n", xlab = "",
   ylab = if (counting) measuring else "milliseconds",
-  main = sprintf("%s by Dijkstra rank (%s)", measuring, basename(input)),
+  # A figure in a paper has a caption and does not want a title as well, and
+  # certainly not the name of the file it was drawn from. On a screen both are
+  # useful for telling one exploratory plot from the next.
+  main = if (paper) "" else sprintf("%s by Dijkstra rank (%s)", measuring, basename(input)),
   outcex = 0.3, whisklty = 1, staplewex = 0.5
 )
 axis(1, at = exponents, labels = parse(text = sprintf("2^%d", exponents)))
@@ -175,7 +191,8 @@ if (!ratio_panel) {
   quit(status = 0)
 }
 
-par(mar = c(4.5, 4.5, 1, 1))
+# the lower panel's title is a pair of engine names and wants the room
+par(mar = if (paper) c(2.6, 4.4, 0.6, 0.6) else c(4.5, 4.5, 1, 1))
 medians <- sapply(engines, function(engine) {
   sapply(exponents, function(exponent) {
     rows <- timings$exponent == exponent & timings$engine == engine
@@ -206,7 +223,7 @@ if (denominator %in% engines && length(engines) > 1) {
   # placed by hand rather than as ylab, so a long pair of names can be set
   # smaller instead of running off the edge of the device
   side_label <- sprintf("%s / %s", measured, name_of(denominator))
-  mtext(side_label, side = 2, line = 3.2, las = 0,
+  mtext(side_label, side = 2, line = if (paper) 3.0 else 3.2, las = 0,
         cex = if (nchar(side_label) > 28) 0.72 else 0.9)
   ticks <- ratios_over(c(ratios, 1))
   axis(2, at = ticks, labels = as_multiple(ticks))
@@ -233,7 +250,7 @@ if (denominator %in% engines && length(engines) > 1) {
     sprintf("%s / %s (up to %.2f\u00d7 at 2^%d)", name_of(engine), name_of(denominator),
             ratios[best, engine], exponents[best])
   })
-  legend("topleft", legend = best_of, col = colour_of[against],
+  legend(if (paper) "bottomleft" else "topleft", legend = best_of, col = colour_of[against],
          lty = 1, pch = 19, bty = "n")
 
 } else {


### PR DESCRIPTION
`examples/on_device.rs` takes `TOOLBOX_TIMINGS` and writes one row a
measurement: `drawn, share, arcs, dirty, tables, seconds, whole_seconds`.

`examples/paged_rss.rs` takes `TOOLBOX_STEPS` and writes one row a step of
opening an instance: what was held after it and what it added.

Both already printed the same numbers in prose; a figure wants them as a table.

`scripts/rank_plot.R` draws a pdf where the output name says so, at seven
inches and eight point Times, which is the width of a two-column page and the
size the text will be read at. A figure in a paper has a caption, so in that
mode it draws no title and not the name of the file it came from. The palette
is Okabe and Ito's, which survives the common kinds of colour blindness and
stays distinct in grey.

`.gitignore` gains `/experiments/`: the scripts that re-run the measurements
name paths on one machine and write large files beside them, so they are kept
out of the repository.

691 tests pass, clippy and fmt clean, and the R script parses. Third of four,
stacked on #620.