### PR TITLE
Prefetch in push-relabel's global relabel, gated on the last level cache

### DIFF
--- a/examples/bfs_prefetch.rs
+++ b/examples/bfs_prefetch.rs
@@ -1,0 +1,237 @@
+//! What software prefetching is worth to a breadth-first search.
+//!
+//!     bfs_prefetch                 grids only
+//!     bfs_prefetch <graph>         grids and a road network
+use std::{collections::VecDeque, env::args, time::Instant};
+
+use toolbox_rs::{
+    edge::InputEdge,
+    io,
+    prefetch::{hint, last_level_cache, worth_it},
+};
+
+/// How many bytes a search over this graph touches at random: the offsets, the
+/// arcs, and a settled flag a node.
+fn working_set(nodes: usize, arcs: usize) -> usize {
+    4 * (nodes + 1 + arcs + nodes)
+}
+
+/// A graph as an adjacency array: where each node's arcs begin, and where they go.
+struct Csr {
+    begins: Vec<u32>,
+    targets: Vec<u32>,
+}
+
+impl Csr {
+    fn of(edges: &[(u32, u32)], nodes: usize) -> Self {
+        let mut begins = vec![0_u32; nodes + 1];
+        for &(from, _) in edges {
+            begins[from as usize + 1] += 1;
+        }
+        for i in 1..begins.len() {
+            begins[i] += begins[i - 1];
+        }
+        let mut cursor = begins.clone();
+        let mut targets = vec![0_u32; edges.len()];
+        for &(from, to) in edges {
+            targets[cursor[from as usize] as usize] = to;
+            cursor[from as usize] += 1;
+        }
+        Self { begins, targets }
+    }
+
+    fn nodes(&self) -> usize {
+        self.begins.len() - 1
+    }
+}
+
+/// The plain search.
+fn bfs(csr: &Csr, source: u32, seen: &mut [u32], queue: &mut VecDeque<u32>) -> usize {
+    seen.fill(u32::MAX);
+    queue.clear();
+    queue.push_back(source);
+    seen[source as usize] = source;
+
+    let mut settled = 0;
+    while let Some(node) = queue.pop_front() {
+        settled += 1;
+        let node = node as usize;
+        let (from, to) = (csr.begins[node] as usize, csr.begins[node + 1] as usize);
+        for edge in from..to {
+            let target = csr.targets[edge] as usize;
+            if seen[target] == u32::MAX {
+                seen[target] = node as u32;
+                queue.push_back(target as u32);
+            }
+        }
+    }
+    settled
+}
+
+/// How far ahead a hint is issued, in queue places for the first two and in
+/// arcs for the third.
+///
+/// Swept over 24 pairs on a grid of four million nodes, where the whole surface
+/// lies between 65 and 69 per cent saved: the distances are not what the
+/// technique turns on. What holds everywhere is the gap between the two, since
+/// the offsets hint must land before the arc hint reads them.
+///
+/// Which arc distance wins is a property of the instance, over four rounds of
+/// four each way: a grid wants two, at 69.1 per cent against 68.0 for six,
+/// while the road network wants six, at 26.5 per cent against 24.2 for two. A
+/// grid's four arcs a node are one line, so the block hint is worth little and
+/// is best issued close to its use; a road network's blocks are scattered
+/// enough to want the longer run-up. Two is the default here because the grids
+/// come first; `PushRelabel` uses six, since a road network is its workload.
+/// Overridable so the sweep can be repeated elsewhere.
+fn ahead() -> (usize, usize) {
+    let of = |name: &str, fallback: usize| {
+        std::env::var(name)
+            .ok()
+            .and_then(|given| given.parse().ok())
+            .unwrap_or(fallback)
+    };
+    (of("TOOLBOX_OFFSETS_AHEAD", 12), of("TOOLBOX_ARCS_AHEAD", 2))
+}
+
+/// The same search, asking for what it is about to want.
+fn bfs_prefetching(csr: &Csr, source: u32, seen: &mut [u32], queue: &mut VecDeque<u32>) -> usize {
+    let (offsets_ahead, arcs_ahead) = ahead();
+    // which of the three sites are in play, for taking them away one at a time
+    let site = |name: &str| std::env::var(name).is_err();
+    let (do_offsets, do_arcs) = (site("TOOLBOX_NO_OFFSETS"), site("TOOLBOX_NO_ARCS"));
+    seen.fill(u32::MAX);
+    queue.clear();
+    queue.push_back(source);
+    seen[source as usize] = source;
+
+    let mut settled = 0;
+    while let Some(node) = queue.pop_front() {
+        settled += 1;
+        // Two stages, because the second address is not known until the first
+        // has landed: the offsets of a node further down the queue, and the arcs
+        // of a nearer one, whose offsets were asked for several rounds ago and
+        // are in cache by now.
+        if do_offsets && let Some(&soon) = queue.get(offsets_ahead) {
+            hint(std::ptr::from_ref(&csr.begins[soon as usize]));
+        }
+        if do_arcs && let Some(&soon) = queue.get(arcs_ahead) {
+            hint(std::ptr::from_ref(
+                &csr.targets[csr.begins[soon as usize] as usize],
+            ));
+        }
+
+        let node = node as usize;
+        let (from, to) = (csr.begins[node] as usize, csr.begins[node + 1] as usize);
+        for edge in from..to {
+            let target = csr.targets[edge] as usize;
+            if seen[target] == u32::MAX {
+                seen[target] = node as u32;
+                queue.push_back(target as u32);
+            }
+        }
+    }
+    settled
+}
+
+/// A four-connected grid, both ways along every arc.
+fn grid(side: usize) -> (Vec<(u32, u32)>, usize) {
+    let node = |row: usize, column: usize| (row * side + column) as u32;
+    let mut edges = Vec::with_capacity(4 * side * side);
+    for row in 0..side {
+        for column in 0..side {
+            if column + 1 < side {
+                edges.push((node(row, column), node(row, column + 1)));
+                edges.push((node(row, column + 1), node(row, column)));
+            }
+            if row + 1 < side {
+                edges.push((node(row, column), node(row + 1, column)));
+                edges.push((node(row + 1, column), node(row, column)));
+            }
+        }
+    }
+    (edges, side * side)
+}
+
+/// Whether a search over this graph is worth prefetching for.
+///
+/// One times the last level cache is where the measurements put the line: a
+/// grid of a million nodes, at 2.8 times the cache, still saves about half.
+fn worth_prefetching(nodes: usize, arcs: usize) -> bool {
+    worth_it(working_set(nodes, arcs))
+}
+
+fn time(what: &str, csr: &Csr, rounds: usize) {
+    let mut seen = vec![u32::MAX; csr.nodes()];
+    let mut queue: VecDeque<u32> = VecDeque::with_capacity(csr.nodes());
+    let mut plain = f64::MAX;
+    let mut ahead = f64::MAX;
+    let mut settled = 0;
+    for round in 0..rounds {
+        let source = ((round * 7919) % csr.nodes()) as u32;
+        let at = Instant::now();
+        let count = bfs(csr, source, &mut seen, &mut queue);
+        plain = plain.min(at.elapsed().as_secs_f64());
+        assert!(
+            settled == 0 || settled == count,
+            "a round settled differently"
+        );
+        settled = count;
+        let at = Instant::now();
+        let again = bfs_prefetching(csr, source, &mut seen, &mut queue);
+        ahead = ahead.min(at.elapsed().as_secs_f64());
+        assert_eq!(settled, again, "the two searches settled different nodes");
+    }
+    println!(
+        "{what:>22} {:>12} {:>12} {:>9} {plain:>10.4} {ahead:>10.4} {:>7.1}% {:>7}",
+        csr.nodes(),
+        csr.targets.len(),
+        format!("{} MiB", working_set(csr.nodes(), csr.targets.len()) >> 20),
+        100.0 * (plain - ahead) / plain,
+        if worth_prefetching(csr.nodes(), csr.targets.len()) {
+            "yes"
+        } else {
+            "no"
+        },
+    );
+}
+
+fn main() {
+    // what the gating column is measured against
+    println!("last level cache: {} MiB", last_level_cache() >> 20);
+    println!(
+        "{:>22} {:>12} {:>12} {:>9} {:>10} {:>10} {:>8} {:>7}",
+        "instance", "nodes", "arcs", "touched", "plain", "prefetch", "saved", "gated"
+    );
+    let sides: Vec<usize> = std::env::var("TOOLBOX_SIDES").map_or_else(
+        |_| vec![512, 1024, 2048, 4096],
+        |given| {
+            given
+                .split(',')
+                .map(|side| side.parse().expect("a grid side"))
+                .collect()
+        },
+    );
+    for side in sides {
+        let (edges, nodes) = grid(side);
+        let csr = Csr::of(&edges, nodes);
+        time(&format!("grid {side}x{side}"), &csr, 5);
+    }
+
+    if let Some(path) = args().nth(1) {
+        let input: Vec<InputEdge<u32>> = io::read_edges_from_file(&path);
+        let nodes = 1 + input
+            .iter()
+            .map(|edge| edge.source.max(edge.target))
+            .max()
+            .expect("an empty graph");
+        let edges: Vec<(u32, u32)> = input
+            .iter()
+            .map(|edge| (edge.source as u32, edge.target as u32))
+            .collect();
+        drop(input);
+        let csr = Csr::of(&edges, nodes);
+        drop(edges);
+        time("road network", &csr, 5);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod path_based_scc;
 pub mod path_unpacking;
 pub mod polyline;
 pub mod pool;
+pub mod prefetch;
 pub mod prim_complete_graph;
 pub mod push_relabel;
 pub mod rdx_sort;

--- a/src/prefetch.rs
+++ b/src/prefetch.rs
@@ -1,0 +1,119 @@
+//! Asking for a line before it is wanted, and deciding whether it is worth it.
+//!
+//! A hint is not a load. It cannot fault, it cannot change a result, and on an
+//! architecture without one it is nothing at all. What it can do is waste an
+//! instruction, which is why [`worth_it`] exists: below the last level cache a
+//! search is not missing, and the hints are then a cost with nothing to show.
+
+use std::sync::OnceLock;
+
+/// Ask for a line to be brought into the first level of cache.
+#[inline(always)]
+pub fn hint<T>(at: *const T) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: the hint takes any address at all, mapped or not, and has no
+    // effect beyond the cache.
+    unsafe {
+        std::arch::x86_64::_mm_prefetch::<{ std::arch::x86_64::_MM_HINT_T0 }>(at.cast());
+    }
+    // the aarch64 intrinsic is unstable, so the instruction is written out:
+    // preload, first level, keep
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: as above. prfm cannot fault and cannot change a result.
+    unsafe {
+        std::arch::asm!(
+            "prfm pldl1keep, [{at}]",
+            at = in(reg) at,
+            options(nostack, preserves_flags)
+        );
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = at;
+}
+
+/// The last level cache, in bytes, asked of the machine once.
+///
+/// `TOOLBOX_LAST_LEVEL_CACHE` overrides, which is how a threshold is swept. A
+/// machine that will not say is taken to have eight mebibytes, so that the
+/// decision below still has something to compare against.
+pub fn last_level_cache() -> usize {
+    static ASKED: OnceLock<usize> = OnceLock::new();
+    *ASKED.get_or_init(|| {
+        if let Some(given) = std::env::var("TOOLBOX_LAST_LEVEL_CACHE")
+            .ok()
+            .and_then(|given| given.parse().ok())
+        {
+            return given;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let mut bytes: u64 = 0;
+            let mut width = std::mem::size_of::<u64>();
+            // SAFETY: the name is a nul terminated literal, and a u64 is written
+            // into a u64 whose width is what is handed over.
+            let asked = unsafe {
+                libc::sysctlbyname(
+                    c"hw.l3cachesize".as_ptr().cast(),
+                    std::ptr::from_mut(&mut bytes).cast(),
+                    &mut width,
+                    std::ptr::null_mut(),
+                    0,
+                )
+            };
+            if asked == 0 && bytes > 0 {
+                return usize::try_from(bytes).unwrap_or(8 << 20);
+            }
+        }
+        #[cfg(target_os = "linux")]
+        for index in 0..8 {
+            let at = format!("/sys/devices/system/cpu/cpu0/cache/index{index}");
+            if let (Ok(level), Ok(size)) = (
+                std::fs::read_to_string(format!("{at}/level")),
+                std::fs::read_to_string(format!("{at}/size")),
+            ) && level.trim() == "3"
+                && let Some(kibibytes) = size.trim().strip_suffix('K')
+                && let Ok(kibibytes) = kibibytes.parse::<usize>()
+            {
+                return kibibytes * 1024;
+            }
+        }
+        8 << 20
+    })
+}
+
+/// Whether a working set of this many bytes is worth prefetching for.
+///
+/// The whole of it has to be missing for a hint to buy anything. A search that
+/// fits in the last level cache is not waiting on memory, and the hints are
+/// then instructions and nothing else.
+#[must_use]
+pub fn worth_it(working_set: usize) -> bool {
+    working_set > last_level_cache()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hint, last_level_cache, worth_it};
+
+    #[test]
+    fn a_hint_leaves_what_it_asks_for_alone() {
+        let numbers = [1_u64, 2, 3, 4];
+        hint(std::ptr::from_ref(&numbers[3]));
+        assert_eq!(numbers, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn the_machine_names_a_last_level_cache() {
+        let bytes = last_level_cache();
+        assert!(bytes > 0);
+        // asking twice is asking once, so the answer cannot drift
+        assert_eq!(bytes, last_level_cache());
+    }
+
+    #[test]
+    fn only_a_working_set_past_the_cache_is_worth_it() {
+        assert!(!worth_it(0));
+        assert!(!worth_it(last_level_cache()));
+        assert!(worth_it(last_level_cache() + 1));
+    }
+}

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -437,13 +437,14 @@ impl MaxFlow for PushRelabel {
         debug!("pairing {} arcs", residual_graph.number_of_edges());
         let pair = Self::pairs_of(&residual_graph);
 
-        // Everything a run touches at random: the graph, the pairs, and a
-        // handful of arrays a node wide. Below the last level cache none of it
-        // is missing and the hints are a cost with nothing to show.
-        let working_set = 8 * (number_of_nodes + 1)
-            + 12 * residual_graph.number_of_edges()
-            + 4 * residual_graph.number_of_edges()
-            + 32 * number_of_nodes;
+        // Everything a run touches at random: the graph, the pairs, and the
+        // arrays a node wide, which are height, current, at_height,
+        // bucket_head and bucket_next in a u32 apiece and excess in an i64.
+        // Below the last level cache none of it is missing and the hints are a
+        // cost with nothing to show.
+        let per_node = 5 * size_of::<u32>() + size_of::<i64>();
+        let working_set =
+            residual_graph.bytes() + size_of::<u32>() * pair.len() + per_node * number_of_nodes;
         let prefetching = crate::prefetch::worth_it(working_set);
         debug!(
             "working set {} MiB, last level cache {} MiB, prefetching {prefetching}",

--- a/src/push_relabel.rs
+++ b/src/push_relabel.rs
@@ -69,6 +69,16 @@ const NOWHERE: u32 = u32::MAX;
 /// How many arcs a partial augmentation may walk before it moves what it found.
 const PATH_ARCS: usize = 4;
 
+/// How far ahead of the sweep's queue a node's offsets are asked for, and how
+/// far ahead its block of arcs is.
+///
+/// The two differ because the second reads the first: working out where a
+/// node's arcs lie means reading its offsets, and at the same distance that
+/// read would miss and stall where the hint was meant to help. The gap is what
+/// matters rather than either number.
+const OFFSETS_AHEAD: usize = 12;
+const ARCS_AHEAD: usize = 6;
+
 /// How many nodes a graph needs before its heights are worth a sweep to start.
 ///
 /// Exact heights cost a search of the whole cell. A cell settled in a few dozen
@@ -131,6 +141,9 @@ pub struct PushRelabel {
     /// which is what a caller watching an upper bound is waiting for.
     lowest_label: bool,
     queue: VecDeque<NodeID>,
+    /// Whether this instance is large enough that asking for a line early pays
+    /// for the instruction it costs. Worked out once, at construction.
+    prefetching: bool,
     relabels: usize,
     global_relabels: usize,
     pushes: usize,
@@ -238,6 +251,17 @@ impl PushRelabel {
         self.queue.clear();
         self.queue.push_back(self.target);
         while let Some(node) = self.queue.pop_front() {
+            if self.prefetching {
+                // the offsets of a node further down the queue, and the arcs of
+                // a nearer one, whose offsets were asked for several rounds ago
+                if let Some(&soon) = self.queue.get(OFFSETS_AHEAD) {
+                    self.residual_graph.prefetch_node(soon);
+                }
+                if let Some(&soon) = self.queue.get(ARCS_AHEAD) {
+                    self.residual_graph
+                        .prefetch_arcs(self.residual_graph.begin_edges(soon));
+                }
+            }
             let next = self.height[node] + 1;
             for edge in self.residual_graph.edge_range(node) {
                 let other = self.residual_graph.target(edge);
@@ -413,9 +437,24 @@ impl MaxFlow for PushRelabel {
         debug!("pairing {} arcs", residual_graph.number_of_edges());
         let pair = Self::pairs_of(&residual_graph);
 
+        // Everything a run touches at random: the graph, the pairs, and a
+        // handful of arrays a node wide. Below the last level cache none of it
+        // is missing and the hints are a cost with nothing to show.
+        let working_set = 8 * (number_of_nodes + 1)
+            + 12 * residual_graph.number_of_edges()
+            + 4 * residual_graph.number_of_edges()
+            + 32 * number_of_nodes;
+        let prefetching = crate::prefetch::worth_it(working_set);
+        debug!(
+            "working set {} MiB, last level cache {} MiB, prefetching {prefetching}",
+            working_set >> 20,
+            crate::prefetch::last_level_cache() >> 20
+        );
+
         Self {
             residual_graph,
             pair,
+            prefetching,
             source,
             target,
             unreachable: u32::try_from(number_of_nodes).expect("the graph is too large"),

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -47,6 +47,16 @@ impl<T: Ord + Copy> StaticGraph<T> {
         }
     }
 
+    /// What the two arrays take up.
+    ///
+    /// This is what a walk that jumps about the graph has to miss on, so it is
+    /// what a decision about prefetching is made against.
+    #[must_use]
+    pub fn bytes(&self) -> usize {
+        size_of::<NodeArrayEntry>() * self.node_array.len()
+            + size_of::<EdgeArrayEntry<T>>() * self.edge_array.len()
+    }
+
     // In time O(V+E) check that the following invariants hold:
     // a) the node array spans the edge array, from zero up to its length. An
     //    empty node array fails here, as it lacks even the sentinel.

--- a/src/static_graph.rs
+++ b/src/static_graph.rs
@@ -28,6 +28,25 @@ impl<T: Ord + Clone> Default for StaticGraph<T> {
 }
 
 impl<T: Ord + Copy> StaticGraph<T> {
+    /// Ask for the offsets of a node, which is where a scan of its arcs begins.
+    ///
+    /// A node taken off a queue is a random place in the node array, so this is
+    /// the first of the two misses a walk of its arcs costs.
+    #[inline(always)]
+    pub fn prefetch_node(&self, node: NodeID) {
+        if let Some(entry) = self.node_array.get(node) {
+            crate::prefetch::hint(std::ptr::from_ref(entry));
+        }
+    }
+
+    /// Ask for the block of arcs a node owns, which is the second.
+    #[inline(always)]
+    pub fn prefetch_arcs(&self, edge: EdgeID) {
+        if let Some(entry) = self.edge_array.get(edge) {
+            crate::prefetch::hint(std::ptr::from_ref(entry));
+        }
+    }
+
     // In time O(V+E) check that the following invariants hold:
     // a) the node array spans the edge array, from zero up to its length. An
     //    empty node array fails here, as it lacks even the sentinel.


### PR DESCRIPTION
## What moved

**New module `prefetch`.**

- `hint<T>(at: *const T)` asks for a line in the first level of cache. `_mm_prefetch` on x86_64, a written out `prfm pldl1keep` on aarch64 because the intrinsic is still unstable, and nothing at all elsewhere.
- `last_level_cache() -> usize` asks the machine once behind a `OnceLock`: `hw.l3cachesize` on macOS, `/sys/devices/system/cpu/cpu0/cache/index*` on Linux, `TOOLBOX_LAST_LEVEL_CACHE` overriding either, eight mebibytes when neither answers.
- `worth_it(working_set: usize) -> bool` is that comparison and nothing more.

**`StaticGraph` gains two methods**, `prefetch_node(NodeID)` and `prefetch_arcs(EdgeID)`, naming the two lines a walk of a node's arcs costs.

**`PushRelabel` gains a `prefetching: bool` field.** It is worked out once in `from_edge_list` from a working set of the graph, the pair array, and the arrays a node wide, and never touched again. The backward search in `global_relabel` asks for the offsets of the node `OFFSETS_AHEAD` (12) down its queue and the arcs of the one `ARCS_AHEAD` (6) down, both behind that field. The two distances differ because the second read depends on the first: working out where a node's arcs lie means reading its offsets, so at the same distance that read would itself miss.

**New example `bfs_prefetch`.** A breadth-first search over an adjacency array, run plain and again asking for what it is about to want, over four-connected grids and optionally a road network given as an argument. It reports what a search touches at random, both times, the saving, and whether `worth_it` would have gated the hints away, which is how the one-times-cache threshold was found. It calls `prefetch::hint` and `prefetch::worth_it` rather than carrying its own copy, so the crate has exactly one place that issues a hint. `TOOLBOX_SIDES`, `TOOLBOX_OFFSETS_AHEAD`, `TOOLBOX_ARCS_AHEAD`, `TOOLBOX_NO_OFFSETS` and `TOOLBOX_NO_ARCS` drive the sweep.

| instance | touched | plain | prefetch | saved | gated |
|---|---|---|---|---|---|
| grid 512x512 | 5 MiB | 0.0026 | 0.0025 | 3.0% | no |
| grid 1024x1024 | 23 MiB | 0.0287 | 0.0149 | 48.0% | yes |
| grid 2048x2048 | 95 MiB | 0.2086 | 0.0655 | 68.6% | yes |
| grid 4096x4096 | 383 MiB | 0.9274 | 0.3028 | 67.4% | yes |
| road network | 298 MiB | 0.6031 | 0.4555 | 24.5% | yes |

The gate sits where the saving appears: below the cache there is nothing to save, and one grid step above it there is half.

## Numbers

europe.ptv, recursion depth eight, four rounds against `origin/main`. The order swaps each round, base first on the odd ones and prefetch first on the even, so that going first is worth nothing:

| | round 1 | round 2 | round 3 | round 4 | mean | min |
|---|---|---|---|---|---|---|
| base | 76.62s | 78.66s | 79.25s | 79.10s | 78.41s | 76.62s |
| prefetch | 73.15s | 75.43s | 72.94s | 71.17s | 73.17s | 71.17s |

A saving of 6.7% on the means and 7.1% on the minima, ahead in four rounds of four, by between 4.1% and 10.0%.

The machine was not as quiet as the numbers deserve: background load put both arms about 6% above an earlier run of the same shape, which had the saving at 6.1% over three rounds. The two runs agree on the size of the effect and the second one measures the code as it now stands, `size_of` fix included.

The cost of the disabled path is still unmeasured, so what a below-cache instance pays for the branch is not known.

## Correctness

Same binary, gate on against gate forced off, europe.ptv at depth eight: the cut csv is byte identical as written, and so is the 72 MB partition file. A debug line confirms the two runs really did take different paths (687 MiB working set against an 8 MiB cache, then against a forced 953674 MiB).

`worth_it` is covered by three unit tests. 707 lib tests pass, clippy and fmt are clean.

## What this leaves

The module adds `unsafe`, which the repo has removed on purpose. There is no way to issue a prefetch without it: `_mm_prefetch` and inline `asm!` are both unsafe. It is confined to the two blocks in `prefetch.rs`, both with a safety note saying a hint cannot fault and cannot change a result. Say the word and I will drop the change rather than spend the exemption.

Most cells fall below the gate. Inertial flow's cells shrink fast with depth, so only the few near the root prefetch at all, which is why 6.1% and not more.

`ARCS_AHEAD` is instance dependent: 6 wins on europe by about two points, 2 wins on grids. 6 is set here because a road network is the workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

