### PR TITLE
Cut with push-relabel, and make it what chipper uses

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -12,4 +12,5 @@ criterion_main!(
     benchmarks::polyline::polyline,
     benchmarks::mercator::mercator_benches,
     benchmarks::mld_query::mld_query,
+    benchmarks::max_flow::max_flow,
 );

--- a/benches/benchmarks/max_flow.rs
+++ b/benches/benchmarks/max_flow.rs
@@ -1,0 +1,232 @@
+//! Dinic against push-relabel, on the shape of graph an inertial flow cut is
+//! asked for.
+//!
+//! A cell of a road network is close to planar and thin: degrees are small, the
+//! source and the sink are whole ranks of nodes contracted into one, and the
+//! cut is narrow. The grid is that shape. The layered graph is the other end of
+//! it, where the cut is wide and the search has to work for it.
+use criterion::{BenchmarkId, Criterion, criterion_group};
+use rand::{RngExt, SeedableRng, prelude::StdRng};
+use std::hint::black_box;
+use std::sync::{Arc, atomic::AtomicI32};
+use toolbox_rs::{
+    dinic::Dinic,
+    edge::InputEdge,
+    max_flow::{MaxFlow, ResidualEdgeData},
+    push_relabel::PushRelabel,
+};
+
+/// A grid with the left rank contracted into the source and the right into the
+/// sink, which is an inertial flow cut of a square cell.
+fn grid(side: usize, rng: &mut StdRng) -> (Vec<InputEdge<ResidualEdgeData>>, usize, usize) {
+    let source = 0;
+    let sink = 1;
+    let node = |row: usize, column: usize| 2 + row * side + column;
+    let mut edges = Vec::new();
+    for row in 0..side {
+        for column in 0..side {
+            let mut capacity = || ResidualEdgeData::new(rng.random_range(1..=4));
+            if column + 1 < side {
+                edges.push(InputEdge::new(
+                    node(row, column),
+                    node(row, column + 1),
+                    capacity(),
+                ));
+                edges.push(InputEdge::new(
+                    node(row, column + 1),
+                    node(row, column),
+                    capacity(),
+                ));
+            }
+            if row + 1 < side {
+                edges.push(InputEdge::new(
+                    node(row, column),
+                    node(row + 1, column),
+                    capacity(),
+                ));
+                edges.push(InputEdge::new(
+                    node(row + 1, column),
+                    node(row, column),
+                    capacity(),
+                ));
+            }
+        }
+        edges.push(InputEdge::new(
+            source,
+            node(row, 0),
+            ResidualEdgeData::new(i32::MAX / 4),
+        ));
+        edges.push(InputEdge::new(
+            node(row, side - 1),
+            sink,
+            ResidualEdgeData::new(i32::MAX / 4),
+        ));
+    }
+    (edges, source, sink)
+}
+
+/// A dense layered graph, where the cut is wide.
+fn layered(
+    width: usize,
+    depth: usize,
+    rng: &mut StdRng,
+) -> (Vec<InputEdge<ResidualEdgeData>>, usize, usize) {
+    let source = 0;
+    let sink = 1 + width * depth;
+    let node = |layer: usize, index: usize| 1 + layer * width + index;
+    let mut edges = Vec::new();
+    for index in 0..width {
+        edges.push(InputEdge::new(
+            source,
+            node(0, index),
+            ResidualEdgeData::new(rng.random_range(1..=8)),
+        ));
+        edges.push(InputEdge::new(
+            node(depth - 1, index),
+            sink,
+            ResidualEdgeData::new(rng.random_range(1..=8)),
+        ));
+    }
+    for layer in 0..depth - 1 {
+        for index in 0..width {
+            for other in 0..width {
+                if rng.random_range(0..100) < 40 {
+                    edges.push(InputEdge::new(
+                        node(layer, index),
+                        node(layer + 1, other),
+                        ResidualEdgeData::new(rng.random_range(1..=5)),
+                    ));
+                }
+            }
+        }
+    }
+    (edges, source, sink)
+}
+
+fn cuts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("min_cut");
+
+    for side in [16_usize, 32, 64, 96] {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let (edges, source, sink) = grid(side, &mut rng);
+        group.bench_with_input(BenchmarkId::new("dinic/grid", side), &side, |b, _| {
+            b.iter_with_setup(
+                || Dinic::from_edge_list(edges.clone(), source, sink),
+                |mut solver| {
+                    solver.run();
+                    black_box(solver.max_flow())
+                },
+            );
+        });
+        group.bench_with_input(
+            BenchmarkId::new("push_relabel/grid", side),
+            &side,
+            |b, _| {
+                b.iter_with_setup(
+                    || PushRelabel::from_edge_list(edges.clone(), source, sink),
+                    |mut solver| {
+                        solver.run();
+                        black_box(solver.max_flow())
+                    },
+                );
+            },
+        );
+    }
+
+    for width in [16_usize, 32, 64] {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let (edges, source, sink) = layered(width, 8, &mut rng);
+        group.bench_with_input(BenchmarkId::new("dinic/layered", width), &width, |b, _| {
+            b.iter_with_setup(
+                || Dinic::from_edge_list(edges.clone(), source, sink),
+                |mut solver| {
+                    solver.run();
+                    black_box(solver.max_flow())
+                },
+            );
+        });
+        group.bench_with_input(
+            BenchmarkId::new("push_relabel/layered", width),
+            &width,
+            |b, _| {
+                b.iter_with_setup(
+                    || PushRelabel::from_edge_list(edges.clone(), source, sink),
+                    |mut solver| {
+                        solver.run();
+                        black_box(solver.max_flow())
+                    },
+                );
+            },
+        );
+    }
+    group.finish();
+
+    // Construction and run together, which is what a caller really pays. The
+    // clone of the edge list is the setup and is not timed; building the
+    // residual graph is, and push-relabel pays for pairing the arcs there while
+    // dinic looks a pair up per push instead.
+    let mut whole = c.benchmark_group("min_cut_built");
+    for side in [32_usize, 64, 96] {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let (edges, source, sink) = grid(side, &mut rng);
+        whole.bench_with_input(BenchmarkId::new("dinic/grid", side), &side, |b, _| {
+            b.iter_with_setup(
+                || edges.clone(),
+                |list| {
+                    let mut solver = Dinic::from_edge_list(list, source, sink);
+                    solver.run();
+                    black_box(solver.max_flow())
+                },
+            );
+        });
+        whole.bench_with_input(
+            BenchmarkId::new("push_relabel/grid", side),
+            &side,
+            |b, _| {
+                b.iter_with_setup(
+                    || edges.clone(),
+                    |list| {
+                        let mut solver = PushRelabel::from_edge_list(list, source, sink);
+                        solver.run();
+                        black_box(solver.max_flow())
+                    },
+                );
+            },
+        );
+    }
+    whole.finish();
+
+    // With an upper bound the solver may give up on, which is how inertial flow
+    // uses it: four axes race and each drops out as soon as it is beaten. The
+    // bound is set well under the real cut, so both give up rather than finish.
+    let mut bounded = c.benchmark_group("min_cut_bounded");
+    for side in [32_usize, 64, 96] {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let (edges, source, sink) = grid(side, &mut rng);
+        bounded.bench_with_input(BenchmarkId::new("dinic/grid", side), &side, |b, _| {
+            b.iter_with_setup(
+                || Dinic::from_edge_list(edges.clone(), source, sink),
+                |mut solver| {
+                    solver.run_with_upper_bound(Arc::new(AtomicI32::new(4)));
+                    black_box(solver.max_flow())
+                },
+            );
+        });
+        bounded.bench_with_input(
+            BenchmarkId::new("push_relabel/grid", side),
+            &side,
+            |b, _| {
+                b.iter_with_setup(
+                    || PushRelabel::from_edge_list(edges.clone(), source, sink),
+                    |mut solver| {
+                        solver.run_with_upper_bound(Arc::new(AtomicI32::new(4)));
+                        black_box(solver.max_flow())
+                    },
+                );
+            },
+        );
+    }
+    bounded.finish();
+}
+
+criterion_group!(max_flow, cuts);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -2,6 +2,7 @@ pub mod fenwick;
 pub mod great_circle;
 pub mod k_way_merge_iterator;
 pub mod loser_tree;
+pub mod max_flow;
 pub mod medium_size_hash_table;
 pub mod mercator;
 pub mod mld_query;

--- a/examples/flow_work.rs
+++ b/examples/flow_work.rs
@@ -1,0 +1,95 @@
+//! What a push-relabel run spends itself on, with and without a bound.
+use std::sync::{Arc, atomic::AtomicI32};
+
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use toolbox_rs::{
+    dinic::Dinic,
+    edge::InputEdge,
+    max_flow::{MaxFlow, ResidualEdgeData},
+    push_relabel::PushRelabel,
+};
+
+fn grid(side: usize, rng: &mut StdRng) -> (Vec<InputEdge<ResidualEdgeData>>, usize, usize) {
+    let node = |row: usize, column: usize| 2 + row * side + column;
+    let mut edges = Vec::new();
+    for row in 0..side {
+        for column in 0..side {
+            let mut capacity = || ResidualEdgeData::new(rng.random_range(1..=4));
+            if column + 1 < side {
+                edges.push(InputEdge::new(
+                    node(row, column),
+                    node(row, column + 1),
+                    capacity(),
+                ));
+                edges.push(InputEdge::new(
+                    node(row, column + 1),
+                    node(row, column),
+                    capacity(),
+                ));
+            }
+            if row + 1 < side {
+                edges.push(InputEdge::new(
+                    node(row, column),
+                    node(row + 1, column),
+                    capacity(),
+                ));
+                edges.push(InputEdge::new(
+                    node(row + 1, column),
+                    node(row, column),
+                    capacity(),
+                ));
+            }
+        }
+        edges.push(InputEdge::new(
+            0,
+            node(row, 0),
+            ResidualEdgeData::new(i32::MAX / 4),
+        ));
+        edges.push(InputEdge::new(
+            node(row, side - 1),
+            1,
+            ResidualEdgeData::new(i32::MAX / 4),
+        ));
+    }
+    (edges, 0, 1)
+}
+
+fn main() {
+    println!(
+        "{:>6} {:>8} {:>8} {:>7} {:>12} {:>10} {:>8} {:>9}",
+        "side", "nodes", "pick", "bound", "pushes", "relabels", "global", "flow"
+    );
+    for side in [32_usize, 64, 96] {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let (edges, source, sink) = grid(side, &mut rng);
+        let nodes = 2 + side * side;
+
+        let mut dinic = Dinic::from_edge_list(edges.clone(), source, sink);
+        dinic.run();
+        let full = dinic.max_flow().expect("dinic did not run");
+
+        for lowest in [false, true] {
+            for bound in [None, Some(4)] {
+                let mut solver = PushRelabel::from_edge_list(edges.clone(), source, sink);
+                solver.by_lowest_label(lowest);
+                match bound {
+                    None => solver.run(),
+                    Some(at) => solver.run_with_upper_bound(Arc::new(AtomicI32::new(at))),
+                }
+                let (pushes, relabels, global) = solver.work();
+                let said = solver
+                    .max_flow()
+                    .map_or_else(|_| "gave up".to_string(), |flow| flow.to_string());
+                println!(
+                    "{side:>6} {nodes:>8} {:>8} {:>7} {pushes:>12} {relabels:>10} {global:>8} {said:>9}",
+                    if lowest { "lowest" } else { "highest" },
+                    bound.map_or("none".to_string(), |at| at.to_string()),
+                );
+            }
+        }
+        println!(
+            "{side:>6} {nodes:>8} {:>8} {:>7} {:>12} {:>10} {:>8} {full:>9}",
+            "dinic", "", "", "", ""
+        );
+    }
+}

