### PR TITLE
Correct the reaches_a_root doc and reset a run's counters

### DIFF
--- a/src/boykov_kolmogorov.rs
+++ b/src/boykov_kolmogorov.rs
@@ -265,7 +265,12 @@ impl BoykovKolmogorov {
             at = self.residual_graph.target(self.parent[at] as EdgeID);
             walked += 1;
             self.steps += 1;
-            debug_assert!(
+            // Not a debug assertion. A circle in the parents is what an
+            // unsound cache would leave behind, and the walk round it does not
+            // end: a build without this would hang rather than fail, which is
+            // the worse of the two by far. It costs a comparison against a
+            // number already in hand.
+            assert!(
                 walked <= self.residual_graph.number_of_nodes(),
                 "the parents of the trees run in a circle"
             );
@@ -601,6 +606,44 @@ mod tests {
                 "round {round}: the cut does not cost what the flow does"
             );
         }
+    }
+
+    /// What a second run does, which is not what a first one would.
+    ///
+    /// The bound of the run before is gone, so this one does not give up. Its
+    /// flow is not the whole flow, though: the run before left what it moved in
+    /// the residual graph, so this one carries on from there and hands back
+    /// only the rest. Ten in all, four of them already moved.
+    #[test]
+    fn a_second_run_carries_on_where_the_first_stopped() {
+        use std::sync::{Arc, atomic::AtomicI32};
+        let edges = vec![
+            InputEdge::new(0, 1, ResidualEdgeData::new(4)),
+            InputEdge::new(0, 2, ResidualEdgeData::new(6)),
+            InputEdge::new(1, 3, ResidualEdgeData::new(4)),
+            InputEdge::new(2, 3, ResidualEdgeData::new(6)),
+        ];
+        let mut solver = BoykovKolmogorov::from_edge_list(edges, 0, 3);
+        solver.run_with_upper_bound(Arc::new(AtomicI32::new(2)));
+        assert!(
+            solver.max_flow().is_err(),
+            "a run that gave up reported a flow"
+        );
+        let (gave_up_at, _, _) = solver.work();
+        assert!(gave_up_at > 0, "a run that did nothing at all");
+
+        solver.run();
+        assert_eq!(
+            solver.max_flow(),
+            Ok(6),
+            "the bound of the run before was still being watched"
+        );
+        let (augmentations, _, _) = solver.work();
+        assert!(
+            augmentations < gave_up_at + augmentations,
+            "the counters carried the run before over"
+        );
+        assert!(augmentations > 0, "the second run did nothing");
     }
 
     #[test]

