### PR TITLE
Assert both indices in CompleteGraph::get_index

### DIFF
--- a/src/complete_graph.rs
+++ b/src/complete_graph.rs
@@ -83,6 +83,15 @@ impl<T: Clone + Default + PartialEq + fmt::Debug> CompleteGraph<T> {
     /// The flat array index
     #[inline(always)]
     fn get_index(&self, i: usize, j: usize) -> usize {
+        // Not a debug_assert. The row is folded into the column here, so a j
+        // past the end lands on a valid element of another row rather than off
+        // the end of the vector: for three nodes, (0, 4) is index 4, which is
+        // (1, 1). Nothing below this catches that.
+        assert!(
+            i < self.num_nodes && j < self.num_nodes,
+            "node indices ({i}, {j}) out of bounds for {} nodes",
+            self.num_nodes
+        );
         i * self.num_nodes + j
     }
 
@@ -97,11 +106,6 @@ impl<T: Clone + Default + PartialEq + fmt::Debug> CompleteGraph<T> {
     ///
     /// A reference to the distance between nodes i and j
     pub fn get(&self, i: usize, j: usize) -> &T {
-        debug_assert!(
-            i < self.num_nodes && j < self.num_nodes,
-            "Node indices out of bounds"
-        );
-
         let idx = self.get_index(i, j);
         &self.distances[idx]
     }
@@ -117,11 +121,6 @@ impl<T: Clone + Default + PartialEq + fmt::Debug> CompleteGraph<T> {
     ///
     /// A mutable reference to the distance between nodes i and j
     pub fn get_mut(&mut self, i: usize, j: usize) -> &mut T {
-        debug_assert!(
-            i < self.num_nodes && j < self.num_nodes,
-            "Node indices out of bounds"
-        );
-
         let idx = self.get_index(i, j);
         &mut self.distances[idx]
     }
@@ -235,24 +234,30 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "out of bounds")]
     fn test_get_index_out_of_bounds() {
         let graph: CompleteGraph<i32> = CompleteGraph::new(3);
 
-        // This should trigger the out-of-bounds check when we try to access an element
-        // The debug_assert! will only panic in debug mode, but in release mode,
-        // we will get a panic from the vector access itself
-        let _ = graph[(3, 0)]; // Index 3 is out of bounds for a 3-node graph
+        // (3, 0) folds to index 9, which is off the end of the vector, so this
+        // one panicked in release even before get_index asserted.
+        let _ = graph[(3, 0)];
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "out of bounds")]
     fn test_get_mut_index_out_of_bounds() {
         let mut graph: CompleteGraph<i32> = CompleteGraph::new(3);
 
-        // This should trigger the out-of-bounds check when we try to access an element mutably
-        // The debug_assert! will only panic in debug mode, but in release mode,
-        // we will get a panic from the vector access itself
-        *graph.get_mut(0, 4) = 10; // Index 4 is out of bounds for a 3-node graph
+        // (0, 4) folds to index 4, which is a valid element of the vector -- it
+        // is (1, 1) -- so the vector access does not catch this and the assert
+        // in get_index has to. In debug and in release alike.
+        *graph.get_mut(0, 4) = 10;
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_get_column_out_of_bounds() {
+        let graph: CompleteGraph<i32> = CompleteGraph::new(3);
+        graph.get(0, 4);
     }
 }


### PR DESCRIPTION
`get_index` folds the row into the column, so a column past the end lands on a
valid element of another row rather than off the end of the vector: for three
nodes `(0, 4)` is index 4, which is `(1, 1)`. The `debug_assert!`s in `get` and
`get_mut` were the only thing catching that, and they are compiled out of a
release build, so `get`, `get_mut`, `Index` and `IndexMut` all returned the
wrong cell for any `j >= num_nodes` whose row kept the product inside the
buffer.

The check moves into `get_index`, where it covers every path, and is an
`assert!` rather than a `debug_assert!`. The vector index below it is then
redundant on the same condition.

## How it surfaced

`test_get_mut_index_out_of_bounds` asserts exactly this and has been failing in
release since it was written. Its comment claims the vector access panics in
release; that is the part that is not true. CI runs `cargo test` in debug only,
so nothing ever reported it.

The test now names the message it expects, the stale comments are replaced by
what the arithmetic does, and `test_get_column_out_of_bounds` covers `get`
beside `get_mut`.

`test_get_index_out_of_bounds` was never affected: `(3, 0)` folds to index 9,
which is off the end, so the vector caught that one. Its comment was stale in
the same way and is corrected.

## Checks

689 tests pass in release, where one was failing before, and 762 in debug.
clippy clean across all targets, `cargo fmt --check` clean.

## What the assert costs

`mst_prim` is O(n²) over these accessors, so the assert sits on a hot path. It
does not cost anything; it pays. Median of seven `mst_prim` runs over a
complete graph of random weights, the two binaries run interleaved:

| n | with the assert | before | |
|---|---|---|---|
| 1024 | 0.0024s | 0.0032s | 1.33× faster |
| 2048 | 0.0090s | 0.0124s | 1.38× faster |
| 4096 | 0.0382s | 0.0498s | 1.30× faster |
| 8192 | 0.1880s | 0.1999s | 1.06× faster |

Same MST cost and edge count from both in every case.

The inner scan is `graph[(u, v)]` for `v in 0..n` with `u` fixed, so `i < n` is
loop-invariant and `j < n` follows from the loop bound. Asserting them up front
appears to let the optimiser discharge the per-element `Vec` bounds check that
was there before, panic branch and all, rather than adding a second one beside
it. At n=8192 the matrix is 268 MB and the loop is memory-bound, which is why
the margin narrows to nothing in particular.

The benchmark was written for this question and is not part of the diff.

Independent of #619 through #622.