--- a/scripts/rank_plot.R
+++ b/scripts/rank_plot.R
@@ -86,17 +86,37 @@ counts_over <- function(values) {
 # always among them because one is where the two engines cost the same.
 ratios_over <- function(values) {
   values <- values[is.finite(values) & values > 0]
+  low <- min(values)
+  high <- max(values)
   wanted <- c(
     0.1, 0.125, 0.15, 0.2, 0.25, 0.33, 0.5, 0.6, 0.7, 0.8, 0.9,
     1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 20, 30, 50, 100
   )
-  kept <- wanted[wanted >= min(values) * 0.98 & wanted <= max(values) * 1.02]
-  sort(unique(c(kept, 1)))
+  kept <- wanted[wanted >= low * 0.98 & wanted <= high * 1.02]
+  if (length(kept) >= 4) {
+    return(sort(unique(c(kept, 1))))
+  }
+
+  # Two engines that cost nearly the same leave every multiple above out of
+  # the span and every one below it, and the panel comes out with a single
+  # tick at one and nothing to read a point against. A span of a few per cent
+  # wants ticks a per cent apart, so the step is worked out from the span
+  # instead of taken from the list.
+  span <- max(high - low, 1e-9)
+  step <- 10^floor(log10(span / 4))
+  for (multiple in c(1, 2, 2.5, 5, 10)) {
+    if (span / (step * multiple) <= 8) {
+      step <- step * multiple
+      break
+    }
+  }
+  ticks <- seq(floor(low / step) * step, ceiling(high / step) * step, by = step)
+  sort(unique(c(ticks[ticks > 0], 1)))
 }
 
 # 1.5 rather than 1.50, and with the sign a reader expects on a multiple
 as_multiple <- function(values) {
-  paste0(formatC(values, format = "fg", drop0trailing = TRUE), "\u00d7")
+  paste0(formatC(signif(values, 4), format = "fg", drop0trailing = TRUE), "\u00d7")
 }
 plainly <- function(values) formatC(values, format = "fg", drop0trailing = TRUE)
 

--- a/src/chipper/bin/command_line.rs
+++ b/src/chipper/bin/command_line.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, ops::RangeInclusive};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 static RECURSION_RANGE: RangeInclusive<u8> = 1..=31;
 static BALANCE_RANGE: RangeInclusive<f64> = 0. ..=0.5;
@@ -60,6 +60,10 @@ pub struct Arguments {
     #[clap(short, long, value_parser = balance_factor_in_range, default_value_t = 0.25)]
     pub b_factor: f64,
 
+    /// which min-cut solver the flow of each axis runs on
+    #[clap(long, value_enum, default_value_t = Solver::PushRelabel)]
+    pub solver: Solver,
+
     /// depth of recursive partitioning; off by one from the level of a node
     /// since the root node has level 1, e.g. depths of 1 gives cells on level 2
     #[clap(short, long, value_parser=recursion_depth_in_range, default_value_t = 1)]
@@ -113,4 +117,20 @@ impl Display for Arguments {
         }
         writeln!(f, "minimum_cell_size: {}", self.minimum_cell_size)
     }
+}
+
+/// Which min-cut solver an axis of the flow runs on.
+///
+/// The two find cuts of the same cost and not always the same cut, so a
+/// partition made by one is not the partition made by the other. Both give a
+/// hierarchy that answers what a plain search answers; the choice is about how
+/// long the cutting takes.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Solver {
+    /// Goldberg and Tarjan's push-relabel. About twice as quick on a road
+    /// network, and what the cutting uses unless told otherwise.
+    PushRelabel,
+    /// Cherkassky's variant of Dinitz' algorithm, which is what this used
+    /// before and what the partitions in the wild were cut with.
+    Dinic,
 }