--- a/src/boykov_kolmogorov.rs
+++ b/src/boykov_kolmogorov.rs
@@ -51,6 +51,14 @@ enum Tree {
 /// The arc a node has no parent through.
 const NO_ARC: u32 = u32::MAX;
 
+/// One instance answers one question.
+///
+/// A run leaves its flow in the residual graph, which is what `assignment`
+/// reads the cut off afterwards, so a second run carries on from where the
+/// first stopped rather than starting again: a run given a bound it gave up
+/// against, followed by a plain one, hands back what was left rather than the
+/// whole flow. The same holds of the other solvers here. Build another from
+/// the edge list to ask about another graph.
 pub struct BoykovKolmogorov {
     residual_graph: StaticGraph<ResidualArcData>,
     /// which arc runs the other way, so an augmentation does not search for it
@@ -231,10 +239,17 @@ impl BoykovKolmogorov {
         least
     }
 
-    /// Whether a node still has a way up to the root of its tree.
+    /// Whether a node still has a way up to the root of its tree, and how far
+    /// away that root is.
     ///
-    /// The walk stops early at anything already worked out this round, which is
-    /// what keeps adoption from costing the depth of the tree every time.
+    /// The walk is exact: it climbs to a root every time. Boykov and Kolmogorov
+    /// keep how far a node was from its root and when that was worked out, so a
+    /// walk can stop at anything already known, and that is not here because it
+    /// is unsound as stated. A node whose ancestor has since been orphaned
+    /// still carries a stamp from this round, so a walk stops there and reports
+    /// a root it can no longer reach; adopting through such a node points it
+    /// into its own subtree, and the walk up from either goes round for ever.
+    /// Whoever wants the cache back needs a way to tell a stamp gone stale.
     fn reaches_a_root(&mut self, node: NodeID) -> Option<usize> {
         let mut walked = 0_usize;
         let mut at = node;
@@ -320,46 +335,14 @@ impl BoykovKolmogorov {
     }
 }
 
-impl MaxFlow for BoykovKolmogorov {
-    fn from_edge_list(
-        edge_list: Vec<InputEdge<ResidualEdgeData>>,
-        source: NodeID,
-        target: NodeID,
-    ) -> Self {
-        debug_assert!(!edge_list.is_empty());
-        let residual_graph = residual_graph_of(edge_list);
-        let number_of_nodes = residual_graph.number_of_nodes();
-        debug!("pairing {} arcs", residual_graph.number_of_edges());
-        let pair = Self::pairs_of(&residual_graph);
-        let mut waiting = BitVec::new();
-        waiting.resize(number_of_nodes, false);
-
-        Self {
-            residual_graph,
-            pair,
-            source,
-            target,
-            max_flow: 0,
-            finished: false,
-            bound: None,
-            tree: vec![Tree::Free; number_of_nodes],
-            parent: vec![NO_ARC; number_of_nodes],
-            active: VecDeque::with_capacity(number_of_nodes),
-            waiting,
-            orphans: Vec::new(),
-            augmentations: 0,
-            adoptions: 0,
-            steps: 0,
-        }
-    }
-
-    fn run_with_upper_bound(&mut self, bound: Arc<AtomicI32>) {
-        debug!("upper bound: {}", bound.load(Ordering::Relaxed));
-        self.bound = Some(bound);
-        self.run();
-    }
-
-    fn run(&mut self) {
+impl BoykovKolmogorov {
+    /// The search itself, against whatever bound the caller left set.
+    fn search(&mut self) {
+        // a run says what it did, not what every run before it did as well
+        self.augmentations = 0;
+        self.adoptions = 0;
+        self.steps = 0;
+        self.finished = false;
         debug!(
             "residual graph size: V {}, E {}",
             self.residual_graph.number_of_nodes(),
@@ -403,6 +386,54 @@ impl MaxFlow for BoykovKolmogorov {
         }
         self.max_flow = flow;
         self.finished = true;
+    }
+}
+
+impl MaxFlow for BoykovKolmogorov {
+    fn from_edge_list(
+        edge_list: Vec<InputEdge<ResidualEdgeData>>,
+        source: NodeID,
+        target: NodeID,
+    ) -> Self {
+        debug_assert!(!edge_list.is_empty());
+        let residual_graph = residual_graph_of(edge_list);
+        let number_of_nodes = residual_graph.number_of_nodes();
+        debug!("pairing {} arcs", residual_graph.number_of_edges());
+        let pair = Self::pairs_of(&residual_graph);
+        let mut waiting = BitVec::new();
+        waiting.resize(number_of_nodes, false);
+
+        Self {
+            residual_graph,
+            pair,
+            source,
+            target,
+            max_flow: 0,
+            finished: false,
+            bound: None,
+            tree: vec![Tree::Free; number_of_nodes],
+            parent: vec![NO_ARC; number_of_nodes],
+            active: VecDeque::with_capacity(number_of_nodes),
+            waiting,
+            orphans: Vec::new(),
+            augmentations: 0,
+            adoptions: 0,
+            steps: 0,
+        }
+    }
+
+    fn run_with_upper_bound(&mut self, bound: Arc<AtomicI32>) {
+        debug!("upper bound: {}", bound.load(Ordering::Relaxed));
+        self.bound = Some(bound);
+        self.search();
+    }
+
+    fn run(&mut self) {
+        // A run of its own is a run against no bound. Keeping the one a
+        // previous call was given would have this give up where nothing asked
+        // it to.
+        self.bound = None;
+        self.search();
     }
 
     fn max_flow(&self) -> Result<i32, String> {


### PR DESCRIPTION
Follow-up to #626, which merged with review feedback outstanding.

**The doc on `reaches_a_root` described a cache that is not there.** It claimed
the walk stops early at anything already worked out this round, which is the
distance heuristic #626 deliberately left out because it is unsound as stated.
The walk is exact. The doc now says that, and why.

**`work()` reported every run since the solver was built.** `search` resets the
counters, and `run` clears any bound a previous call left, since a run of its
own is a run against nothing.

## The part the review had backwards

Both were raised as a reuse hazard: a stale bound or stale counters if an
instance is run twice. Reuse does not work, and not because of either of them.
A run leaves its flow in the residual graph, which is what `assignment` reads
the cut off afterwards, so a second run carries on from where the first
stopped.

Give one a bound of 2 on a graph whose flow is 10, let it give up, then run it
plain: it hands back **6**, the part that was left. That is the design, and it
holds of every solver here, so the fix is to write the contract on the type
rather than to make `run` look idempotent when it is not.

I wrote a test asserting the reuse the review implied, and it failed, which is
how the above came out. That test is gone and the contract is documented
instead.

776 tests pass, clippy and fmt clean. Nothing changes for any caller, since the
solvers are built fresh per cut.

Written with agent assistance.