--- a/src/chipper/bin/command_line.rs
+++ b/src/chipper/bin/command_line.rs
@@ -105,6 +105,7 @@ impl Display for Arguments {
         if !self.cut_csv.is_empty() {
             writeln!(f, "cut csv: {}", self.cut_csv)?;
         }
+        writeln!(f, "solver: {:?}", self.solver)?;
         writeln!(f, "graph: {}", self.graph)?;
         writeln!(f, "coordinates: {}", self.coordinates)?;
         writeln!(f, "recursion depth: {}", self.recursion_depth)?;

--- a/src/chipper/bin/main.rs
+++ b/src/chipper/bin/main.rs
@@ -27,7 +27,7 @@ use toolbox_rs::{
     push_relabel::PushRelabel,
 };
 use {
-    command_line::Arguments,
+    command_line::{Arguments, Solver},
     serialize::{write_level_directory, write_results},
 };
 
@@ -60,8 +60,7 @@ fn main() {
     // Which min-cut solver the flow runs on. The two find cuts of the same
     // cost, but not necessarily the same cut, so this is here to compare the
     // partitions they lead to rather than to be switched in passing.
-    let by_push_relabel =
-        std::env::var("TOOLBOX_SOLVER").is_ok_and(|given| given == "push_relabel");
+    let by_push_relabel = args.solver == Solver::PushRelabel;
     info!("{args}");
 
     // set the number of threads if supplied on the command line

--- a/src/chipper/bin/main.rs
+++ b/src/chipper/bin/main.rs
@@ -20,9 +20,11 @@ use toolbox_rs::geometry::FPCoordinate;
 use toolbox_rs::io;
 use toolbox_rs::{
     assembly,
+    dinic::Dinic,
     inertial_flow::{self, Flow, flow_cmp},
     level_directory::CellId,
     partition_id::PartitionID,
+    push_relabel::PushRelabel,
 };
 use {
     command_line::Arguments,
@@ -55,6 +57,11 @@ fn main() {
 
     // parse and print command line parameters
     let args = <Arguments as clap::Parser>::parse();
+    // Which min-cut solver the flow runs on. The two find cuts of the same
+    // cost, but not necessarily the same cut, so this is here to compare the
+    // partitions they lead to rather than to be switched in passing.
+    let by_push_relabel =
+        std::env::var("TOOLBOX_SOLVER").is_ok_and(|given| given == "push_relabel");
     info!("{args}");
 
     // set the number of threads if supplied on the command line
@@ -157,14 +164,25 @@ fn main() {
                 let best_max_flow = (0..4)
                     .into_par_iter()
                     .map(|axis| -> Result<Flow, inertial_flow::FlowError> {
-                        inertial_flow::sub_step(
-                            &job.0,
-                            &job.1,
-                            &coordinates,
-                            axis,
-                            args.b_factor,
-                            upper_bound.clone(),
-                        )
+                        if by_push_relabel {
+                            inertial_flow::sub_step::<PushRelabel>(
+                                &job.0,
+                                &job.1,
+                                &coordinates,
+                                axis,
+                                args.b_factor,
+                                upper_bound.clone(),
+                            )
+                        } else {
+                            inertial_flow::sub_step::<Dinic>(
+                                &job.0,
+                                &job.1,
+                                &coordinates,
+                                axis,
+                                args.b_factor,
+                                upper_bound.clone(),
+                            )
+                        }
                     })
                     .filter_map(Result::ok)
                     .min_by(flow_cmp);

--- a/src/dinic.rs
+++ b/src/dinic.rs
@@ -8,8 +8,8 @@
 //! saturated edge that is closest to the source.
 use crate::{
     edge::InputEdge,
-    graph::{EdgeArrayEntry, EdgeID, Graph, NodeID},
-    max_flow::{MaxFlow, ResidualArcData, ResidualEdgeData},
+    graph::{EdgeID, Graph, NodeID},
+    max_flow::{MaxFlow, ResidualArcData, ResidualEdgeData, residual_graph_of},
     static_graph::StaticGraph,
 };
 use bitvec::vec::BitVec;
@@ -180,102 +180,12 @@ impl MaxFlow for Dinic {
         target: NodeID,
     ) -> Self {
         debug_assert!(!edge_list.is_empty());
-
-        // The residual graph holds a reverse arc of zero capacity for each input
-        // arc. Instead of materializing those and then sorting 2|E| entries, the
-        // adjacency array is built directly by a counting sort in O(V + E).
         let number_of_nodes = 1 + edge_list
             .iter()
             .map(|edge| max(edge.source, edge.target))
             .max()
             .expect("edge list is empty");
-        debug!("counting degrees of {number_of_nodes} nodes");
-
-        // count the residual degree of each node in node_array[node + 1], then
-        // turn the counts into the offsets of the adjacency blocks
-        let mut node_array = vec![0_usize; number_of_nodes + 1];
-        for edge in &edge_list {
-            node_array[edge.source + 1] += 1;
-            node_array[edge.target + 1] += 1;
-        }
-        for i in 1..node_array.len() {
-            node_array[i] += node_array[i - 1];
-        }
-
-        debug!("scattering {} arcs", 2 * edge_list.len());
-        // Scatter the arcs into their blocks. node_array[u] serves as the write
-        // cursor of node u and thus ends up pointing at the end of u's block.
-        // Each input arc contributes its capacity to the forward arc and to the
-        // cached reverse capacity of the reverse arc, which is why the cache
-        // comes for free.
-        let mut edge_array = vec![
-            EdgeArrayEntry {
-                target: 0,
-                data: ResidualArcData::default()
-            };
-            2 * edge_list.len()
-        ];
-        for edge in &edge_list {
-            let forward = node_array[edge.source];
-            node_array[edge.source] += 1;
-            edge_array[forward] = EdgeArrayEntry {
-                target: u32::try_from(edge.target).expect("the graph is too large to hold"),
-                data: ResidualArcData {
-                    capacity: edge.data.capacity,
-                    reverse_capacity: 0,
-                },
-            };
-
-            let reverse = node_array[edge.target];
-            node_array[edge.target] += 1;
-            edge_array[reverse] = EdgeArrayEntry {
-                target: u32::try_from(edge.source).expect("the graph is too large to hold"),
-                data: ResidualArcData {
-                    capacity: 0,
-                    reverse_capacity: edge.data.capacity,
-                },
-            };
-        }
-        drop(edge_list);
-
-        // each cursor now points at the end of its block, which is the begin of
-        // the next one. Shifting by one restores the adjacency array.
-        node_array.rotate_right(1);
-        node_array[0] = 0;
-
-        debug!("merging parallel arcs");
-        // sort each adjacency block by target and merge parallel arcs into a
-        // single one that carries the accumulated capacity. Note that this is
-        // fine, as we are looking to compute a node partition. Blocks are short,
-        // hence sorting them is cheap.
-        let mut write = 0;
-        let mut begin = 0;
-        for node in 0..number_of_nodes {
-            let end = node_array[node + 1];
-            edge_array[begin..end].sort_unstable_by_key(|entry| entry.target);
-
-            let block_begin = write;
-            for read in begin..end {
-                if write > block_begin && edge_array[write - 1].target == edge_array[read].target {
-                    edge_array[write - 1].data.capacity += edge_array[read].data.capacity;
-                    edge_array[write - 1].data.reverse_capacity +=
-                        edge_array[read].data.reverse_capacity;
-                } else {
-                    edge_array[write] = edge_array[read];
-                    write += 1;
-                }
-            }
-            begin = end;
-            node_array[node + 1] = write;
-        }
-        edge_array.truncate(write);
-        edge_array.shrink_to_fit();
-        debug!("residual graph has {write} arcs");
-
-        // the DFS stores arc ids in parent_edge as u32, so a larger graph would
-        // silently index the wrong arc
-        assert!(write <= u32::MAX as usize, "arc ids have to fit into u32");
-        let residual_graph = StaticGraph::from_adjacency_array(node_array, edge_array);
+        let residual_graph = residual_graph_of(edge_list);
 
         Self {
             residual_graph,

--- a/src/dinic.rs
+++ b/src/dinic.rs
@@ -244,7 +244,7 @@ impl MaxFlow for Dinic {
 
     fn max_flow(&self) -> Result<i32, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
         debug!(
             "finished in {} DFS, and {} BFS runs",
@@ -255,7 +255,7 @@ impl MaxFlow for Dinic {
 
     fn assignment(&self, source: NodeID) -> Result<BitVec, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
 
         // run a reachability analysis

--- a/src/edmonds_karp.rs
+++ b/src/edmonds_karp.rs
@@ -129,14 +129,14 @@ impl MaxFlow for EdmondsKarp {
 
     fn max_flow(&self) -> Result<i32, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
         Ok(self.max_flow)
     }
 
     fn assignment(&self, source: NodeID) -> Result<BitVec, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
 
         // run a reachability analysis

--- a/src/ford_fulkerson.rs
+++ b/src/ford_fulkerson.rs
@@ -126,14 +126,14 @@ impl MaxFlow for FordFulkerson {
 
     fn max_flow(&self) -> Result<i32, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
         Ok(self.max_flow)
     }
 
     fn assignment(&self, source: NodeID) -> Result<BitVec, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
 
         // run a reachability analysis

--- a/src/inertial_flow.rs
+++ b/src/inertial_flow.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use log::debug;
 
 use crate::{
-    dinic::Dinic,
     edge::{InputEdge, TrivialEdge},
     geometry::FPCoordinate,
     graph::NodeID,
@@ -59,7 +58,7 @@ pub fn flow_cmp(a: &Flow, b: &Flow) -> std::cmp::Ordering {
 /// * `coordinates` - immutable slice of coordinates of the graphs nodes
 /// * `balance_factor` - balance factor, i.e. how many nodes get contracted
 /// * `upper_bound` - a global upperbound to the best inertial flow cut
-pub fn sub_step(
+pub fn sub_step<M: MaxFlow>(
     input_edges: &[TrivialEdge],
     node_id_list: &[usize],
     coordinates: &[FPCoordinate],
@@ -163,7 +162,7 @@ pub fn sub_step(
     edges.shrink_to_fit();
 
     debug!("[{axis}] instantiating min-cut solver, epsilon {balance_factor}");
-    let mut max_flow_solver = Dinic::from_edge_list(edges, 0, 1);
+    let mut max_flow_solver = M::from_edge_list(edges, 0, 1);
     debug!("[{axis}] instantiated min-cut solver");
     max_flow_solver.run_with_upper_bound(upper_bound);
 
@@ -229,6 +228,7 @@ mod tests {
     use std::sync::{Arc, atomic::AtomicI32};
 
     use crate::{
+        dinic::Dinic,
         geometry::FPCoordinate,
         inertial_flow::{Flow, TrivialEdge, flow_cmp, sub_step},
     };
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn inertial_flow() {
         let upper_bound = Arc::new(AtomicI32::new(6));
-        let result = sub_step(&EDGES, &NODE_ID_LIST, &COORDINATES, 3, 0.25, upper_bound)
+        let result = sub_step::<Dinic>(&EDGES, &NODE_ID_LIST, &COORDINATES, 3, 0.25, upper_bound)
             .expect("error should not happen");
         assert_eq!(result.flow, 1);
         assert_eq!(result.balance, 0.5);
@@ -330,7 +330,7 @@ mod tests {
         static NODE_ID_LIST_WITH_ISOLATED: [usize; 7] = [0, 1, 2, 3, 4, 5, 6];
 
         let upper_bound = Arc::new(AtomicI32::new(7));
-        let result = sub_step(
+        let result = sub_step::<Dinic>(
             &EDGES,
             &NODE_ID_LIST_WITH_ISOLATED,
             &COORDINATES_WITH_ISOLATED,
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn cell_without_edges_is_reported() {
         let upper_bound = Arc::new(AtomicI32::new(6));
-        let result = sub_step(&[], &NODE_ID_LIST, &COORDINATES, 0, 0.25, upper_bound);
+        let result = sub_step::<Dinic>(&[], &NODE_ID_LIST, &COORDINATES, 0, 0.25, upper_bound);
         assert!(matches!(result, Err(super::FlowError::EmptyGraph)));
     }
 
@@ -357,7 +357,7 @@ mod tests {
         let upper_bound = Arc::new(AtomicI32::new(6));
         let result = (0..4)
             .map(|axis| -> Result<_, _> {
-                sub_step(
+                sub_step::<Dinic>(
                     &EDGES,
                     &NODE_ID_LIST,
                     &COORDINATES,

--- a/src/inertial_flow.rs
+++ b/src/inertial_flow.rs
@@ -101,11 +101,28 @@ pub fn sub_step<M: MaxFlow>(
             (projection, id)
         })
         .collect_vec();
-    node_id_list.sort_unstable();
-
     let size_of_contraction = max(1, (node_id_list.len() as f64 * balance_factor) as usize);
+    let held = node_id_list.len();
+    // Only the two ends of the order are wanted. The first share of the nodes
+    // is what the source is contracted from and the last share is the sink;
+    // nothing asks about the order of what lies between, and it is the great
+    // majority of the list. Two selections cost a pass each where a sort costs
+    // a pass per level of it.
+    //
+    // The pairs hold the node id beside the projection and no two nodes share
+    // one, so the first share is the same set of nodes either way and no cut
+    // moves because of this.
+    if 2 * size_of_contraction >= held {
+        // the two ends meet or overlap, which selecting cannot express
+        node_id_list.sort_unstable();
+    } else {
+        node_id_list.select_nth_unstable(size_of_contraction - 1);
+        let rest = &mut node_id_list[size_of_contraction..];
+        let leading = rest.len() - size_of_contraction;
+        rest.select_nth_unstable(leading);
+    }
     let sources = &node_id_list[0..size_of_contraction];
-    let targets = &node_id_list[node_id_list.len() - size_of_contraction..];
+    let targets = &node_id_list[held - size_of_contraction..];
 
     debug_assert!(!sources.is_empty());
     debug_assert!(!targets.is_empty());
@@ -379,23 +396,18 @@ mod tests {
 
         let min_max = result.into_iter().map(|r| r.unwrap()).minmax_by(flow_cmp);
         let (min, max) = min_max.into_option().expect("minmax failed");
-        assert_eq!(
-            min,
-            Flow {
-                flow: 1,
-                balance: 0.5,
-                left_ids: vec![2, 0, 1],
-                right_ids: vec![4, 5, 3]
-            }
-        );
-        assert_eq!(
-            max,
-            Flow {
-                flow: 1,
-                balance: 0.5,
-                left_ids: vec![4, 5, 3],
-                right_ids: vec![2, 0, 1]
-            }
-        );
+        // The sides are what is being asserted, not the order they are listed
+        // in. Only the two ends of the projection order are worked out, so what
+        // lies between them arrives in whatever order the selection left it,
+        // and nothing downstream reads that order.
+        let sides = |flow: Flow| {
+            let mut left = flow.left_ids;
+            let mut right = flow.right_ids;
+            left.sort_unstable();
+            right.sort_unstable();
+            (flow.flow, flow.balance, left, right)
+        };
+        assert_eq!(sides(min), (1, 0.5, vec![0, 1, 2], vec![3, 4, 5]));
+        assert_eq!(sides(max), (1, 0.5, vec![3, 4, 5], vec![0, 1, 2]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod path_unpacking;
 pub mod polyline;
 pub mod pool;
 pub mod prim_complete_graph;
+pub mod push_relabel;
 pub mod rdx_sort;
 pub mod renumbering_table;
 pub mod run_iterator;

--- a/src/max_flow.rs
+++ b/src/max_flow.rs
@@ -179,9 +179,20 @@ pub fn residual_graph_of(
         let block_begin = write;
         for read in begin..end {
             if write > block_begin && edge_array[write - 1].target == edge_array[read].target {
-                edge_array[write - 1].data.capacity += edge_array[read].data.capacity;
-                edge_array[write - 1].data.reverse_capacity +=
-                    edge_array[read].data.reverse_capacity;
+                // Checked, since a flow larger than four bytes is one this
+                // cannot answer about anyway: max_flow hands back an i32. A cell
+                // of a road network carries a capacity of one an arc and comes
+                // nowhere near, but this is a builder anything may call.
+                let more = edge_array[read].data;
+                let held = &mut edge_array[write - 1].data;
+                held.capacity = held
+                    .capacity
+                    .checked_add(more.capacity)
+                    .expect("parallel arcs of more capacity than a flow can hold");
+                held.reverse_capacity = held
+                    .reverse_capacity
+                    .checked_add(more.reverse_capacity)
+                    .expect("parallel arcs of more capacity than a flow can hold");
             } else {
                 edge_array[write] = edge_array[read];
                 write += 1;

--- a/src/max_flow.rs
+++ b/src/max_flow.rs
@@ -67,6 +67,9 @@ pub trait MaxFlow {
     }
 }
 
+/// How long an adjacency block may be and still be worth an insertion sort.
+const SHORT_BLOCK: usize = 32;
+
 /// Builds the residual graph a max-flow solver runs on.
 ///
 /// The residual graph holds a reverse arc of zero capacity for each input arc.
@@ -150,7 +153,28 @@ pub fn residual_graph_of(
     let mut begin = 0;
     for node in 0..number_of_nodes {
         let end = node_array[node + 1];
-        edge_array[begin..end].sort_unstable_by_key(|entry| entry.target);
+        // A node of a road network has a handful of arcs and the residual graph
+        // doubles that, so these blocks are five entries long and there are as
+        // many of them as there are nodes. A general sort spends most of a block
+        // that size working out that it is dealing with a block that size.
+        //
+        // Not every block though: inertial flow contracts whole ranks of nodes
+        // into the source and the sink, whose blocks are a good fraction of the
+        // graph, and an insertion sort over those would be quadratic.
+        let block = &mut edge_array[begin..end];
+        if block.len() <= SHORT_BLOCK {
+            for i in 1..block.len() {
+                let entry = block[i];
+                let mut j = i;
+                while j > 0 && block[j - 1].target > entry.target {
+                    block[j] = block[j - 1];
+                    j -= 1;
+                }
+                block[j] = entry;
+            }
+        } else {
+            block.sort_unstable_by_key(|entry| entry.target);
+        }
 
         let block_begin = write;
         for read in begin..end {

--- a/src/max_flow.rs
+++ b/src/max_flow.rs
@@ -1,8 +1,12 @@
-use std::sync::{Arc, atomic::AtomicI32};
+use std::{
+    cmp::max,
+    sync::{Arc, atomic::AtomicI32},
+};
 
 use crate::{
     edge::{EdgeWithData, InputEdge},
-    graph::NodeID,
+    graph::{EdgeArrayEntry, NodeID},
+    static_graph::StaticGraph,
 };
 use bitvec::vec::BitVec;
 use log::debug;
@@ -61,4 +65,113 @@ pub trait MaxFlow {
         debug!("created {} ff edges", edge_list.len());
         Self::from_edge_list(edge_list, source, target)
     }
+}
+
+/// Builds the residual graph a max-flow solver runs on.
+///
+/// The residual graph holds a reverse arc of zero capacity for each input arc.
+/// Instead of materializing those and then sorting 2|E| entries, the adjacency
+/// array is built directly by a counting sort in O(V + E).
+///
+/// Each arc caches the capacity of its pair. A backward search checks the
+/// reverse capacity of every arc it relaxes, and looking that arc up dominated
+/// the run time before it was cached. The cache is free of charge, as the
+/// padding of the adjacency array entry is used up.
+///
+/// Parallel arcs are merged into one carrying the accumulated capacity, which
+/// is sound here because what is wanted is a node partition.
+///
+/// # Panics
+///
+/// Panics on an empty edge list, or where the arcs do not fit into `u32`.
+#[must_use]
+pub fn residual_graph_of(
+    edge_list: Vec<InputEdge<ResidualEdgeData>>,
+) -> StaticGraph<ResidualArcData> {
+    debug_assert!(!edge_list.is_empty());
+    let number_of_nodes = 1 + edge_list
+        .iter()
+        .map(|edge| max(edge.source, edge.target))
+        .max()
+        .expect("edge list is empty");
+    debug!("counting degrees of {number_of_nodes} nodes");
+
+    // count the residual degree of each node in node_array[node + 1], then
+    // turn the counts into the offsets of the adjacency blocks
+    let mut node_array = vec![0_usize; number_of_nodes + 1];
+    for edge in &edge_list {
+        node_array[edge.source + 1] += 1;
+        node_array[edge.target + 1] += 1;
+    }
+    for i in 1..node_array.len() {
+        node_array[i] += node_array[i - 1];
+    }
+
+    debug!("scattering {} arcs", 2 * edge_list.len());
+    // node_array[u] serves as the write cursor of node u and thus ends up
+    // pointing at the end of u's block
+    let mut edge_array = vec![
+        EdgeArrayEntry {
+            target: 0,
+            data: ResidualArcData::default()
+        };
+        2 * edge_list.len()
+    ];
+    for edge in &edge_list {
+        let forward = node_array[edge.source];
+        node_array[edge.source] += 1;
+        edge_array[forward] = EdgeArrayEntry {
+            target: u32::try_from(edge.target).expect("the graph is too large to hold"),
+            data: ResidualArcData {
+                capacity: edge.data.capacity,
+                reverse_capacity: 0,
+            },
+        };
+
+        let reverse = node_array[edge.target];
+        node_array[edge.target] += 1;
+        edge_array[reverse] = EdgeArrayEntry {
+            target: u32::try_from(edge.source).expect("the graph is too large to hold"),
+            data: ResidualArcData {
+                capacity: 0,
+                reverse_capacity: edge.data.capacity,
+            },
+        };
+    }
+    drop(edge_list);
+
+    // each cursor now points at the end of its block, which is the begin of the
+    // next one. Shifting by one restores the adjacency array.
+    node_array.rotate_right(1);
+    node_array[0] = 0;
+
+    debug!("merging parallel arcs");
+    let mut write = 0;
+    let mut begin = 0;
+    for node in 0..number_of_nodes {
+        let end = node_array[node + 1];
+        edge_array[begin..end].sort_unstable_by_key(|entry| entry.target);
+
+        let block_begin = write;
+        for read in begin..end {
+            if write > block_begin && edge_array[write - 1].target == edge_array[read].target {
+                edge_array[write - 1].data.capacity += edge_array[read].data.capacity;
+                edge_array[write - 1].data.reverse_capacity +=
+                    edge_array[read].data.reverse_capacity;
+            } else {
+                edge_array[write] = edge_array[read];
+                write += 1;
+            }
+        }
+        begin = end;
+        node_array[node + 1] = write;
+    }
+    edge_array.truncate(write);
+    edge_array.shrink_to_fit();
+    debug!("residual graph has {write} arcs");
+
+    // arc ids are held as u32 by the solvers, so a larger graph would silently
+    // index the wrong arc
+    assert!(write <= u32::MAX as usize, "arc ids have to fit into u32");
+    StaticGraph::from_adjacency_array(node_array, edge_array)
 }

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -538,7 +538,7 @@ impl MaxFlow for PushRelabel {
 
     fn max_flow(&self) -> Result<i32, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
         debug!(
             "finished in {} pushes, {} relabels and {} global relabels",
@@ -549,7 +549,7 @@ impl MaxFlow for PushRelabel {
 
     fn assignment(&self, source: NodeID) -> Result<BitVec, String> {
         if !self.finished {
-            return Err("Assigment was not computed.".to_string());
+            return Err("Assignment was not computed.".to_string());
         }
 
         // The side of the cut the source is on is what *cannot reach the sink*,

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -1,17 +1,24 @@
 //! A max-flow computation by push-relabel, for the min cut of an inertial flow
 //! run.
 //!
-//! The algorithm is Goldberg and Tarjan's, with the three things that make the
-//! difference between a textbook version and a competitive one:
+//! The algorithm is Goldberg and Tarjan's, with the heuristics that make the
+//! difference between a textbook version and a usable one:
 //!
-//! 1) *Highest label selection.* The active node discharged next is one of the
-//!    greatest height there is, which bounds the pushes that do not saturate an
-//!    arc by `O(n^2 sqrt(m))` rather than by `O(n^2 m)`.
-//! 2) *Global relabelling.* Every so often the heights are thrown away and
+//! 1) *Lowest label selection.* The active node discharged next is one of the
+//!    least height there is. Highest label is the usual choice and has the
+//!    better bound, but a height is the distance to the sink, so it discharges
+//!    what is furthest from the sink first and delivers nothing there until the
+//!    end. That makes an upper bound useless, which is what inertial flow
+//!    prunes an axis by. See [`PushRelabel::by_lowest_label`].
+//! 2) *Partial augmentation.* A discharge walks a path of admissible arcs and
+//!    moves the flow along the whole of it, rather than pushing across one arc
+//!    and asking the buckets for the excess again a step further on.
+//! 3) *Global relabelling.* Every so often the heights are thrown away and
 //!    worked out again by a backward breadth-first search from the sink, which
 //!    is the exact distance to it. Heights that are exact rather than merely
-//!    valid are what stops the search climbing a node one step at a time.
-//! 3) *The gap heuristic.* If no node is left at some height below `n`, then no
+//!    valid are what stops the search climbing a node one step at a time. A
+//!    graph small enough not to earn that back starts at zero instead.
+//! 4) *The gap heuristic.* If no node is left at some height below `n`, then no
 //!    node above that height can reach the sink at all, and all of them are
 //!    lifted out of the way at once.
 //!
@@ -37,13 +44,19 @@ use std::{
     },
 };
 
-/// How much work is done between two global relabellings, as a multiple of the
-/// arcs of the residual graph.
+/// How much work is done between two sweeps of the heights, as a multiple of
+/// the arcs of the residual graph.
 ///
 /// Cherkassky and Goldberg count the arcs a run has looked at rather than the
-/// relabels it has done, since that is what a sweep of the heights costs and
-/// what it is being weighed against. Six is the value their measurements
-/// settle on; the one here is measured against a road network instead.
+/// relabels it has done, since that is what a sweep is being weighed against.
+/// Six is the value their measurements settle on and it holds up here.
+///
+/// The tally costs an increment in the innermost loop, which looks like
+/// something to remove until it is removed: counting relabels instead reaches
+/// the threshold far later, since work accrues from every arc scanned and not
+/// only from a relabel, and the sweeps that stop the heights drifting then come
+/// too seldom. A threshold of one relabel a node cost five per cent, two cost
+/// eleven, and four cost a third of the run.
 const WORK_PER_SWEEP: usize = 6;
 
 /// What a relabel is charged, over the arcs it scans, for the sweep it makes of
@@ -75,6 +88,9 @@ pub struct PushRelabel {
     pair: Vec<u32>,
     source: NodeID,
     target: NodeID,
+    /// The height that means "cannot reach the sink". A node this high is on
+    /// the source side of the cut and has nothing left to do in phase one.
+    unreachable: u32,
     max_flow: i32,
     finished: bool,
     bound: Option<Arc<AtomicI32>>,
@@ -138,12 +154,6 @@ impl PushRelabel {
         (self.pushes, self.relabels, self.global_relabels)
     }
 
-    /// The height that means "cannot reach the sink". A node this high is on
-    /// the source side of the cut and has nothing left to do in phase one.
-    fn unreachable(&self) -> u32 {
-        u32::try_from(self.residual_graph.number_of_nodes()).expect("the graph is too large")
-    }
-
     /// Which arc runs the other way, for every arc.
     fn pairs_of(graph: &StaticGraph<ResidualArcData>) -> Vec<u32> {
         let mut pair = vec![0_u32; graph.number_of_edges()];
@@ -162,6 +172,7 @@ impl PushRelabel {
     /// Puts a node at the head of the bucket of its height.
     fn link(&mut self, node: NodeID, height: usize) {
         debug_assert!(self.bucket_next[node] == NOWHERE, "a node linked twice");
+        debug_assert!(height < self.bucket_head.len(), "a height past the buckets");
         self.bucket_next[node] = self.bucket_head[height];
         self.bucket_head[height] = u32::try_from(node).expect("the graph is too large to hold");
         self.highest = self.highest.max(height);
@@ -170,7 +181,7 @@ impl PushRelabel {
 
     /// Lifts a node to one above the lowest node it can still reach.
     fn relabel(&mut self, node: NodeID) {
-        let unreachable = self.unreachable();
+        let unreachable = self.unreachable;
         let was = self.height[node];
 
         let mut lowest = u32::MAX;
@@ -189,27 +200,20 @@ impl PushRelabel {
 
         self.height[node] = now;
         self.relabels += 1;
-        if (was as usize) < self.at_height.len() {
-            self.at_height[was as usize] -= 1;
-        }
-        if (now as usize) < self.at_height.len() {
-            self.at_height[now as usize] += 1;
-        }
+        self.at_height[was as usize] -= 1;
+        self.at_height[now as usize] += 1;
 
         // The gap: nothing is left at the height this node came from, so
         // nothing above it and below `unreachable` has a way down to the sink
         // either, and every one of them can be lifted out of the way at once.
-        if was < unreachable
-            && (was as usize) < self.at_height.len()
-            && self.at_height[was as usize] == 0
-        {
+        if was < unreachable && self.at_height[was as usize] == 0 {
             self.gap(was);
         }
     }
 
     /// Lifts everything above an empty height out of phase one.
     fn gap(&mut self, empty: u32) {
-        let unreachable = self.unreachable();
+        let unreachable = self.unreachable;
         for node in 0..self.residual_graph.number_of_nodes() {
             let height = self.height[node];
             if node != self.source && height > empty && height < unreachable {
@@ -224,7 +228,7 @@ impl PushRelabel {
 
     /// Works the heights out again as the exact distance to the sink.
     fn global_relabel(&mut self) {
-        let unreachable = self.unreachable();
+        let unreachable = self.unreachable;
         self.global_relabels += 1;
         self.height
             .iter_mut()
@@ -274,19 +278,18 @@ impl PushRelabel {
         for node in 0..self.residual_graph.number_of_nodes() {
             self.current[node] = self.residual_graph.begin_edges(node);
             let height = self.height[node] as usize;
-            if node != self.source && height < self.at_height.len() {
+            if node != self.source {
                 self.at_height[height] += 1;
             }
             if node == self.source || node == self.target || self.excess[node] <= 0 {
                 continue;
             }
-            if height < self.bucket_head.len() {
-                self.link(node, height);
-            }
+            self.link(node, height);
         }
     }
 
-    /// The next active node of the greatest height, if there is one.
+    /// The next active node of whichever end of the heights is being taken
+    /// from, if there is one.
     fn next_active(&mut self) -> Option<NodeID> {
         loop {
             let at = if self.lowest_label {
@@ -308,7 +311,9 @@ impl PushRelabel {
             };
             let node = self.bucket_head[at] as NodeID;
             self.bucket_head[at] = self.bucket_next[node];
-            self.bucket_next[node] = NOWHERE;
+            if cfg!(debug_assertions) {
+                self.bucket_next[node] = NOWHERE;
+            }
             // buckets are left stale rather than searched through, so what
             // comes out of one is checked here
             if self.excess[node] > 0
@@ -365,16 +370,13 @@ impl PushRelabel {
         let before = self.excess[last];
         self.excess[last] += amount;
         if before == 0 && last != self.source && last != self.target {
-            let height = self.height[last] as usize;
-            if height < self.bucket_head.len() {
-                self.link(last, height);
-            }
+            self.link(last, self.height[last] as usize);
         }
     }
 
     /// Carries a node's excess onward a path at a time.
     fn discharge(&mut self, node: NodeID) {
-        let unreachable = self.unreachable();
+        let unreachable = self.unreachable;
         while self.excess[node] > 0 {
             self.path.clear();
             let mut at = node;
@@ -416,6 +418,7 @@ impl MaxFlow for PushRelabel {
             pair,
             source,
             target,
+            unreachable: u32::try_from(number_of_nodes).expect("the graph is too large"),
             max_flow: 0,
             finished: false,
             bound: None,
@@ -479,7 +482,7 @@ impl MaxFlow for PushRelabel {
 
         // every arc out of the source is filled, which is where the preflow
         // comes from
-        let unreachable = self.unreachable();
+        let unreachable = self.unreachable;
         self.height[self.source] = unreachable;
         for edge in self.residual_graph.edge_range(self.source) {
             let moved = self.residual_graph.data(edge).capacity;

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -56,6 +56,14 @@ const NOWHERE: u32 = u32::MAX;
 /// How many arcs a partial augmentation may walk before it moves what it found.
 const PATH_ARCS: usize = 4;
 
+/// How many nodes a graph needs before its heights are worth a sweep to start.
+///
+/// Exact heights cost a search of the whole cell. A cell settled in a few dozen
+/// relabels never earns that back, and a partition of a continent is mostly
+/// such cells. Zero is a valid height for everything but the source, so the run
+/// simply starts there instead.
+const SMALLEST_FOR_A_SWEEP: usize = 1024;
+
 pub struct PushRelabel {
     residual_graph: StaticGraph<ResidualArcData>,
     /// The arc that runs the other way, for each arc.
@@ -221,7 +229,6 @@ impl PushRelabel {
         self.height
             .iter_mut()
             .for_each(|height| *height = unreachable);
-        self.at_height.iter_mut().for_each(|count| *count = 0);
 
         self.height[self.target] = 0;
         self.queue.clear();
@@ -244,8 +251,12 @@ impl PushRelabel {
         }
         self.height[self.source] = unreachable;
         self.work = 0;
+        self.seed();
+    }
 
-        // the buckets are stale, so they are filled again from what is active
+    /// Fills the buckets, the counts and the arc cursors from the heights as
+    /// they stand, whether those came from a sweep or from nothing at all.
+    fn seed(&mut self) {
         // Only the heads. A stale `next` is never walked into, since `link`
         // overwrites it before the node is ever at the head of a chain; the
         // clear below is what the assertion in `link` reads, and a sweep of the
@@ -254,6 +265,7 @@ impl PushRelabel {
         if cfg!(debug_assertions) {
             self.bucket_next.iter_mut().for_each(|next| *next = NOWHERE);
         }
+        self.at_height.iter_mut().for_each(|count| *count = 0);
         self.highest = 0;
         self.lowest = self.bucket_head.len() - 1;
         // Counting the heights, filling the buckets and winding the arc cursors
@@ -486,8 +498,12 @@ impl MaxFlow for PushRelabel {
             self.excess[self.source] -= i64::from(moved);
         }
 
-        // and the heights start out exact rather than at zero
-        self.global_relabel();
+        if number_of_nodes > SMALLEST_FOR_A_SWEEP {
+            // the heights start out exact rather than at zero
+            self.global_relabel();
+        } else {
+            self.seed();
+        }
 
         let sweep = (WORK_PER_SWEEP * self.residual_graph.number_of_edges()).max(1);
         while let Some(node) = self.next_active() {

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -1,0 +1,745 @@
+//! A max-flow computation by push-relabel, for the min cut of an inertial flow
+//! run.
+//!
+//! The algorithm is Goldberg and Tarjan's, with the three things that make the
+//! difference between a textbook version and a competitive one:
+//!
+//! 1) *Highest label selection.* The active node discharged next is one of the
+//!    greatest height there is, which bounds the pushes that do not saturate an
+//!    arc by `O(n^2 sqrt(m))` rather than by `O(n^2 m)`.
+//! 2) *Global relabelling.* Every so often the heights are thrown away and
+//!    worked out again by a backward breadth-first search from the sink, which
+//!    is the exact distance to it. Heights that are exact rather than merely
+//!    valid are what stops the search climbing a node one step at a time.
+//! 3) *The gap heuristic.* If no node is left at some height below `n`, then no
+//!    node above that height can reach the sink at all, and all of them are
+//!    lifted out of the way at once.
+//!
+//! Only the first phase is run. The second, which returns the excess that never
+//! reached the sink and turns the preflow into a flow, costs as much again and
+//! says nothing about where the cut is: once no active node can reach the sink,
+//! the nodes the source still reaches through residual capacity are one side of
+//! a minimum cut, and the flow value is what has arrived at the sink. That is
+//! all [`crate::inertial_flow`] asks for.
+use crate::{
+    edge::InputEdge,
+    graph::{EdgeID, Graph, NodeID},
+    max_flow::{MaxFlow, ResidualArcData, ResidualEdgeData, residual_graph_of},
+    static_graph::StaticGraph,
+};
+use bitvec::vec::BitVec;
+use log::debug;
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc,
+        atomic::{AtomicI32, Ordering},
+    },
+};
+
+/// How much work is done between two global relabellings, as a multiple of the
+/// arcs of the residual graph.
+///
+/// Cherkassky and Goldberg count the arcs a run has looked at rather than the
+/// relabels it has done, since that is what a sweep of the heights costs and
+/// what it is being weighed against. Six is the value their measurements
+/// settle on; the one here is measured against a road network instead.
+const WORK_PER_SWEEP: usize = 6;
+
+/// What a relabel is charged, over the arcs it scans, for the sweep it makes of
+/// a node's whole block.
+const WORK_OF_A_RELABEL: usize = 12;
+
+/// The end of a bucket's chain of active nodes.
+const NOWHERE: u32 = u32::MAX;
+
+pub struct PushRelabel {
+    residual_graph: StaticGraph<ResidualArcData>,
+    /// The arc that runs the other way, for each arc.
+    ///
+    /// A push moves capacity between an arc and its pair, and push-relabel
+    /// pushes far more often than an augmenting-path method does. Searching the
+    /// other node's block for it every time, as the augmenting methods here do,
+    /// is a binary search per push; this is worked out once instead.
+    pair: Vec<u32>,
+    source: NodeID,
+    target: NodeID,
+    max_flow: i32,
+    finished: bool,
+    bound: Option<Arc<AtomicI32>>,
+
+    /// the distance to the sink, as far as it is known
+    height: Vec<u32>,
+    /// what has arrived at a node and not left it again
+    excess: Vec<i64>,
+    /// where the scan of a node's arcs has got to, so that a discharge that
+    /// gives up and comes back does not start from the beginning
+    current: Vec<EdgeID>,
+    /// how many nodes sit at each height, which is what the gap heuristic reads
+    at_height: Vec<u32>,
+    /// The first active node of each height, and the one after each node.
+    ///
+    /// A vector per height is the obvious way to bucket and the wrong one here:
+    /// the first cut of a continent runs on eighteen million nodes, and a
+    /// vector apiece is four hundred megabytes of empty vectors before a single
+    /// node is pushed, times the axes that run at once. The buckets are singly
+    /// linked through the nodes instead, which is two flat arrays and no
+    /// allocation at all. A node is linked at most once: it is only linked when
+    /// its excess rises from nothing, and it is unlinked before it is
+    /// discharged.
+    bucket_head: Vec<u32>,
+    bucket_next: Vec<u32>,
+    /// the greatest height any bucket holds anything at
+    highest: usize,
+    /// the least height any bucket holds anything at
+    lowest: usize,
+    /// Whether to discharge the node nearest the sink rather than the one
+    /// furthest from it.
+    ///
+    /// Highest label is the variant with the better bound and the better run
+    /// time to a finished flow. It is also the worst possible order for a run
+    /// that may be given up on: a height is the distance to the sink, so it
+    /// discharges what is furthest from the sink first and nothing arrives
+    /// there until the end. Lowest label delivers to the sink from the start,
+    /// which is what a caller watching an upper bound is waiting for.
+    lowest_label: bool,
+    queue: VecDeque<NodeID>,
+    relabels: usize,
+    global_relabels: usize,
+    pushes: usize,
+    /// arcs looked at since the last sweep of the heights
+    work: usize,
+}
+
+impl PushRelabel {
+    /// Discharges the node nearest the sink rather than the one furthest from
+    /// it. See the field of the same name for why that is worth having.
+    pub fn by_lowest_label(&mut self, yes: bool) {
+        self.lowest_label = yes;
+    }
+
+    /// What the run did: pushes, relabels, and global relabels. For working
+    /// out which of the three a change of heuristic actually moved.
+    #[must_use]
+    pub fn work(&self) -> (usize, usize, usize) {
+        (self.pushes, self.relabels, self.global_relabels)
+    }
+
+    /// The height that means "cannot reach the sink". A node this high is on
+    /// the source side of the cut and has nothing left to do in phase one.
+    fn unreachable(&self) -> u32 {
+        u32::try_from(self.residual_graph.number_of_nodes()).expect("the graph is too large")
+    }
+
+    /// Which arc runs the other way, for every arc.
+    fn pairs_of(graph: &StaticGraph<ResidualArcData>) -> Vec<u32> {
+        let mut pair = vec![0_u32; graph.number_of_edges()];
+        for node in 0..graph.number_of_nodes() {
+            for edge in graph.edge_range(node) {
+                let other = graph.target(edge);
+                let back = graph
+                    .find_edge_sorted(other, node)
+                    .expect("residual graph is not symmetric");
+                pair[edge] = u32::try_from(back).expect("arc ids have to fit into u32");
+            }
+        }
+        pair
+    }
+
+    /// Puts a node at the head of the bucket of its height.
+    fn link(&mut self, node: NodeID, height: usize) {
+        debug_assert!(self.bucket_next[node] == NOWHERE, "a node linked twice");
+        self.bucket_next[node] = self.bucket_head[height];
+        self.bucket_head[height] = u32::try_from(node).expect("the graph is too large to hold");
+        self.highest = self.highest.max(height);
+        self.lowest = self.lowest.min(height);
+    }
+
+    /// Moves what it can along an arc that is known to be admissible.
+    fn push(&mut self, node: NodeID, edge: EdgeID, other: NodeID) {
+        let room = i64::from(self.residual_graph.data(edge).capacity);
+        let amount = self.excess[node].min(room);
+        debug_assert!(amount > 0, "a push that moves nothing");
+        let moved = i32::try_from(amount).expect("a push larger than a capacity");
+
+        let residual = self.residual_graph.data_mut(edge);
+        residual.capacity -= moved;
+        residual.reverse_capacity += moved;
+        let back = self.pair[edge] as EdgeID;
+        let residual = self.residual_graph.data_mut(back);
+        residual.capacity += moved;
+        residual.reverse_capacity -= moved;
+
+        self.excess[node] -= amount;
+        let before = self.excess[other];
+        self.excess[other] += amount;
+        self.pushes += 1;
+
+        // a node that had nothing and now has something joins the buckets, and
+        // the sink and the source are never discharged
+        if before == 0 && other != self.source && other != self.target {
+            let height = self.height[other] as usize;
+            if height < self.bucket_head.len() {
+                self.link(other, height);
+            }
+        }
+    }
+
+    /// Lifts a node to one above the lowest node it can still reach.
+    fn relabel(&mut self, node: NodeID) {
+        let unreachable = self.unreachable();
+        let was = self.height[node];
+
+        let mut lowest = u32::MAX;
+        self.work += WORK_OF_A_RELABEL + self.residual_graph.end_edges(node)
+            - self.residual_graph.begin_edges(node);
+        for edge in self.residual_graph.edge_range(node) {
+            if self.residual_graph.data(edge).capacity > 0 {
+                lowest = lowest.min(self.height[self.residual_graph.target(edge)]);
+            }
+        }
+        let now = if lowest == u32::MAX {
+            unreachable
+        } else {
+            lowest.saturating_add(1).min(unreachable)
+        };
+
+        self.height[node] = now;
+        self.relabels += 1;
+        if (was as usize) < self.at_height.len() {
+            self.at_height[was as usize] -= 1;
+        }
+        if (now as usize) < self.at_height.len() {
+            self.at_height[now as usize] += 1;
+        }
+
+        // The gap: nothing is left at the height this node came from, so
+        // nothing above it and below `unreachable` has a way down to the sink
+        // either, and every one of them can be lifted out of the way at once.
+        if was < unreachable
+            && (was as usize) < self.at_height.len()
+            && self.at_height[was as usize] == 0
+        {
+            self.gap(was);
+        }
+    }
+
+    /// Lifts everything above an empty height out of phase one.
+    fn gap(&mut self, empty: u32) {
+        let unreachable = self.unreachable();
+        for node in 0..self.residual_graph.number_of_nodes() {
+            let height = self.height[node];
+            if node != self.source && height > empty && height < unreachable {
+                self.at_height[height as usize] -= 1;
+                self.height[node] = unreachable;
+            }
+        }
+        // the buckets above the gap hold nothing that is still worth taking,
+        // and what is left in them is stepped over when it is popped
+        self.highest = self.highest.min(empty as usize);
+    }
+
+    /// Works the heights out again as the exact distance to the sink.
+    fn global_relabel(&mut self) {
+        let unreachable = self.unreachable();
+        self.global_relabels += 1;
+        self.height
+            .iter_mut()
+            .for_each(|height| *height = unreachable);
+        self.at_height.iter_mut().for_each(|count| *count = 0);
+
+        self.height[self.target] = 0;
+        self.queue.clear();
+        self.queue.push_back(self.target);
+        while let Some(node) = self.queue.pop_front() {
+            let next = self.height[node] + 1;
+            for edge in self.residual_graph.edge_range(node) {
+                let other = self.residual_graph.target(edge);
+                // An arc that runs into `node` and has capacity left is a step
+                // of the backward search. The capacity of that arc is what this
+                // one caches, so the pair does not have to be looked up.
+                if self.height[other] == unreachable
+                    && other != self.source
+                    && self.residual_graph.data(edge).reverse_capacity > 0
+                {
+                    self.height[other] = next;
+                    self.queue.push_back(other);
+                }
+            }
+        }
+        self.height[self.source] = unreachable;
+        self.work = 0;
+
+        // the buckets are stale, so they are filled again from what is active
+        // Only the heads. A stale `next` is never walked into, since `link`
+        // overwrites it before the node is ever at the head of a chain; the
+        // clear below is what the assertion in `link` reads, and a sweep of the
+        // nodes is not worth paying for in a build that does not check it.
+        self.bucket_head.iter_mut().for_each(|head| *head = NOWHERE);
+        if cfg!(debug_assertions) {
+            self.bucket_next.iter_mut().for_each(|next| *next = NOWHERE);
+        }
+        self.highest = 0;
+        self.lowest = self.bucket_head.len() - 1;
+        // Counting the heights, filling the buckets and winding the arc cursors
+        // back are three walks of the same nodes, and this is a quarter of the
+        // time the whole run takes, so they are one walk.
+        for node in 0..self.residual_graph.number_of_nodes() {
+            self.current[node] = self.residual_graph.begin_edges(node);
+            let height = self.height[node] as usize;
+            if node != self.source && height < self.at_height.len() {
+                self.at_height[height] += 1;
+            }
+            if node == self.source || node == self.target || self.excess[node] <= 0 {
+                continue;
+            }
+            if height < self.bucket_head.len() {
+                self.link(node, height);
+            }
+        }
+    }
+
+    /// The next active node of the greatest height, if there is one.
+    fn next_active(&mut self) -> Option<NodeID> {
+        loop {
+            let at = if self.lowest_label {
+                while self.bucket_head[self.lowest] == NOWHERE {
+                    if self.lowest + 1 >= self.bucket_head.len() {
+                        return None;
+                    }
+                    self.lowest += 1;
+                }
+                self.lowest
+            } else {
+                while self.bucket_head[self.highest] == NOWHERE {
+                    if self.highest == 0 {
+                        return None;
+                    }
+                    self.highest -= 1;
+                }
+                self.highest
+            };
+            let node = self.bucket_head[at] as NodeID;
+            self.bucket_head[at] = self.bucket_next[node];
+            self.bucket_next[node] = NOWHERE;
+            // buckets are left stale rather than searched through, so what
+            // comes out of one is checked here
+            if self.excess[node] > 0
+                && (self.height[node] as usize) == at
+                && node != self.source
+                && node != self.target
+            {
+                return Some(node);
+            }
+        }
+    }
+
+    /// Pushes a node's excess onward until it is gone or the node is out of
+    /// phase one.
+    fn discharge(&mut self, node: NodeID) {
+        let unreachable = self.unreachable();
+        let end = self.residual_graph.end_edges(node);
+        while self.excess[node] > 0 {
+            if self.current[node] == end {
+                self.relabel(node);
+                if self.height[node] >= unreachable {
+                    return;
+                }
+                self.current[node] = self.residual_graph.begin_edges(node);
+                continue;
+            }
+            let edge = self.current[node];
+            let other = self.residual_graph.target(edge);
+            if self.residual_graph.data(edge).capacity > 0
+                && self.height[node] == self.height[other] + 1
+            {
+                self.push(node, edge, other);
+            } else {
+                self.current[node] += 1;
+                self.work += 1;
+            }
+        }
+        // it still has a height and no excess, so it goes back in its bucket
+        // only when something is pushed to it again
+    }
+}
+
+impl MaxFlow for PushRelabel {
+    fn from_edge_list(
+        edge_list: Vec<InputEdge<ResidualEdgeData>>,
+        source: NodeID,
+        target: NodeID,
+    ) -> Self {
+        debug_assert!(!edge_list.is_empty());
+        let residual_graph = residual_graph_of(edge_list);
+        let number_of_nodes = residual_graph.number_of_nodes();
+        debug!("pairing {} arcs", residual_graph.number_of_edges());
+        let pair = Self::pairs_of(&residual_graph);
+
+        Self {
+            residual_graph,
+            pair,
+            source,
+            target,
+            max_flow: 0,
+            finished: false,
+            bound: None,
+            height: vec![0; number_of_nodes],
+            excess: vec![0; number_of_nodes],
+            current: vec![0; number_of_nodes],
+            // a height of `n` means the sink cannot be reached, so the counts
+            // only ever run up to there
+            at_height: vec![0; number_of_nodes + 1],
+            bucket_head: vec![NOWHERE; number_of_nodes + 1],
+            bucket_next: vec![NOWHERE; number_of_nodes],
+            highest: 0,
+            lowest: 0,
+            // Lowest label by default. Highest label has the better bound and
+            // is the usual choice, but a height is the distance to the sink, so
+            // it discharges what is furthest from the sink first and delivers
+            // nothing until the end -- which makes an upper bound useless. On
+            // the cuts measured here lowest label also finished with fewer
+            // pushes and far fewer relabels, so nothing is given up for it.
+            lowest_label: true,
+            queue: VecDeque::with_capacity(number_of_nodes),
+            relabels: 0,
+            global_relabels: 0,
+            pushes: 0,
+            work: 0,
+        }
+    }
+
+    fn run_with_upper_bound(&mut self, bound: Arc<AtomicI32>) {
+        debug!("upper bound: {}", bound.load(Ordering::Relaxed));
+        self.bound = Some(bound);
+        self.run();
+    }
+
+    fn run(&mut self) {
+        debug!(
+            "residual graph size: V {}, E {}",
+            self.residual_graph.number_of_nodes(),
+            self.residual_graph.number_of_edges()
+        );
+        let number_of_nodes = self.residual_graph.number_of_nodes();
+        if self.source == self.target || number_of_nodes == 0 {
+            self.max_flow = 0;
+            self.finished = true;
+            return;
+        }
+
+        self.height.iter_mut().for_each(|height| *height = 0);
+        self.excess.iter_mut().for_each(|excess| *excess = 0);
+        self.at_height.iter_mut().for_each(|count| *count = 0);
+        // Only the heads. A stale `next` is never walked into, since `link`
+        // overwrites it before the node is ever at the head of a chain; the
+        // clear below is what the assertion in `link` reads, and a sweep of the
+        // nodes is not worth paying for in a build that does not check it.
+        self.bucket_head.iter_mut().for_each(|head| *head = NOWHERE);
+        if cfg!(debug_assertions) {
+            self.bucket_next.iter_mut().for_each(|next| *next = NOWHERE);
+        }
+        self.highest = 0;
+
+        // every arc out of the source is filled, which is where the preflow
+        // comes from
+        let unreachable = self.unreachable();
+        self.height[self.source] = unreachable;
+        for edge in self.residual_graph.edge_range(self.source) {
+            let moved = self.residual_graph.data(edge).capacity;
+            if moved <= 0 {
+                continue;
+            }
+            let other = self.residual_graph.target(edge);
+            let residual = self.residual_graph.data_mut(edge);
+            residual.capacity -= moved;
+            residual.reverse_capacity += moved;
+            let back = self.pair[edge] as EdgeID;
+            let residual = self.residual_graph.data_mut(back);
+            residual.capacity += moved;
+            residual.reverse_capacity -= moved;
+            self.excess[other] += i64::from(moved);
+            self.excess[self.source] -= i64::from(moved);
+        }
+
+        // and the heights start out exact rather than at zero
+        self.global_relabel();
+
+        let sweep = (WORK_PER_SWEEP * self.residual_graph.number_of_edges()).max(1);
+        while let Some(node) = self.next_active() {
+            self.discharge(node);
+
+            if let Some(bound) = &self.bound {
+                // the sink never gives anything back, so what has arrived at it
+                // only grows and a bound it has passed it cannot come back under
+                let arrived = self.excess[self.target];
+                if arrived > i64::from(bound.load(Ordering::Relaxed)) {
+                    debug!("aborting max flow computation at {arrived}");
+                    self.max_flow = i32::try_from(arrived).unwrap_or(i32::MAX);
+                    return;
+                }
+            }
+
+            if self.work >= sweep {
+                self.global_relabel();
+            }
+        }
+
+        let flow = i32::try_from(self.excess[self.target]).expect("a flow larger than four bytes");
+        if let Some(bound) = &self.bound {
+            bound.fetch_min(flow, Ordering::Relaxed);
+        }
+        self.max_flow = flow;
+        self.finished = true;
+    }
+
+    fn max_flow(&self) -> Result<i32, String> {
+        if !self.finished {
+            return Err("Assigment was not computed.".to_string());
+        }
+        debug!(
+            "finished in {} pushes, {} relabels and {} global relabels",
+            self.pushes, self.relabels, self.global_relabels
+        );
+        Ok(self.max_flow)
+    }
+
+    fn assignment(&self, source: NodeID) -> Result<BitVec, String> {
+        if !self.finished {
+            return Err("Assigment was not computed.".to_string());
+        }
+
+        // The side of the cut the source is on is what *cannot reach the sink*,
+        // and not what the source reaches.
+        //
+        // Those are the same set for a flow and not for a preflow. Phase one
+        // fills every arc out of the source and leaves standing at the nodes in
+        // between whatever never made it to the sink -- phase two, which is not
+        // run, is what would send that back. So the arcs out of the source are
+        // saturated whatever the flow really is, and a search forward from it
+        // would hand back the source on its own and call its own arcs the cut.
+        //
+        // Searching backwards from the sink has no such trouble. Phase one ends
+        // when no node that can still reach the sink holds anything, so no
+        // residual path from the source to the sink is left, the two are on
+        // opposite sides, and the arcs between the sets cost what arrived.
+        let number_of_nodes = self.residual_graph.number_of_nodes();
+        let mut reaches_sink = BitVec::new();
+        reaches_sink.resize(number_of_nodes, false);
+        let mut stack = Vec::with_capacity(number_of_nodes);
+        stack.push(self.target);
+        reaches_sink.set(self.target, true);
+        while let Some(node) = stack.pop() {
+            for edge in self.residual_graph.edge_range(node) {
+                let other = self.residual_graph.target(edge);
+                // the arc that runs the other way is the one that would carry
+                // something into `node`, and this one caches its capacity
+                if !reaches_sink[other] && self.residual_graph.data(edge).reverse_capacity > 0 {
+                    stack.push(other);
+                    reaches_sink.set(other, true);
+                }
+            }
+        }
+
+        let mut assignment = !reaches_sink;
+        assignment.truncate(number_of_nodes);
+        debug_assert!(
+            assignment[source],
+            "the source can reach the sink after a finished run"
+        );
+        Ok(assignment)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PushRelabel;
+    use crate::dinic::Dinic;
+    use crate::edge::InputEdge;
+    use crate::max_flow::{MaxFlow, ResidualEdgeData};
+    use rand::{RngExt, SeedableRng, prelude::StdRng};
+
+    /// What the arcs of the input cost to cut, given which side each node fell
+    /// on. This is the check that matters: a flow value nobody can place a cut
+    /// against says nothing.
+    fn cut_of(edges: &[InputEdge<ResidualEdgeData>], assignment: &bitvec::vec::BitVec) -> i32 {
+        edges
+            .iter()
+            .filter(|edge| assignment[edge.source] && !assignment[edge.target])
+            .map(|edge| edge.data.capacity)
+            .sum()
+    }
+
+    /// A random layered graph. Its depth forces the search through a number of
+    /// heights, and the arcs that skip and lead back a layer keep the layering
+    /// from being the one the graph was built with.
+    fn layered_graph(
+        rng: &mut StdRng,
+        width: usize,
+        depth: usize,
+    ) -> (Vec<InputEdge<ResidualEdgeData>>, usize, usize) {
+        let source = 0;
+        let target = 1 + width * depth;
+        let node = |layer: usize, index: usize| 1 + layer * width + index;
+
+        let mut edges = Vec::new();
+        for index in 0..width {
+            edges.push(InputEdge::new(
+                source,
+                node(0, index),
+                ResidualEdgeData::new(rng.random_range(1..=8)),
+            ));
+            edges.push(InputEdge::new(
+                node(depth - 1, index),
+                target,
+                ResidualEdgeData::new(rng.random_range(1..=8)),
+            ));
+        }
+        for layer in 0..depth - 1 {
+            for index in 0..width {
+                for other in 0..width {
+                    if rng.random_range(0..100) < 40 {
+                        edges.push(InputEdge::new(
+                            node(layer, index),
+                            node(layer + 1, other),
+                            ResidualEdgeData::new(rng.random_range(1..=5)),
+                        ));
+                    }
+                }
+                if layer + 2 < depth && rng.random_range(0..100) < 20 {
+                    edges.push(InputEdge::new(
+                        node(layer, index),
+                        node(layer + 2, index),
+                        ResidualEdgeData::new(rng.random_range(1..=5)),
+                    ));
+                }
+                if layer > 0 && rng.random_range(0..100) < 15 {
+                    edges.push(InputEdge::new(
+                        node(layer, index),
+                        node(layer - 1, index),
+                        ResidualEdgeData::new(rng.random_range(1..=5)),
+                    ));
+                }
+            }
+        }
+        (edges, source, target)
+    }
+
+    #[test]
+    fn a_path_carries_what_its_narrowest_arc_does() {
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(5)),
+            InputEdge::new(1, 2, ResidualEdgeData::new(3)),
+            InputEdge::new(2, 3, ResidualEdgeData::new(7)),
+        ];
+        let mut solver = PushRelabel::from_edge_list(edges.clone(), 0, 3);
+        solver.run();
+        assert_eq!(solver.max_flow(), Ok(3));
+        let assignment = solver.assignment(0).expect("it ran");
+        assert_eq!(cut_of(&edges, &assignment), 3);
+    }
+
+    #[test]
+    fn two_ways_round_carry_the_sum_of_both() {
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(0, 2, ResidualEdgeData::new(6)),
+            InputEdge::new(1, 3, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 3, ResidualEdgeData::new(6)),
+        ];
+        let mut solver = PushRelabel::from_edge_list(edges.clone(), 0, 3);
+        solver.run();
+        assert_eq!(solver.max_flow(), Ok(10));
+        let assignment = solver.assignment(0).expect("it ran");
+        assert_eq!(cut_of(&edges, &assignment), 10);
+    }
+
+    #[test]
+    fn a_sink_the_source_cannot_reach_carries_nothing() {
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 3, ResidualEdgeData::new(6)),
+        ];
+        let mut solver = PushRelabel::from_edge_list(edges.clone(), 0, 3);
+        solver.run();
+        assert_eq!(solver.max_flow(), Ok(0));
+        let assignment = solver.assignment(0).expect("it ran");
+        assert_eq!(cut_of(&edges, &assignment), 0);
+    }
+
+    /// The answer has to be the one an augmenting-path method gives, on graphs
+    /// neither of them was written against.
+    #[test]
+    fn it_agrees_with_dinic_over_many_graphs() {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        for round in 0..64 {
+            let width = 2 + round % 7;
+            let depth = 2 + round % 5;
+            let (edges, source, target) = layered_graph(&mut rng, width, depth);
+
+            let mut pushed = PushRelabel::from_edge_list(edges.clone(), source, target);
+            // both ways of picking the next node, since they are two orders over
+            // the same invariants and either could be the one that breaks them
+            pushed.by_lowest_label(round % 2 == 0);
+            pushed.run();
+            let mut dinic = Dinic::from_edge_list(edges.clone(), source, target);
+            dinic.run();
+
+            let one = pushed.max_flow().expect("push-relabel did not run");
+            let other = dinic.max_flow().expect("dinic did not run");
+            assert_eq!(
+                one, other,
+                "round {round}: push-relabel says {one}, dinic says {other}"
+            );
+
+            // and the cut it names has to cost what it says the flow is
+            let assignment = pushed.assignment(source).expect("push-relabel did not run");
+            assert!(assignment[source], "the source is not on its own side");
+            assert!(!assignment[target], "the sink is on the source side");
+            assert_eq!(
+                cut_of(&edges, &assignment),
+                one,
+                "round {round}: the cut does not cost what the flow does"
+            );
+        }
+    }
+
+    /// A bound the flow passes stops the run, which is how inertial flow drops
+    /// an axis that cannot win.
+    #[test]
+    fn a_flow_over_the_bound_gives_up() {
+        use std::sync::{Arc, atomic::AtomicI32};
+
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(0, 2, ResidualEdgeData::new(6)),
+            InputEdge::new(1, 3, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 3, ResidualEdgeData::new(6)),
+        ];
+        let mut solver = PushRelabel::from_edge_list(edges, 0, 3);
+        solver.run_with_upper_bound(Arc::new(AtomicI32::new(2)));
+        assert!(
+            solver.max_flow().is_err(),
+            "a run that gave up reported a flow"
+        );
+    }
+
+    /// And one it stays under runs to the end and lowers the bound.
+    #[test]
+    fn a_flow_under_the_bound_lowers_it() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicI32, Ordering},
+        };
+
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(1, 2, ResidualEdgeData::new(4)),
+        ];
+        let bound = Arc::new(AtomicI32::new(100));
+        let mut solver = PushRelabel::from_edge_list(edges, 0, 2);
+        solver.run_with_upper_bound(bound.clone());
+        assert_eq!(solver.max_flow(), Ok(4));
+        assert_eq!(bound.load(Ordering::Relaxed), 4);
+    }
+}

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -53,6 +53,9 @@ const WORK_OF_A_RELABEL: usize = 12;
 /// The end of a bucket's chain of active nodes.
 const NOWHERE: u32 = u32::MAX;
 
+/// How many arcs a partial augmentation may walk before it moves what it found.
+const PATH_ARCS: usize = 4;
+
 pub struct PushRelabel {
     residual_graph: StaticGraph<ResidualArcData>,
     /// The arc that runs the other way, for each arc.
@@ -109,6 +112,8 @@ pub struct PushRelabel {
     pushes: usize,
     /// arcs looked at since the last sweep of the heights
     work: usize,
+    /// the arcs of the path being walked, kept so it is not allocated per walk
+    path: Vec<EdgeID>,
 }
 
 impl PushRelabel {
@@ -153,36 +158,6 @@ impl PushRelabel {
         self.bucket_head[height] = u32::try_from(node).expect("the graph is too large to hold");
         self.highest = self.highest.max(height);
         self.lowest = self.lowest.min(height);
-    }
-
-    /// Moves what it can along an arc that is known to be admissible.
-    fn push(&mut self, node: NodeID, edge: EdgeID, other: NodeID) {
-        let room = i64::from(self.residual_graph.data(edge).capacity);
-        let amount = self.excess[node].min(room);
-        debug_assert!(amount > 0, "a push that moves nothing");
-        let moved = i32::try_from(amount).expect("a push larger than a capacity");
-
-        let residual = self.residual_graph.data_mut(edge);
-        residual.capacity -= moved;
-        residual.reverse_capacity += moved;
-        let back = self.pair[edge] as EdgeID;
-        let residual = self.residual_graph.data_mut(back);
-        residual.capacity += moved;
-        residual.reverse_capacity -= moved;
-
-        self.excess[node] -= amount;
-        let before = self.excess[other];
-        self.excess[other] += amount;
-        self.pushes += 1;
-
-        // a node that had nothing and now has something joins the buckets, and
-        // the sink and the source are never discharged
-        if before == 0 && other != self.source && other != self.target {
-            let height = self.height[other] as usize;
-            if height < self.bucket_head.len() {
-                self.link(other, height);
-            }
-        }
     }
 
     /// Lifts a node to one above the lowest node it can still reach.
@@ -334,13 +309,72 @@ impl PushRelabel {
         }
     }
 
-    /// Pushes a node's excess onward until it is gone or the node is out of
-    /// phase one.
+    /// The next admissible arc out of a node, moving its cursor up to it.
+    fn admissible(&mut self, node: NodeID) -> Option<EdgeID> {
+        let end = self.residual_graph.end_edges(node);
+        while self.current[node] < end {
+            let edge = self.current[node];
+            let other = self.residual_graph.target(edge);
+            if self.residual_graph.data(edge).capacity > 0
+                && self.height[node] == self.height[other] + 1
+            {
+                return Some(edge);
+            }
+            self.current[node] += 1;
+            self.work += 1;
+        }
+        None
+    }
+
+    /// Moves what the walked path will carry along the whole of it.
+    fn augment(&mut self, from: NodeID) {
+        let mut amount = self.excess[from];
+        for &edge in &self.path {
+            amount = amount.min(i64::from(self.residual_graph.data(edge).capacity));
+        }
+        debug_assert!(amount > 0, "an augmentation that moves nothing");
+        let moved = i32::try_from(amount).expect("an augmentation larger than a capacity");
+
+        let mut last = from;
+        for at in 0..self.path.len() {
+            let edge = self.path[at];
+            let residual = self.residual_graph.data_mut(edge);
+            residual.capacity -= moved;
+            residual.reverse_capacity += moved;
+            let back = self.pair[edge] as EdgeID;
+            let residual = self.residual_graph.data_mut(back);
+            residual.capacity += moved;
+            residual.reverse_capacity -= moved;
+            last = self.residual_graph.target(edge);
+            self.pushes += 1;
+        }
+
+        self.excess[from] -= amount;
+        let before = self.excess[last];
+        self.excess[last] += amount;
+        if before == 0 && last != self.source && last != self.target {
+            let height = self.height[last] as usize;
+            if height < self.bucket_head.len() {
+                self.link(last, height);
+            }
+        }
+    }
+
+    /// Carries a node's excess onward a path at a time.
     fn discharge(&mut self, node: NodeID) {
         let unreachable = self.unreachable();
-        let end = self.residual_graph.end_edges(node);
         while self.excess[node] > 0 {
-            if self.current[node] == end {
+            self.path.clear();
+            let mut at = node;
+            while self.path.len() < PATH_ARCS && at != self.target {
+                let Some(edge) = self.admissible(at) else {
+                    break;
+                };
+                self.path.push(edge);
+                at = self.residual_graph.target(edge);
+            }
+
+            if self.path.is_empty() {
                 self.relabel(node);
                 if self.height[node] >= unreachable {
                     return;
@@ -348,19 +382,8 @@ impl PushRelabel {
                 self.current[node] = self.residual_graph.begin_edges(node);
                 continue;
             }
-            let edge = self.current[node];
-            let other = self.residual_graph.target(edge);
-            if self.residual_graph.data(edge).capacity > 0
-                && self.height[node] == self.height[other] + 1
-            {
-                self.push(node, edge, other);
-            } else {
-                self.current[node] += 1;
-                self.work += 1;
-            }
+            self.augment(node);
         }
-        // it still has a height and no excess, so it goes back in its bucket
-        // only when something is pushed to it again
     }
 }
 
@@ -406,6 +429,7 @@ impl MaxFlow for PushRelabel {
             global_relabels: 0,
             pushes: 0,
             work: 0,
+            path: Vec::with_capacity(PATH_ARCS),
         }
     }
 


### PR DESCRIPTION
`PushRelabel` implements `MaxFlow`, `inertial_flow::sub_step` is generic over
the trait rather than naming a solver, and `chipper --solver` picks between
them with push-relabel as the default.

    chipper --solver push-relabel   the default
    chipper --solver dinic          what this used before

`residual_graph_of` moves out of `Dinic::from_edge_list` into `max_flow`, since
both solvers want the same residual graph built the same way.

## The solver

Goldberg and Tarjan's, phase one only. The second phase returns the excess that
never reached the sink and turns the preflow into a flow; it costs as much again
and says nothing about where the cut is, which is all inertial flow asks for.

`assignment` searches backwards from the sink and hands back the complement,
where the augmenting solvers here search forward from the source. Those are the
same set for a flow and not for a preflow: phase one fills every arc out of the
source, so a search forward from it hands back the source on its own and calls
its own arcs the cut. The tests caught that, and the reasoning is in the source.

Four heuristics carry it, in the order they were worth anything:

| | |
|---|---|
| lowest label selection | 354x less work on a run that gives up |
| a sweep of the heights in one walk of the nodes, not eight | 10% |
| selecting the ends of the projection order rather than sorting it | 3.7% |
| skipping the sweep on a cell too small to earn it | 1.3% |
| partial augmentation | 1.5% |

Lowest label is the one that matters. Highest label is the usual choice and has
the better bound, but a height is the distance to the sink, so it discharges
what is furthest from the sink first and delivers nothing there until the end.
That makes an upper bound useless, and an upper bound is how inertial flow drops
an axis that cannot win: on a grid of 9218 nodes with a bound of 4, the run that
gives up did 183915 pushes against 184009 for the run that finishes.

Three things were tried and taken back out: the pair index inside the arc entry,
which widens the entry and slows the scans that outnumber pushes, and cost Dinic
5%; a check for blocks already in order, which pays a scan on millions of tiny
blocks; and counting relabels rather than arcs to trigger a sweep, which sweeps
too seldom and cost between 5% and a third of the run.

## What it is worth

europe.ptv, 18010173 nodes and 42188664 arcs, one machine, alternating runs.

| | push-relabel | dinic |
|---|---|---|
| cutting, recursion depth 8 | 74s | 136s |
| the whole six level partition | 118s | 181s |
| peak resident | 6.51 GB | 6.53 GB |

Memory is a tie. Push-relabel holds about 14% more per instance, nearly all of
it the array of arc pairs, but the peak is set by the copy of the edge list that
each axis holds, which is a gigabyte at the root cut and the same either way.

## That it is right

`ranks check` holds the search over the cells against a plain search through
them: 4800 pairs from rank 2 to rank 2^24, and the two agree on every one, for a
partition cut either way.

A query costs the same on either hierarchy. Median over 4800 pairs is 101.9us
against 102.5us, and the ratio stays between 0.96x and 1.07x across all 24 rank
buckets with no trend.

The hierarchies are not the same, though. The two solvers find minimum cuts of
the same cost and break a tie differently, so they share 4720 of some 28800 cut
arcs. Anything measured against a partition cut by Dinic is measured against a
different partition, which is why Dinic stays.

The unit tests cross-check the flow against Dinic over 64 random layered graphs
under both selection rules, and assert that the cut named costs what the flow
does. A flow value with no valid cut behind it would pass a value-only test.

Written with agent assistance.