### PR TITLE
On-the-fly EBG simulation

### DIFF
--- a/examples/edge_based_cells.rs
+++ b/examples/edge_based_cells.rs
@@ -1,0 +1,108 @@
+//! What an edge-based overlay would cost against the node-based one it is
+//! built from.
+//!
+//!     edge_based_cells <graph> <level directory>
+//!
+//! An edge-based node is an arc, so a cell holds the arcs whose tail lies in
+//! it, and its border is the arcs that cross into or out of it rather than the
+//! nodes that sit on the boundary. A cell's table is every way in against
+//! every way out, so what it costs is the entering arcs times the leaving
+//! ones, where the node-based table costs the border nodes squared.
+//!
+//! Nothing is customized here. This counts what customizing would have to hold.
+use std::env::args;
+
+use toolbox_rs::{
+    graph::{Arcs, NodeID},
+    io,
+    level_directory::LevelDirectory,
+    static_graph::StaticGraph,
+};
+
+fn main() {
+    let graph = args().nth(1).expect("a graph");
+    let directory = args().nth(2).expect("a level directory");
+
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph));
+    let directory: LevelDirectory = io::read_from_file(&directory);
+    println!(
+        "{} nodes, {} arcs, {} levels",
+        graph.number_of_nodes(),
+        graph.number_of_edges(),
+        directory.levels()
+    );
+
+    println!(
+        "\n{:>6} {:>10} {:>14} {:>12} {:>12} {:>16} {:>16} {:>16} {:>8}",
+        "level",
+        "cells",
+        "border nodes",
+        "rows",
+        "columns",
+        "node entries",
+        "square now",
+        "rectangular",
+        "saving"
+    );
+
+    for level in 0..directory.levels() {
+        let cells = directory.cells_on_level(level);
+        // a node the boundary touches at all, one a route can enter by, and the
+        // arcs that cross out of the cell
+        let mut touched = vec![false; graph.number_of_nodes()];
+        let mut entered = vec![false; graph.number_of_nodes()];
+        let mut crossing_out = vec![0_u64; cells];
+
+        for tail in 0..graph.number_of_nodes() {
+            let mine = directory.cell_of(tail, level) as usize;
+            for arc in graph.edge_range(tail) {
+                let head = graph.target(arc) as NodeID;
+                if mine == directory.cell_of(head, level) as usize {
+                    continue;
+                }
+                crossing_out[mine] += 1;
+                touched[tail] = true;
+                touched[head] = true;
+                // the arc runs into the other cell, so its head is a way in
+                entered[head] = true;
+            }
+        }
+
+        // what each cell holds, counted the three ways
+        let mut border_nodes = vec![0_u64; cells];
+        let mut leaving_touched = vec![0_u64; cells];
+        let mut leaving_entered = vec![0_u64; cells];
+        for node in 0..graph.number_of_nodes() {
+            let cell = directory.cell_of(node, level) as usize;
+            let out = graph.edge_range(node).len() as u64;
+            if touched[node] {
+                border_nodes[cell] += 1;
+                leaving_touched[cell] += out;
+            }
+            if entered[node] {
+                leaving_entered[cell] += out;
+            }
+        }
+
+        let (mut nodes_sq, mut square, mut tighter) = (0_u128, 0_u128, 0_u128);
+        let (mut rows, mut columns) = (0_u64, 0_u64);
+        for cell in 0..cells {
+            nodes_sq += u128::from(border_nodes[cell]) * u128::from(border_nodes[cell]);
+            square += u128::from(leaving_touched[cell]) * u128::from(leaving_touched[cell]);
+            tighter += u128::from(leaving_entered[cell]) * u128::from(crossing_out[cell]);
+            rows += leaving_entered[cell];
+            columns += crossing_out[cell];
+        }
+        println!(
+            "{level:>6} {:>10} {:>14} {:>12} {:>12} {:>16} {:>16} {:>16} {:>7.2}x",
+            cells,
+            border_nodes.iter().sum::<u64>(),
+            rows,
+            columns,
+            nodes_sq,
+            square,
+            tighter,
+            tighter as f64 / square as f64
+        );
+    }
+}

--- a/examples/edge_based_customize.rs
+++ b/examples/edge_based_customize.rs
@@ -1,0 +1,69 @@
+//! What it costs to tabulate the cells of an edge-based overlay.
+//!
+//!     edge_based_customize <graph> <coordinates> <level directory> [levels]
+//!
+//! The cells are asked for level by level, since a coarse one is built out of
+//! the cells below it and asking for it first would customize those on the way
+//! anyway, without saying which level the time went to.
+use std::{env::args, time::Instant};
+
+use toolbox_rs::{
+    edge_based::AnglePenalty,
+    edge_based_overlay::EdgeBasedOverlay,
+    geometry::FPCoordinate,
+    graph::Graph,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    overlay::{CellTable, Overlay},
+    static_graph::StaticGraph,
+};
+
+fn main() {
+    let graph = args().nth(1).expect("a graph");
+    let coordinates = args().nth(2).expect("coordinates");
+    let directory = args().nth(3).expect("a level directory");
+    let upto: usize = args()
+        .nth(4)
+        .map_or(usize::MAX, |given| given.parse().expect("a level count"));
+
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph));
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&coordinates);
+    let directory: LevelDirectory = io::read_from_file(&directory);
+    println!(
+        "{} nodes, {} arcs, {} levels",
+        graph.number_of_nodes(),
+        graph.number_of_edges(),
+        directory.levels()
+    );
+
+    let started = Instant::now();
+    let overlay =
+        EdgeBasedOverlay::new(graph, coordinates, AnglePenalty::new(30., 100), &directory);
+    println!(
+        "built the overlay in {:.1} s",
+        started.elapsed().as_secs_f64()
+    );
+
+    println!(
+        "\n{:>6} {:>10} {:>14} {:>16} {:>10}",
+        "level", "cells", "ways out", "entries", "seconds"
+    );
+    for level in 0..directory.levels().min(upto) {
+        let started = Instant::now();
+        let (mut ways_out, mut entries, mut tabled) = (0_u64, 0_u128, 0_u64);
+        for cell in 0..overlay.cells_on_level(level) {
+            let Some(table) = overlay.distances_of(level, cell as CellId) else {
+                continue;
+            };
+            let wide = table.border_nodes().len() as u64;
+            ways_out += wide;
+            entries += u128::from(table.entries() as u64);
+            tabled += 1;
+        }
+        println!(
+            "{level:>6} {:>10} {ways_out:>14} {entries:>16} {:>9.1}s",
+            tabled,
+            started.elapsed().as_secs_f64()
+        );
+    }
+}

--- a/examples/edge_based_probe.rs
+++ b/examples/edge_based_probe.rs
@@ -1,0 +1,223 @@
+//! What an edge-based graph worked out as it is walked costs, and what it
+//! changes.
+//!
+//!     edge_based_probe <graph> <coordinates> [source] [rounds]
+//!
+//! Each round is one search to exhaustion from a single source, four times
+//! over: on the
+//! node-based graph, and on the edge-based graph with free turns, with
+//! reversals refused, and with a penalty by angle. One search reaches
+//! everything the source can reach, so nothing here rests on which pairs were
+//! picked. The rounds run one after another and the least time each way took
+//! is the one reported, since a machine with anything else on it can only ever
+//! make a run slower than it is.
+//!
+//! An edge-based search leaves a cost against each arc. What it cost to reach a
+//! node is the least of those over the arcs running into it, which is what the
+//! two are compared as.
+use std::{env::args, time::Instant};
+
+use toolbox_rs::{
+    edge_based::{AnglePenalty, EdgeBasedGraph, FreeTurns, NoUTurns, TurnCost, between_nodes},
+    geometry::FPCoordinate,
+    graph::{Arcs, NodeID},
+    io,
+    static_graph::StaticGraph,
+    unidirectional_dijkstra::TrackedUnidirectionalDijkstra,
+};
+
+const UNREACHED: usize = usize::MAX;
+
+/// What one way of costing turns did, and what it left behind.
+struct Run {
+    what: &'static str,
+    seconds: f64,
+    /// nodes the queue took in, which for an edge-based run counts arcs
+    search_space: usize,
+    /// offsets read looking for tails, over tails asked for
+    steps: usize,
+    lookups: usize,
+    /// what it cost to reach each node of the underlying graph
+    distance: Vec<usize>,
+}
+
+impl Run {
+    fn reached(&self) -> usize {
+        self.distance.iter().filter(|&&at| at != UNREACHED).count()
+    }
+
+    /// How this run's answers differ from the ones free turns gave.
+    ///
+    /// Free turns forbid nothing and cost nothing, so they answer what the
+    /// node-based graph answers, and every difference here is something the
+    /// turn cost did.
+    fn against(&self, free: &Run) -> (usize, usize, f64, usize) {
+        let (mut dearer, mut shut_out, mut sum, mut worst) = (0, 0, 0.0, 0);
+        for (mine, theirs) in self.distance.iter().zip(&free.distance) {
+            if *theirs == UNREACHED {
+                continue;
+            }
+            if *mine == UNREACHED {
+                shut_out += 1;
+            } else if mine > theirs {
+                dearer += 1;
+                sum += (mine - theirs) as f64 / *theirs as f64;
+                worst = worst.max(mine - theirs);
+            }
+        }
+        let share = if dearer == 0 {
+            0.0
+        } else {
+            sum / dearer as f64
+        };
+        (dearer, shut_out, 100.0 * share, worst)
+    }
+}
+
+/// A search to exhaustion over the node-based graph.
+fn over_nodes(graph: &StaticGraph<u32>, source: NodeID, rounds: usize) -> Run {
+    let mut search = TrackedUnidirectionalDijkstra::new();
+    let nowhere = graph.number_of_nodes();
+
+    let mut seconds = f64::MAX;
+    for _ in 0..rounds {
+        let at = Instant::now();
+        search.run(graph, source, nowhere);
+        seconds = seconds.min(at.elapsed().as_secs_f64());
+    }
+
+    let distance = (0..graph.number_of_nodes())
+        .map(|node| search.distance(node))
+        .collect();
+    Run {
+        what: "node-based",
+        seconds,
+        search_space: search.search_space_len(),
+        steps: 0,
+        lookups: 0,
+        distance,
+    }
+}
+
+/// A search to exhaustion over the edge-based graph, folded back onto nodes.
+fn over_edges<T: TurnCost>(
+    what: &'static str,
+    graph: &StaticGraph<u32>,
+    coordinates: &[FPCoordinate],
+    turns: T,
+    source: NodeID,
+    rounds: usize,
+) -> Run {
+    let expanded = EdgeBasedGraph::new(graph, coordinates, turns);
+    let mut search = TrackedUnidirectionalDijkstra::new();
+    let nowhere = graph.number_of_nodes();
+
+    let mut seconds = f64::MAX;
+    for _ in 0..rounds {
+        let at = Instant::now();
+        between_nodes(&mut search, &expanded, source, nowhere);
+        seconds = seconds.min(at.elapsed().as_secs_f64());
+    }
+
+    // what it cost to reach a node is the least over the arcs that run into it
+    let mut distance = vec![UNREACHED; graph.number_of_nodes()];
+    for arc in 0..graph.number_of_edges() {
+        let reached = search.distance(arc);
+        if reached != UNREACHED {
+            let head = graph.target(arc);
+            distance[head] = distance[head].min(reached);
+        }
+    }
+    // the source itself is where the run began, at no cost
+    distance[source] = 0;
+
+    let (steps, lookups) = expanded.tail_steps();
+    Run {
+        what,
+        seconds,
+        search_space: search.search_space_len(),
+        steps,
+        lookups,
+        distance,
+    }
+}
+
+fn main() {
+    let graph = args().nth(1).expect("a graph");
+    let coordinates = args().nth(2).expect("coordinates");
+    let source: NodeID = args()
+        .nth(3)
+        .map_or(1_000_003, |given| given.parse().expect("a source node"));
+    let rounds: usize = args()
+        .nth(4)
+        .map_or(3, |given| given.parse().expect("a round count"));
+
+    let edges = io::read_edges_from_file(&graph);
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&coordinates);
+    let graph = StaticGraph::new(edges);
+    println!(
+        "{} nodes, {} arcs, {} coordinates, source {source}, {rounds} rounds",
+        graph.number_of_nodes(),
+        graph.number_of_edges(),
+        coordinates.len()
+    );
+
+    let plain = over_nodes(&graph, source, rounds);
+    let free = over_edges("free", &graph, &coordinates, FreeTurns, source, rounds);
+    let none = over_edges("no u-turns", &graph, &coordinates, NoUTurns, source, rounds);
+    let angle = over_edges(
+        "angle 30/100",
+        &graph,
+        &coordinates,
+        AnglePenalty::new(30., 100),
+        source,
+        rounds,
+    );
+
+    println!(
+        "\n{:>14} {:>9} {:>14} {:>22} {:>8} {:>12}",
+        "turns", "time", "search space", "offsets read", "slower", "reached"
+    );
+    for run in [&plain, &free, &none, &angle] {
+        let steps = if run.lookups == 0 {
+            "-".to_string()
+        } else {
+            format!("{} in {}", run.steps, run.lookups)
+        };
+        println!(
+            "{:>14} {:>8.3}s {:>14} {:>22} {:>7.2}x {:>12}",
+            run.what,
+            run.seconds,
+            run.search_space,
+            steps,
+            run.seconds / plain.seconds,
+            run.reached()
+        );
+    }
+
+    println!(
+        "\n{:>14} {:>12} {:>10} {:>10} {:>10}",
+        "turns", "dearer", "shut out", "mean rise", "worst rise"
+    );
+    for run in [&none, &angle] {
+        let (dearer, shut_out, share, worst) = run.against(&free);
+        println!(
+            "{:>14} {:>12} {:>10} {:>9.2}% {:>10}",
+            run.what, dearer, shut_out, share, worst
+        );
+    }
+
+    // the check that matters: free turns forbid nothing and cost nothing
+    let wrong = free
+        .distance
+        .iter()
+        .zip(&plain.distance)
+        .filter(|(mine, theirs)| mine != theirs)
+        .count();
+    println!(
+        "\nfree turns answered {} of {} nodes exactly as the node-based graph did",
+        graph.number_of_nodes() - wrong,
+        graph.number_of_nodes()
+    );
+    assert_eq!(wrong, 0, "the expansion changed a distance it must not");
+}

--- a/examples/edge_based_store_check.rs
+++ b/examples/edge_based_store_check.rs
@@ -1,0 +1,126 @@
+//! Whether a table read off a file is the table that was written.
+//!
+//!     edge_based_store_check <graph> <coordinates> <level directory> <tables>
+//!
+//! The cells are tabulated in memory and read back out of the store, and the
+//! two are held against each other cell by cell: the arcs each names on its
+//! border, and then what it says about crossing between them.
+use std::env::args;
+
+use toolbox_rs::{
+    block_map::BlockMap,
+    block_store::BlockStore,
+    border_levels::BorderLevels,
+    cell_tree::CellTree,
+    edge_based::AnglePenalty,
+    edge_based_overlay::{EdgeBasedOverlay, PagedEdgeBasedOverlay},
+    geometry::FPCoordinate,
+    io,
+    level_directory::{CellId, LevelDirectory},
+    overlay::{CellTable, Overlay},
+    packed_partition::PackedPartition,
+    paged_overlay::PagedOverlay,
+    pool::Pool,
+    static_graph::StaticGraph,
+};
+
+fn main() {
+    let graph_at = args().nth(1).expect("a graph");
+    let coordinates_at = args().nth(2).expect("coordinates");
+    let directory_at = args().nth(3).expect("a level directory");
+    let tables_at = args().nth(4).expect("the packed tables");
+
+    let graph = StaticGraph::new(io::read_edges_from_file(&graph_at));
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&coordinates_at);
+    let directory: LevelDirectory = io::read_from_file(&directory_at);
+
+    let held = EdgeBasedOverlay::new(
+        StaticGraph::new(io::read_edges_from_file(&graph_at)),
+        coordinates.clone(),
+        AnglePenalty::new(30., 100),
+        &directory,
+    );
+
+    let map: BlockMap = io::read_from_file(&format!("{tables_at}.map"));
+    let tree: CellTree = io::read_from_file(&format!("{tables_at}.tree"));
+    let begins: Vec<Vec<u32>> = io::read_vec_from_file(&format!("{tables_at}.begins"));
+    let widths: Vec<Vec<u32>> = io::read_vec_from_file(&format!("{tables_at}.widths"));
+    let partition = PackedPartition::of(&directory);
+    let borders = BorderLevels::of(&graph, &partition);
+    let store = BlockStore::open_counting_from(
+        std::path::Path::new(&format!("{tables_at}.blocks")),
+        map,
+        tree,
+        begins.clone(),
+        widths,
+    )
+    .expect("a store to open");
+    let paged = PagedEdgeBasedOverlay::new(
+        PagedOverlay::new(
+            store,
+            StaticGraph::new(io::read_edges_from_file(&graph_at)),
+            partition,
+            borders,
+            Pool::of(512 << 20),
+        ),
+        graph,
+        coordinates,
+        AnglePenalty::new(30., 100),
+    );
+
+    println!(
+        "{:>6} {:>10} {:>10} {:>10} {:>12} {:>12}",
+        "level", "checked", "no table", "wrong ids", "wrong rows", "arcs begin"
+    );
+    for level in 0..directory.levels() {
+        let cells = held.cells_on_level(level);
+        let (mut checked, mut missing, mut wrong_ids, mut wrong_rows) = (0, 0, 0, 0);
+        // a sample, since a continent has half a million cells on its finest
+        for cell in (0..cells).step_by(1 + cells / 200) {
+            let cell = cell as CellId;
+            let (Some(mine), Some(theirs)) = (
+                held.distances_of(level, cell),
+                paged.distances_of(level, cell),
+            ) else {
+                missing += 1;
+                continue;
+            };
+            checked += 1;
+            if mine.border_nodes() != theirs.border_nodes() {
+                wrong_ids += 1;
+                if wrong_ids == 1 {
+                    let (a, b) = (mine.border_nodes(), theirs.border_nodes());
+                    let at = a.iter().zip(b).position(|(x, y)| x != y);
+                    println!(
+                        "  level {level} cell {cell}: held {} ids, read {} ids, first differing at {at:?}",
+                        a.len(),
+                        b.len()
+                    );
+                    if let Some(at) = at {
+                        let upto = (at + 4).min(a.len()).min(b.len());
+                        println!(
+                            "    held {:?} against read {:?}",
+                            &a[at..upto],
+                            &b[at..upto]
+                        );
+                    }
+                }
+                continue;
+            }
+            for source in 0..mine.border_nodes().len() {
+                if mine.row(source) != theirs.row(source) {
+                    wrong_rows += 1;
+                    break;
+                }
+            }
+        }
+        println!(
+            "{level:>6} {checked:>10} {missing:>10} {wrong_ids:>10} {wrong_rows:>12} {:>12}",
+            begins
+                .get(level)
+                .and_then(|at| at.first())
+                .copied()
+                .unwrap_or(0)
+        );
+    }
+}

--- a/src/block_store.rs
+++ b/src/block_store.rs
@@ -177,6 +177,12 @@ pub struct BlockStore {
     blocks: File,
     map: BlockMap,
     tree: CellTree,
+    /// What each cell's ids count from, where that is not the cell's first
+    /// node. One entry a cell a level, and nothing at all for the usual case.
+    begins: Option<Vec<Vec<u32>>>,
+    /// How wide each cell's table is, where that is not the number of nodes on
+    /// the cell's border. Held beside `begins` and for the same reason.
+    widths: Option<Vec<Vec<u32>>>,
 }
 
 /// What went wrong reading a cell.
@@ -220,7 +226,45 @@ impl BlockStore {
             blocks: File::open(blocks)?,
             map,
             tree,
+            begins: None,
+            widths: None,
         })
+    }
+
+    /// The same, for a store whose tables are named by something other than the
+    /// nodes of a cell.
+    ///
+    /// A block writes each border id as how far into the cell it sits, and what
+    /// it counts from is the cell's first node. An overlay whose tables name
+    /// arcs counts from the cell's first arc instead, and says so here, one
+    /// entry per cell per level.
+    ///
+    /// # Errors
+    ///
+    /// What opening the file said.
+    pub fn open_counting_from(
+        blocks: &Path,
+        map: BlockMap,
+        tree: CellTree,
+        begins: Vec<Vec<u32>>,
+        widths: Vec<Vec<u32>>,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            blocks: File::open(blocks)?,
+            map,
+            tree,
+            begins: Some(begins),
+            widths: Some(widths),
+        })
+    }
+
+    /// What a cell's ids count from.
+    #[must_use]
+    pub fn counting_from(&self, level: usize, cell: CellId) -> u32 {
+        self.begins.as_ref().map_or_else(
+            || self.tree.nodes_begin(level, cell),
+            |begins| begins[level][cell as usize],
+        )
     }
 
     #[must_use]
@@ -256,7 +300,7 @@ impl BlockStore {
         let which = (cell - entry.first_cell) as usize;
         block.unpack_into(which, &widths, table);
 
-        let begins = self.tree.nodes_begin(level, cell);
+        let begins = self.counting_from(level, cell);
         block.places_into(which, &widths, nodes);
         if nodes.is_empty() {
             // the border nodes lead the run, so the places are nought upward
@@ -296,7 +340,13 @@ impl BlockStore {
     #[must_use]
     pub fn widths_of(&self, entry: &BlockEntry, level: usize) -> Vec<usize> {
         (0..entry.cells)
-            .map(|at| self.tree.facts(level, entry.first_cell + at).on_border as usize)
+            .map(|at| {
+                let cell = entry.first_cell + at;
+                self.widths.as_ref().map_or_else(
+                    || self.tree.facts(level, cell).on_border as usize,
+                    |widths| widths[level][cell as usize] as usize,
+                )
+            })
             .collect()
     }
 

--- a/src/edge_based.rs
+++ b/src/edge_based.rs
@@ -1,0 +1,545 @@
+//! An edge-based graph worked out as it is walked, rather than held.
+//!
+//! # What it is
+//!
+//! A node-based graph says where a road goes. It cannot say what happens at
+//! the junction: a route that arrives at a crossing and leaves the way it came
+//! costs, in such a graph, nothing at all. Turning that into something a search
+//! can price means making each arc a node, and each turn between two arcs an
+//! arc. That is the edge-based graph.
+//!
+//! # Why it is not built
+//!
+//! A continent is eighteen million nodes and forty-two million arcs, and its
+//! turns number the sum over each node of its in-degree times its out-degree:
+//! about ninety-eight million. Written down that is a graph of forty-two
+//! million nodes and ninety-eight million arcs, more than twice the arcs of the
+//! one it came from, and better part of a gigabyte before a weight is stored.
+//!
+//! None of it has to be written down. [`StaticGraph`](crate::static_graph)
+//! already numbers its arcs densely from zero, so an arc *is* an edge-based
+//! node id with no table in between, and the turns leaving it are exactly the
+//! arcs leaving its head. A turn from `e` to `f` is named by `f` alone, since
+//! `f` says both which turn it is and where it lands. So the whole expansion is
+//! two questions the underlying graph already answers, and this module asks
+//! them one node at a time through [`Adjacency`].
+//!
+//! # What it costs to hold
+//!
+//! Nothing beyond the graph and the coordinates that were there already. An
+//! arc's head is written down and its tail is not, and a turn needs both, so
+//! the tail would have to be searched for among the offsets. It is not: an arc
+//! is reached by turning onto it at the head of the arc before it, so whatever
+//! a search was standing on last says the tail outright, and [`Adjacency`]
+//! hands that over. Over a continent that leaves two searches of the offsets a
+//! query, at the source, rather than one per node settled.
+
+use std::cell::Cell;
+
+use crate::{
+    geometry::FPCoordinate,
+    graph::{Adjacency, Arcs, EdgeID, NodeID},
+    heap_stats::HeapStats,
+    unidirectional_dijkstra::UnidirectionalSearch,
+};
+
+/// The two segments that meet at a turn, in a frame where both are flat.
+///
+/// The units are micro-degrees of latitude, with longitude scaled to match at
+/// the latitude the turn is at. Nothing here is a distance, and none of it is
+/// meant to be: only the angle between the two is asked about.
+pub struct Turn {
+    /// the segment arrived along, pointing the way the route was going
+    pub arriving: (f64, f64),
+    /// the segment about to be taken, pointing the way it would go
+    pub leaving: (f64, f64),
+    /// whether the turn goes back down the segment it arrived on
+    pub reversal: bool,
+}
+
+impl Turn {
+    /// Positive turning left of the way on, negative turning right.
+    #[must_use]
+    pub fn cross(&self) -> f64 {
+        self.arriving.0 * self.leaving.1 - self.arriving.1 * self.leaving.0
+    }
+
+    /// Positive carrying on the way it was going, negative doubling back.
+    #[must_use]
+    pub fn dot(&self) -> f64 {
+        self.arriving.0 * self.leaving.0 + self.arriving.1 * self.leaving.1
+    }
+
+    /// How far off carrying straight on the turn is, in degrees: zero straight
+    /// on, ninety a right angle, a hundred and eighty back the way it came.
+    /// Left of the way on is positive.
+    ///
+    /// Nothing a search runs over calls this, and nothing should: a cost that
+    /// wants to know how sharp a turn is can be written against
+    /// [`Self::cross`] and [`Self::dot`] and not pay for an `atan2` a turn.
+    /// [`AnglePenalty`] is the worked example.
+    #[must_use]
+    pub fn degrees(&self) -> f64 {
+        self.cross().atan2(self.dot()).to_degrees()
+    }
+}
+
+/// What a turn costs, in whatever unit the graph's own arcs are weighted in.
+pub trait TurnCost {
+    /// What the turn costs, or `None` when it may not be taken at all.
+    fn cost(&self, turn: &Turn) -> Option<u32>;
+}
+
+/// Every turn is allowed and none of them costs anything.
+///
+/// The edge-based graph under this answers every distance the node-based graph
+/// does, which is what makes it the thing to check an expansion against.
+pub struct FreeTurns;
+
+impl TurnCost for FreeTurns {
+    fn cost(&self, _turn: &Turn) -> Option<u32> {
+        Some(0)
+    }
+}
+
+/// Turning back down the arc just travelled is refused. Everything else is
+/// free.
+///
+/// This asks nothing of the coordinates and has no number in it to get wrong,
+/// which is the whole of its appeal: a reversal is a reversal because of what
+/// the graph says, not because of where anything lies.
+pub struct NoUTurns;
+
+impl TurnCost for NoUTurns {
+    fn cost(&self, turn: &Turn) -> Option<u32> {
+        if turn.reversal { None } else { Some(0) }
+    }
+}
+
+/// How finely the cost is written down against the cosine of the turn angle.
+///
+/// A thousand steps put about a fifth of a degree between two entries where the
+/// cost is still rising, and less than that towards a right angle. Where the
+/// cosine says least about the angle, near straight on, the cost is flat
+/// anyway.
+const COSINE_STEPS: usize = 1024;
+
+/// A reversal is refused, and everything else costs by how far off straight on
+/// it is.
+///
+/// Within `free_within` degrees of carrying on there is nothing to pay. From
+/// there the cost rises evenly with the angle, reaching `sharpest` at a right
+/// angle and staying there for anything sharper. Both numbers are in the unit
+/// the graph's arcs are weighted in, which this module has no way to know.
+///
+/// # How the angle is not worked out
+///
+/// A turn is priced by the cosine of its angle rather than by the angle. The
+/// cosine of the angle between two segments is their dot product over the
+/// product of their lengths, which is one square root, and the cost against it
+/// is written down once when this is built. Asking for the angle itself costs
+/// an `atan2` a turn instead, and a search over a continent looks at ninety
+/// eight million of them: measured, that was thirteen seconds of a twenty nine
+/// second run.
+pub struct AnglePenalty {
+    /// what a turn costs, by the cosine of how far off straight it is, from
+    /// turning back on itself at the start to carrying straight on at the end
+    by_cosine: Vec<u32>,
+}
+
+impl AnglePenalty {
+    #[must_use]
+    pub fn new(free_within: f64, sharpest: u32) -> Self {
+        let by_cosine = (0..COSINE_STEPS)
+            .map(|at| {
+                let cosine = 2.0 * at as f64 / (COSINE_STEPS - 1) as f64 - 1.0;
+                let off = cosine.clamp(-1.0, 1.0).acos().to_degrees();
+                if off <= free_within {
+                    return 0;
+                }
+                let span = 90.0 - free_within;
+                if span <= 0.0 {
+                    return sharpest;
+                }
+                let share = ((off - free_within) / span).min(1.0);
+                (share * f64::from(sharpest)) as u32
+            })
+            .collect();
+        Self { by_cosine }
+    }
+
+    /// What carrying straight on costs, which is what a turn with no angle to
+    /// speak of is charged.
+    fn straight_on(&self) -> u32 {
+        self.by_cosine[COSINE_STEPS - 1]
+    }
+}
+
+impl TurnCost for AnglePenalty {
+    fn cost(&self, turn: &Turn) -> Option<u32> {
+        if turn.reversal {
+            return None;
+        }
+        let lengths = (turn.arriving.0 * turn.arriving.0 + turn.arriving.1 * turn.arriving.1)
+            * (turn.leaving.0 * turn.leaving.0 + turn.leaving.1 * turn.leaving.1);
+        if lengths <= 0.0 {
+            // two nodes in the same place leave a segment with no direction,
+            // and nothing that has no direction has been turned away from
+            return Some(self.straight_on());
+        }
+        let cosine = (turn.dot() / lengths.sqrt()).clamp(-1.0, 1.0);
+        let at = ((cosine + 1.0) * 0.5 * (COSINE_STEPS - 1) as f64) as usize;
+        Some(self.by_cosine[at])
+    }
+}
+
+/// A graph whose nodes are the arcs of another, expanded as it is asked.
+///
+/// A node of this is an arc of `graph`, by the same id. It holds a reference to
+/// the graph and to the coordinates, a turn cost, and one node id worth of
+/// state to start the next tail search from.
+pub struct EdgeBasedGraph<'a, G, T> {
+    graph: &'a G,
+    coordinates: &'a [FPCoordinate],
+    turns: T,
+    /// where the last tail was found, so the next search starts near it
+    hint: Cell<NodeID>,
+    /// how many offsets the tail searches have read, and how many were asked
+    steps: Cell<usize>,
+    lookups: Cell<usize>,
+}
+
+impl<'a, G: Arcs<u32>, T: TurnCost> EdgeBasedGraph<'a, G, T> {
+    /// # Panics
+    ///
+    /// If the coordinates do not cover the graph's nodes.
+    #[must_use]
+    pub fn new(graph: &'a G, coordinates: &'a [FPCoordinate], turns: T) -> Self {
+        assert!(
+            coordinates.len() >= graph.number_of_nodes(),
+            "the coordinates do not cover the graph"
+        );
+        Self {
+            graph,
+            coordinates,
+            turns,
+            hint: Cell::new(0),
+            steps: Cell::new(0),
+            lookups: Cell::new(0),
+        }
+    }
+
+    /// How many offsets the tail searches have read, over how many tails were
+    /// asked for. Their ratio is what holding no array of tails costs.
+    #[must_use]
+    pub fn tail_steps(&self) -> (usize, usize) {
+        (self.steps.get(), self.lookups.get())
+    }
+
+    /// The node an arc runs into, which is where its turns are.
+    #[must_use]
+    pub fn head(&self, arc: EdgeID) -> NodeID {
+        self.graph.target(arc)
+    }
+
+    /// Whether a node's block of arcs holds this one.
+    fn owns(&self, node: NodeID, arc: EdgeID) -> bool {
+        let block = self.offsets(node);
+        block.start <= arc && arc < block.end
+    }
+
+    /// A node's block, counted so that the cost of finding a tail is known.
+    fn offsets(&self, node: NodeID) -> core::ops::Range<EdgeID> {
+        self.steps.set(self.steps.get() + 1);
+        self.graph.edge_range(node)
+    }
+
+    /// The node an arc runs out of.
+    ///
+    /// An adjacency array writes down where each node's arcs begin, so a head
+    /// is there to be read and a tail is not. Rather than keep a second array
+    /// of tails, which on a continent is a hundred and seventy megabytes on top
+    /// of a graph of five hundred, it is searched for among the offsets, which
+    /// are sorted because the blocks are laid out in order.
+    ///
+    /// The node the last lookup landed on is tried first, since a walk of one
+    /// node's turns asks about arcs that are all its own. Past that it is a
+    /// plain binary search of the whole array.
+    ///
+    /// Widening a bracket around the last answer was tried instead and was
+    /// worse: 42.6 offsets read per lookup against 24 for the search below.
+    /// A Dijkstra settles in order of distance and not in order of arc, so one
+    /// lookup says nothing about where the next will land, and the walk outward
+    /// is paid for before a binary search of a wider bracket than this one.
+    #[must_use]
+    pub fn tail(&self, arc: EdgeID) -> NodeID {
+        self.lookups.set(self.lookups.get() + 1);
+        let last = self.graph.number_of_nodes() - 1;
+        let hint = self.hint.get().min(last);
+        if self.owns(hint, arc) {
+            return hint;
+        }
+
+        // the answer is the last node whose block starts at or before the arc
+        let (mut low, mut high) = (0, last);
+        while low < high {
+            let middle = low + (high - low).div_ceil(2);
+            if self.offsets(middle).start <= arc {
+                low = middle;
+            } else {
+                high = middle - 1;
+            }
+        }
+        self.hint.set(low);
+        low
+    }
+
+    /// Every arc leaving a node, as the edge-based node it is and what it cost
+    /// to have taken it.
+    ///
+    /// This is where a search that names its ends by node rather than by arc
+    /// starts from.
+    pub fn for_each_departure(&self, node: NodeID, mut f: impl FnMut(EdgeID, usize)) {
+        for arc in self.graph.edge_range(node) {
+            f(arc, self.graph.weight(arc) as usize);
+        }
+    }
+
+    /// The turns leaving an arc, as the arc each lands on and what it costs to
+    /// get there, the arc's own weight included.
+    ///
+    /// A turn that the cost refuses is not offered at all.
+    pub fn for_each_turn(&self, arc: EdgeID, f: impl FnMut(EdgeID, u32)) {
+        self.turns_from(arc, self.tail(arc), f);
+    }
+
+    /// The same, told which node the arc runs out of rather than looking.
+    fn turns_from(&self, arc: EdgeID, from: NodeID, mut f: impl FnMut(EdgeID, u32)) {
+        let via = self.head(arc);
+        // one unit of longitude is this much of a unit of latitude, here
+        let squeeze = f64::from(self.coordinates[via].lat)
+            .mul_add(1e-6_f64.to_radians(), 0.0)
+            .cos();
+        let arriving = self.vector(from, via, squeeze);
+
+        // Asked arc at a time rather than through `for_each_arc`, which hands
+        // over where an arc goes and not which arc it is. Which arc it is, is
+        // the whole of the answer here: it is the node being turned onto.
+        for onto in self.graph.edge_range(via) {
+            let to = self.graph.target(onto);
+            let turn = Turn {
+                arriving,
+                leaving: self.vector(via, to, squeeze),
+                reversal: to == from,
+            };
+            if let Some(cost) = self.turns.cost(&turn) {
+                f(onto, self.graph.weight(onto) + cost);
+            }
+        }
+    }
+
+    /// The step from one node to another, with longitude squeezed so that the
+    /// two axes are the same size on the ground.
+    fn vector(&self, from: NodeID, to: NodeID, squeeze: f64) -> (f64, f64) {
+        let (from, to) = (&self.coordinates[from], &self.coordinates[to]);
+        (
+            f64::from(to.lon - from.lon) * squeeze,
+            f64::from(to.lat - from.lat),
+        )
+    }
+}
+
+impl<G: Arcs<u32>, T: TurnCost> Adjacency<u32> for EdgeBasedGraph<'_, G, T> {
+    /// A node here is an arc there.
+    fn number_of_nodes(&self) -> usize {
+        self.graph.number_of_edges()
+    }
+
+    /// The node `n` runs out of is the node `from` runs into, so being told
+    /// what this arc was reached from is being told its tail. Where the search
+    /// began there is nothing to be told, and it is looked for instead.
+    fn for_each_arc(&self, n: NodeID, from: NodeID, f: impl FnMut(NodeID, u32)) {
+        let tail = if from == n {
+            self.tail(n)
+        } else {
+            self.graph.target(from)
+        };
+        self.turns_from(n, tail, f);
+    }
+}
+
+/// A search between two nodes of the underlying graph.
+///
+/// An edge-based node is an arc, so standing at a node means standing on any
+/// of the arcs leaving it, and arriving at one means arriving on any of the
+/// arcs running into it. Each source starts at what its arc costs, so the
+/// answer is the cost of the whole route, first arc included.
+///
+/// [`UnidirectionalSearch::run`] takes the arc form instead: it starts at the
+/// head of the arc it is given, having already paid for it, and stops on the
+/// arc it is asked for.
+pub fn between_nodes<S: HeapStats<NodeID>, G: Arcs<u32>, T: TurnCost>(
+    search: &mut UnidirectionalSearch<S>,
+    graph: &EdgeBasedGraph<G, T>,
+    source: NodeID,
+    target: NodeID,
+) -> usize {
+    let mut departures = Vec::new();
+    graph.for_each_departure(source, |arc, cost| departures.push((arc, cost)));
+    search.run_many(graph, &departures, |arc| graph.head(arc) == target)
+}
+
+/// The nodes a route of arcs runs through.
+///
+/// A search here leaves a path of arcs. The nodes are where the first one
+/// starts and where each of them ends, so a route of `n` arcs is `n + 1`
+/// nodes. An empty route is no nodes at all, since standing still is not
+/// somewhere.
+pub fn node_path<G: Arcs<u32>, T: TurnCost>(
+    graph: &EdgeBasedGraph<G, T>,
+    arcs: &[EdgeID],
+) -> Vec<NodeID> {
+    let Some(&first) = arcs.first() else {
+        return Vec::new();
+    };
+    let mut path = Vec::with_capacity(arcs.len() + 1);
+    path.push(graph.tail(first));
+    path.extend(arcs.iter().map(|&arc| graph.head(arc)));
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AnglePenalty, EdgeBasedGraph, FreeTurns, NoUTurns, between_nodes, node_path};
+    use crate::{
+        edge::InputEdge,
+        geometry::FPCoordinate,
+        graph::{Arcs, NodeID},
+        static_graph::StaticGraph,
+        unidirectional_dijkstra::UnidirectionalDijkstra,
+    };
+
+    /// A plus sign: a middle node with four spokes, every arc both ways.
+    ///
+    ///        3
+    ///        |
+    ///   1 -- 0 -- 2
+    ///        |
+    ///        4
+    fn plus() -> (StaticGraph<u32>, Vec<FPCoordinate>) {
+        let mut edges = Vec::new();
+        for spoke in 1..5 {
+            edges.push(InputEdge::new(0, spoke, 10));
+            edges.push(InputEdge::new(spoke, 0, 10));
+        }
+        let coordinates = vec![
+            FPCoordinate::new(0, 0),
+            FPCoordinate::new(0, -1000),
+            FPCoordinate::new(0, 1000),
+            FPCoordinate::new(1000, 0),
+            FPCoordinate::new(-1000, 0),
+        ];
+        (StaticGraph::new(edges), coordinates)
+    }
+
+    #[test]
+    fn every_arc_knows_the_node_it_runs_out_of() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, FreeTurns);
+
+        for node in graph.node_range() {
+            for arc in graph.edge_range(node) {
+                assert_eq!(expanded.tail(arc), node, "arc {arc} of node {node}");
+            }
+        }
+    }
+
+    /// The hint is carried from one lookup to the next, so the order they are
+    /// asked in must not change any answer.
+    #[test]
+    fn a_tail_is_the_same_whatever_was_asked_before() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, FreeTurns);
+
+        let forwards: Vec<NodeID> = (0..graph.number_of_edges())
+            .map(|arc| expanded.tail(arc))
+            .collect();
+        let backwards: Vec<NodeID> = (0..graph.number_of_edges())
+            .rev()
+            .map(|arc| expanded.tail(arc))
+            .collect();
+
+        assert_eq!(forwards, backwards.into_iter().rev().collect::<Vec<_>>());
+    }
+
+    /// Free turns cost nothing and forbid nothing, so the expansion must
+    /// answer every distance the graph it came from answers.
+    #[test]
+    fn free_turns_answer_what_the_node_based_graph_answers() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, FreeTurns);
+        let mut plain = UnidirectionalDijkstra::new();
+        let mut turning = UnidirectionalDijkstra::new();
+
+        for source in graph.node_range() {
+            for target in graph.node_range() {
+                if source == target {
+                    continue;
+                }
+                let expected = plain.run(&graph, source, target);
+                let found = between_nodes(&mut turning, &expanded, source, target);
+                assert_eq!(found, expected, "from {source} to {target}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_route_of_arcs_reads_back_as_the_nodes_it_runs_through() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, FreeTurns);
+        let mut search = UnidirectionalDijkstra::new();
+
+        assert_eq!(between_nodes(&mut search, &expanded, 1, 2), 20);
+        let arcs = search
+            .retrieve_node_path(search.met())
+            .expect("the target was reached");
+        assert_eq!(node_path(&expanded, &arcs), vec![1, 0, 2]);
+    }
+
+    #[test]
+    fn a_route_of_no_arcs_runs_through_nowhere() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, FreeTurns);
+        assert!(node_path(&expanded, &[]).is_empty());
+    }
+
+    /// A spoke can only be left by going back through the middle, so refusing
+    /// reversals leaves no way out of one at all.
+    #[test]
+    fn refusing_reversals_shuts_a_dead_end_in() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, NoUTurns);
+        let mut search = UnidirectionalDijkstra::new();
+
+        assert_eq!(between_nodes(&mut search, &expanded, 1, 2), 20);
+        // 1 to 0 and back to 1 is the only route, and it is a reversal
+        assert_eq!(
+            between_nodes(&mut search, &expanded, 1, 1),
+            usize::MAX,
+            "a reversal was taken"
+        );
+    }
+
+    /// Going straight across the plus is free; turning a corner is not.
+    #[test]
+    fn a_corner_costs_what_carrying_straight_on_does_not() {
+        let (graph, coordinates) = plus();
+        let expanded = EdgeBasedGraph::new(&graph, &coordinates, AnglePenalty::new(10., 100));
+        let mut search = UnidirectionalDijkstra::new();
+
+        // west to east is a straight line through the middle
+        assert_eq!(between_nodes(&mut search, &expanded, 1, 2), 20);
+        // west to north is a right angle, and pays the whole penalty
+        assert_eq!(between_nodes(&mut search, &expanded, 1, 3), 120);
+    }
+}

--- a/src/edge_based.rs
+++ b/src/edge_based.rs
@@ -94,7 +94,14 @@ pub trait TurnCost {
 ///
 /// The edge-based graph under this answers every distance the node-based graph
 /// does, which is what makes it the thing to check an expansion against.
+#[derive(Clone)]
 pub struct FreeTurns;
+
+impl<T: TurnCost + ?Sized> TurnCost for &T {
+    fn cost(&self, turn: &Turn) -> Option<u32> {
+        (**self).cost(turn)
+    }
+}
 
 impl TurnCost for FreeTurns {
     fn cost(&self, _turn: &Turn) -> Option<u32> {
@@ -108,6 +115,7 @@ impl TurnCost for FreeTurns {
 /// This asks nothing of the coordinates and has no number in it to get wrong,
 /// which is the whole of its appeal: a reversal is a reversal because of what
 /// the graph says, not because of where anything lies.
+#[derive(Clone)]
 pub struct NoUTurns;
 
 impl TurnCost for NoUTurns {
@@ -141,6 +149,7 @@ const COSINE_STEPS: usize = 1024;
 /// an `atan2` a turn instead, and a search over a continent looks at ninety
 /// eight million of them: measured, that was thirteen seconds of a twenty nine
 /// second run.
+#[derive(Clone)]
 pub struct AnglePenalty {
     /// what a turn costs, by the cosine of how far off straight it is, from
     /// turning back on itself at the start to carrying straight on at the end
@@ -148,8 +157,19 @@ pub struct AnglePenalty {
 }
 
 impl AnglePenalty {
+    /// # Panics
+    ///
+    /// If `free_within` is not a number of degrees between nothing and a right
+    /// angle. Outside that the ramp this describes has no meaning: at ninety
+    /// there is nothing left for the cost to rise across, and a value that is
+    /// not a number compares false against everything and would quietly charge
+    /// the whole of `sharpest` for every turn.
     #[must_use]
     pub fn new(free_within: f64, sharpest: u32) -> Self {
+        assert!(
+            free_within.is_finite() && (0.0..90.0).contains(&free_within),
+            "a turn is free within {free_within} degrees, which is not an angle to be free within"
+        );
         let by_cosine = (0..COSINE_STEPS)
             .map(|at| {
                 let cosine = 2.0 * at as f64 / (COSINE_STEPS - 1) as f64 - 1.0;
@@ -311,6 +331,33 @@ impl<'a, G: Arcs<u32>, T: TurnCost> EdgeBasedGraph<'a, G, T> {
     /// A turn that the cost refuses is not offered at all.
     pub fn for_each_turn(&self, arc: EdgeID, f: impl FnMut(EdgeID, u32)) {
         self.turns_from(arc, self.tail(arc), f);
+    }
+
+    /// The turns leaving an arc, as the arc each lands on and what the turn
+    /// itself costs, with no arc's weight in it.
+    ///
+    /// [`Self::for_each_turn`] charges the arc being turned onto, which makes a
+    /// distance the cost of reaching that arc's head. A caller that means a
+    /// node to stand for the tail of its arc charges the arc being left
+    /// instead, and this hands over the part they share.
+    pub fn for_each_turn_cost(&self, arc: EdgeID, from: NodeID, mut f: impl FnMut(EdgeID, u32)) {
+        let via = self.head(arc);
+        let squeeze = f64::from(self.coordinates[via].lat)
+            .mul_add(1e-6_f64.to_radians(), 0.0)
+            .cos();
+        let arriving = self.vector(from, via, squeeze);
+
+        for onto in self.graph.edge_range(via) {
+            let to = self.graph.target(onto);
+            let turn = Turn {
+                arriving,
+                leaving: self.vector(via, to, squeeze),
+                reversal: to == from,
+            };
+            if let Some(cost) = self.turns.cost(&turn) {
+                f(onto, cost);
+            }
+        }
     }
 
     /// The same, told which node the arc runs out of rather than looking.
@@ -531,6 +578,18 @@ mod tests {
     }
 
     /// Going straight across the plus is free; turning a corner is not.
+    #[test]
+    #[should_panic(expected = "not an angle to be free within")]
+    fn a_turn_cannot_be_free_within_a_right_angle() {
+        let _ = AnglePenalty::new(90., 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "not an angle to be free within")]
+    fn a_turn_cannot_be_free_within_something_that_is_not_a_number() {
+        let _ = AnglePenalty::new(f64::NAN, 100);
+    }
+
     #[test]
     fn a_corner_costs_what_carrying_straight_on_does_not() {
         let (graph, coordinates) = plus();

--- a/src/edge_based_overlay.rs
+++ b/src/edge_based_overlay.rs
@@ -1,0 +1,832 @@
+//! Cells whose nodes are the arcs of a graph, worked out as they are asked
+//! for.
+//!
+//! # What a cell holds
+//!
+//! An edge-based node is an arc, and the cell it lies in is the cell of the
+//! node that arc runs *out of*. That choice is what makes a store of blocks
+//! possible: a block names a border node by how far into the cell it sits, so
+//! every id a table holds has to lie inside the cell, and a graph numbered so
+//! that a cell's nodes run consecutively has that cell's arcs running
+//! consecutively too. Keyed on the head instead, the ways out of a cell would
+//! sit in the neighbouring one and no offset would name them.
+//!
+//! So a node of this overlay is "standing at the tail of this arc, about to
+//! travel it", and what it cost to get there is the cost of everything before
+//! it. A step across a cell runs from one such arc to another, and the arcs on
+//! the border are the ones leaving a node that the cell's boundary touches.
+//!
+//! # Why the whole of it is not built
+//!
+//! [`crate::edge_based`] expands the graph as a search walks it. This holds
+//! what a search over cells cannot work out on the fly: what it costs to cross
+//! a cell. Those are tabulated once per cell, the first time a search asks.
+
+use std::sync::OnceLock;
+
+use log::debug;
+use rustc_hash::FxHashMap;
+
+use crate::{
+    border_levels::BorderLevels,
+    edge::InputEdge,
+    edge_based::{EdgeBasedGraph, TurnCost},
+    geometry::FPCoordinate,
+    graph::{Adjacency, EdgeID, Graph, NodeID},
+    level_directory::{CellId, LevelDirectory},
+    one_to_many_dijkstra::OneToManyDijkstra,
+    overlay::{CellTable, Overlay},
+    packed_partition::PackedPartition,
+    paged_overlay::PagedOverlay,
+    static_graph::StaticGraph,
+};
+
+/// What it costs to cross a cell, from each way in to each way out.
+///
+/// # Why this is not square
+///
+/// The node-based table is: a cell's border nodes are both the ways in and the
+/// ways out, so one list serves as rows and as columns. Arcs are not so
+/// obliging. A route that has just entered a cell is standing on an arc leaving
+/// the node it came in at, and there are as many of those as that node has
+/// arcs; a route leaving the cell is on an arc that crosses the boundary, and
+/// there is one of those per crossing. Measured over europe.ptv the first
+/// outnumbers the second by 2.7 to one, so a square table of the wider set
+/// holds three times the entries it needs.
+pub struct ArcTable {
+    /// the arcs a route may be standing on having just entered the cell
+    rows: Vec<u32>,
+    /// the arcs that cross out of the cell, which is what a step across it
+    /// lands on
+    columns: Vec<u32>,
+    matrix: Vec<u32>,
+    place_of: FxHashMap<NodeID, usize>,
+}
+
+impl ArcTable {
+    fn of(rows: Vec<u32>, columns: Vec<u32>, matrix: Vec<u32>) -> Self {
+        debug_assert_eq!(matrix.len(), rows.len() * columns.len(), "a table of rows");
+        let place_of = rows
+            .iter()
+            .enumerate()
+            .map(|(at, &arc)| (arc as NodeID, at))
+            .collect();
+        Self {
+            rows,
+            columns,
+            matrix,
+            place_of,
+        }
+    }
+}
+
+impl ArcTable {
+    /// How many numbers the table holds.
+    #[must_use]
+    pub fn entries(&self) -> usize {
+        self.matrix.len()
+    }
+}
+
+impl CellTable for &ArcTable {
+    /// The arcs a step across the cell lands on, which are its ways out.
+    fn border_nodes(&self) -> &[u32] {
+        &self.columns
+    }
+
+    fn row(&self, source: usize) -> &[u32] {
+        let wide = self.columns.len();
+        &self.matrix[source * wide..(source + 1) * wide]
+    }
+
+    /// Not held, and not wanted by any search that runs over this.
+    ///
+    /// A column is what a search running backwards through a cell reads, and
+    /// this table is not square: its rows and its columns name different arcs,
+    /// so the transpose is a different table rather than the same one read the
+    /// other way. Nothing has needed it, so nothing has been built.
+    fn column(&self, _target: usize) -> &[u32] {
+        unimplemented!("an edge-based cell table holds no columns")
+    }
+
+    /// Where an arc sits among the ways in.
+    fn place_of(&self, node: NodeID) -> Option<usize> {
+        self.place_of.get(&node).copied()
+    }
+}
+
+/// An overlay over the arcs of a graph rather than its nodes.
+pub struct EdgeBasedOverlay<T: TurnCost> {
+    graph: StaticGraph<u32>,
+    coordinates: Vec<FPCoordinate>,
+    turns: T,
+    partition: PackedPartition,
+    borders: BorderLevels,
+    /// the node each arc runs out of, which every cell lookup asks for
+    ///
+    /// [`crate::edge_based`] works this out from the arc a search was standing
+    /// on last. An overlay is asked which cells an arc lies in without being
+    /// told how it was reached, so here it is written down: four bytes an arc,
+    /// against tables that are already the larger part of what this holds.
+    tail: Vec<u32>,
+    /// where each cell's nodes begin, per level, the numbering being one where
+    /// a cell's nodes run consecutively
+    begins: Vec<Vec<u32>>,
+    /// whether each node has the boundary of its cell running through it
+    on_border: Vec<Vec<bool>>,
+    /// whether each node is one an arc reaches from outside its cell, which is
+    /// where a route entering the cell finds itself
+    entered: Vec<Vec<bool>>,
+    /// the cells of the level below that each cell is built out of, empty for
+    /// the finest level, which is built out of the road network itself
+    children: Vec<Vec<Vec<CellId>>>,
+    tabulated: Vec<Vec<OnceLock<Option<Box<ArcTable>>>>>,
+}
+
+impl<T: TurnCost> EdgeBasedOverlay<T> {
+    /// # Panics
+    ///
+    /// If the coordinates are not the graph's, or if the numbering is not one
+    /// where each cell's nodes run consecutively. A cell's arcs are named by
+    /// how far into the cell they sit, which is an answer only then.
+    #[must_use]
+    pub fn new(
+        graph: StaticGraph<u32>,
+        coordinates: Vec<FPCoordinate>,
+        turns: T,
+        directory: &LevelDirectory,
+    ) -> Self {
+        assert_eq!(
+            coordinates.len(),
+            Graph::number_of_nodes(&graph),
+            "another set of coordinates"
+        );
+        let partition = PackedPartition::of(directory);
+        let borders = BorderLevels::of(&graph, &partition);
+
+        let mut tail = vec![0_u32; graph.number_of_edges()];
+        for node in graph.node_range() {
+            for arc in graph.edge_range(node) {
+                tail[arc] = u32::try_from(node).expect("the graph is too large");
+            }
+        }
+
+        let levels = directory.levels();
+        let mut begins = Vec::with_capacity(levels);
+        let mut on_border = Vec::with_capacity(levels);
+        let mut entered = Vec::with_capacity(levels);
+        for level in 0..levels {
+            let cells = directory.cells_on_level(level);
+            let mut at = vec![u32::MAX; cells + 1];
+            let mut last = usize::MAX;
+            for node in graph.node_range() {
+                let cell = partition.cell_of(node, level) as usize;
+                if cell == last {
+                    continue;
+                }
+                assert!(
+                    at[cell] == u32::MAX,
+                    "the nodes of cell {cell} on level {level} do not run consecutively"
+                );
+                at[cell] = u32::try_from(node).expect("the graph is too large");
+                last = cell;
+            }
+            // a cell nothing lies in begins where the next one does
+            at[cells] =
+                u32::try_from(Graph::number_of_nodes(&graph)).expect("the graph is too large");
+            for cell in (0..cells).rev() {
+                if at[cell] == u32::MAX {
+                    at[cell] = at[cell + 1];
+                }
+            }
+
+            // An arc across the boundary puts both of its ends on it: a node an
+            // arc only reaches from outside is a way in, and a path across the
+            // cell above may come by it.
+            let mut touched = vec![false; Graph::number_of_nodes(&graph)];
+            let mut reached = vec![false; Graph::number_of_nodes(&graph)];
+            for node in graph.node_range() {
+                for arc in graph.edge_range(node) {
+                    if borders.leaves_cell(arc, level) {
+                        touched[node] = true;
+                        touched[graph.target(arc)] = true;
+                        // the arc runs into the cell on the other side, so its
+                        // head is where a route entering there stands
+                        reached[graph.target(arc)] = true;
+                    }
+                }
+            }
+            begins.push(at);
+            on_border.push(touched);
+            entered.push(reached);
+        }
+
+        let mut children: Vec<Vec<Vec<CellId>>> = vec![Vec::new()];
+        for level in 1..levels {
+            let mut held = vec![Vec::new(); directory.cells_on_level(level)];
+            for (child, &parent) in directory.parents_on_level(level - 1).iter().enumerate() {
+                held[parent as usize]
+                    .push(CellId::try_from(child).expect("more cells than a cell id counts"));
+            }
+            children.push(held);
+        }
+
+        let tabulated = (0..levels)
+            .map(|level| {
+                (0..directory.cells_on_level(level))
+                    .map(|_| OnceLock::new())
+                    .collect()
+            })
+            .collect();
+
+        Self {
+            graph,
+            coordinates,
+            turns,
+            partition,
+            borders,
+            tail,
+            begins,
+            on_border,
+            entered,
+            children,
+            tabulated,
+        }
+    }
+
+    /// The node an arc runs out of.
+    #[must_use]
+    pub fn tail(&self, arc: EdgeID) -> NodeID {
+        self.tail[arc] as NodeID
+    }
+
+    /// What the arcs of a cell count from, per level and cell.
+    ///
+    /// A cell's nodes run consecutively and its arcs are grouped by the node
+    /// they run out of, so its arcs run consecutively too. That is what lets a
+    /// table of arcs be written into a block, whose ids are offsets.
+    #[must_use]
+    pub fn arcs_begin(&self) -> Vec<Vec<u32>> {
+        (0..self.begins.len())
+            .map(|level| {
+                (0..self.cells_on_level(level))
+                    .map(|cell| {
+                        let nodes = self.nodes_of(level, cell as CellId);
+                        u32::try_from(self.graph.edge_range(nodes.start).start)
+                            .expect("the graph is too large")
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// How wide each cell's table is, per level and cell, which a store has no
+    /// other way of knowing: it reads a width off the tree, and the tree counts
+    /// the nodes on a cell's border rather than the arcs.
+    ///
+    /// # Panics
+    ///
+    /// If a cell has not been tabulated yet, since a width nobody has worked
+    /// out is not a width.
+    #[must_use]
+    pub fn border_widths(&self) -> Vec<Vec<u32>> {
+        (0..self.begins.len())
+            .map(|level| {
+                (0..self.cells_on_level(level))
+                    .map(|cell| {
+                        self.distances_of(level, cell as CellId).map_or(0, |table| {
+                            u32::try_from(table.columns.len()).expect("a cell wider than a u32")
+                        })
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// How many arcs each cell holds, per level and cell, which is what a place
+    /// written into a block needs room for.
+    #[must_use]
+    pub fn arcs_held(&self) -> Vec<Vec<usize>> {
+        (0..self.begins.len())
+            .map(|level| {
+                (0..self.cells_on_level(level))
+                    .map(|cell| {
+                        let nodes = self.nodes_of(level, cell as CellId);
+                        if nodes.is_empty() {
+                            return 0;
+                        }
+                        self.graph.edge_range(nodes.end - 1).end
+                            - self.graph.edge_range(nodes.start).start
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The nodes of a cell, which run consecutively.
+    fn nodes_of(&self, level: usize, cell: CellId) -> std::ops::Range<NodeID> {
+        let at = &self.begins[level];
+        at[cell as usize] as NodeID..at[cell as usize + 1] as NodeID
+    }
+
+    /// The ways into a cell and the ways out of it.
+    ///
+    /// A route that has just entered is standing on an arc leaving the node it
+    /// came in at, so the ways in are every arc of every node an arc reaches
+    /// from outside. A route leaving is on an arc that crosses the boundary, so
+    /// the ways out are those and no more. The second set is the smaller by
+    /// nearly three to one, which is why they are counted apart.
+    fn ways_in_and_out(&self, level: usize, cell: CellId) -> (Vec<u32>, Vec<u32>) {
+        let inside = self.nodes_of(level, cell);
+        let (mut rows, mut columns) = (Vec::new(), Vec::new());
+        for node in inside.clone() {
+            if self.on_border[level][node] {
+                for arc in self.graph.edge_range(node) {
+                    if !inside.contains(&self.graph.target(arc)) {
+                        columns.push(u32::try_from(arc).expect("the graph is too large"));
+                    }
+                }
+            }
+            if self.entered[level][node] {
+                for arc in self.graph.edge_range(node) {
+                    rows.push(u32::try_from(arc).expect("the graph is too large"));
+                }
+            }
+        }
+        (rows, columns)
+    }
+
+    /// The turns inside a cell, as a graph over the arcs of it.
+    ///
+    /// The ways out lead the numbering, so that a search run as far as them
+    /// answers a whole row of the table. An arc is a node here, and a turn from
+    /// one to the next costs what travelling the first costs plus what the turn
+    /// does, so that what a row says is the cost of reaching the tail of the
+    /// arc it names.
+    fn turn_graph(&self, level: usize, cell: CellId, numbering: &[u32]) -> StaticGraph<u32> {
+        let mut of_arc: FxHashMap<EdgeID, NodeID> = FxHashMap::default();
+        for &arc in numbering {
+            let next = of_arc.len();
+            of_arc.insert(arc as EdgeID, next);
+        }
+        let inside = self.nodes_of(level, cell);
+        let expanded = EdgeBasedGraph::new(&self.graph, &self.coordinates, &self.turns);
+
+        let mut edges = Vec::new();
+        for node in inside.clone() {
+            for arc in self.graph.edge_range(node) {
+                let head = self.graph.target(arc);
+                if !inside.contains(&head) {
+                    // the arc leaves the cell, so nothing it turns onto is in
+                    continue;
+                }
+                let travelled = *self.graph.data(arc);
+                expanded.for_each_turn_cost(arc, node, |onto, turn| {
+                    let next = of_arc.len();
+                    let source = *of_arc.entry(arc).or_insert(next);
+                    let next = of_arc.len();
+                    let target = *of_arc.entry(onto).or_insert(next);
+                    edges.push(InputEdge::new(source, target, travelled + turn));
+                });
+            }
+        }
+        let nodes = of_arc.len().max(numbering.len());
+        edges.sort_unstable();
+        StaticGraph::from_sorted_slice(nodes, &edges)
+    }
+
+    /// The turns inside a cell, as a graph over the border arcs of the cells it
+    /// is built out of.
+    ///
+    /// A coarse cell holds too much of the graph to search arc by arc. What a
+    /// route does inside a cell below is already tabulated, and what it does
+    /// between two of them is a turn of the road network, so those are what is
+    /// searched instead.
+    fn turn_graph_of_children(
+        &self,
+        level: usize,
+        cell: CellId,
+        border: &[u32],
+    ) -> StaticGraph<u32> {
+        let mut of_arc: FxHashMap<EdgeID, NodeID> = FxHashMap::default();
+        for &arc in border {
+            let next = of_arc.len();
+            of_arc.insert(arc as EdgeID, next);
+        }
+        let expanded = EdgeBasedGraph::new(&self.graph, &self.coordinates, &self.turns);
+        let mut edges = Vec::new();
+
+        for &child in &self.children[level][cell as usize] {
+            let Some(across) = self.distances_of(level - 1, child) else {
+                // a cell below with no border cannot be entered or left, so no
+                // route of this cell runs through it
+                continue;
+            };
+
+            // what a route does inside the cell below, which is tabulated
+            let wide = across.columns.len();
+            for (source, &from) in across.rows.iter().enumerate() {
+                for (target, &to) in across.columns.iter().enumerate() {
+                    let weight = across.matrix[source * wide + target];
+                    if from == to || weight == u32::MAX {
+                        continue;
+                    }
+                    let next = of_arc.len();
+                    let from = *of_arc.entry(from as EdgeID).or_insert(next);
+                    let next = of_arc.len();
+                    let to = *of_arc.entry(to as EdgeID).or_insert(next);
+                    edges.push(InputEdge::new(from, to, weight));
+                }
+            }
+
+            // and what it does crossing from one cell below into another one of
+            // this cell, which is a turn of the road network
+            for &arc in &across.columns {
+                let arc = arc as EdgeID;
+                let head = self.graph.target(arc);
+                if self.partition.cell_of(head, level) != cell
+                    || self.partition.cell_of(head, level - 1) == child
+                {
+                    continue;
+                }
+                let travelled = *self.graph.data(arc);
+                expanded.for_each_turn_cost(arc, self.tail(arc), |onto, turn| {
+                    let next = of_arc.len();
+                    let from = *of_arc.entry(arc).or_insert(next);
+                    let next = of_arc.len();
+                    let to = *of_arc.entry(onto).or_insert(next);
+                    edges.push(InputEdge::new(from, to, travelled + turn));
+                });
+            }
+        }
+
+        let nodes = of_arc.len().max(border.len());
+        edges.sort_unstable();
+        StaticGraph::from_sorted_slice(nodes, &edges)
+    }
+
+    /// What it costs to cross a cell, worked out the first time it is asked
+    /// for.
+    fn tabulate(&self, level: usize, cell: CellId) -> Option<ArcTable> {
+        let (rows, columns) = self.ways_in_and_out(level, cell);
+        if rows.is_empty() || columns.is_empty() {
+            debug!("cell {cell} of level {level} has no way in or none out");
+            return None;
+        }
+
+        // the ways out lead, so that a search as far as them is a whole row
+        let mut numbering = columns.clone();
+        numbering.extend(rows.iter().filter(|arc| !columns.contains(arc)));
+        let turns = if level == 0 {
+            self.turn_graph(level, cell, &numbering)
+        } else {
+            self.turn_graph_of_children(level, cell, &numbering)
+        };
+        let of_arc: FxHashMap<u32, usize> = numbering
+            .iter()
+            .enumerate()
+            .map(|(at, &arc)| (arc, at))
+            .collect();
+
+        let wide = columns.len();
+        let mut matrix = vec![u32::MAX; rows.len() * wide];
+        let mut search = OneToManyDijkstra::new();
+        for (source, arc) in rows.iter().enumerate() {
+            let from = of_arc[arc];
+            search.run_to_leading(&turns, from, wide);
+            for (target, across) in matrix[source * wide..(source + 1) * wide]
+                .iter_mut()
+                .enumerate()
+            {
+                *across = u32::try_from(search.distance(target)).unwrap_or(u32::MAX);
+            }
+        }
+        Some(ArcTable::of(rows, columns, matrix))
+    }
+}
+
+/// The same arcs a search over the cells walks near its ends, so that a plain
+/// search and one over the cells can be held against each other over exactly
+/// the same graph, the same turns and the same prices.
+impl<T: TurnCost> Adjacency<u32> for EdgeBasedOverlay<T> {
+    fn number_of_nodes(&self) -> usize {
+        self.graph.number_of_edges()
+    }
+
+    fn for_each_arc(&self, n: NodeID, from: NodeID, f: impl FnMut(NodeID, u32)) {
+        Overlay::for_each_arc(self, n, from, f);
+    }
+}
+
+impl<T: TurnCost> Overlay for EdgeBasedOverlay<T> {
+    type Graph = StaticGraph<u32>;
+    type Table<'a>
+        = &'a ArcTable
+    where
+        Self: 'a;
+    type Borders = BorderLevels;
+
+    fn graph(&self) -> &Self::Graph {
+        &self.graph
+    }
+
+    fn partition(&self) -> &PackedPartition {
+        &self.partition
+    }
+
+    fn borders(&self) -> &Self::Borders {
+        &self.borders
+    }
+
+    fn levels(&self) -> usize {
+        self.begins.len()
+    }
+
+    fn cells_on_level(&self, level: usize) -> usize {
+        self.begins[level].len() - 1
+    }
+
+    /// An arc lies in the cells of the node it runs out of.
+    fn word_of(&self, node: NodeID) -> u128 {
+        self.partition.word(self.tail(node))
+    }
+
+    /// The turns out of an arc, each costing what travelling the arc costs and
+    /// what the turn itself does.
+    fn for_each_arc(&self, node: NodeID, from: NodeID, mut f: impl FnMut(NodeID, u32)) {
+        let _ = from;
+        let travelled = *self.graph.data(node);
+        let expanded = EdgeBasedGraph::new(&self.graph, &self.coordinates, &self.turns);
+        expanded.for_each_turn_cost(node, self.tail(node), |onto, turn| {
+            f(onto, travelled + turn);
+        });
+    }
+
+    /// Whether the turns out of an arc leave its cell is a fact about the arc
+    /// and not about the turn: every turn out of it starts where it ends, so
+    /// either all of them leave or none of them do.
+    fn for_each_arc_out_of_cell(
+        &self,
+        node: NodeID,
+        from: NodeID,
+        level: usize,
+        f: impl FnMut(NodeID, u32),
+    ) {
+        if self.borders.leaves_cell(node, level) {
+            Overlay::for_each_arc(self, node, from, f);
+        }
+    }
+
+    fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>> {
+        let slot = self.tabulated.get(level)?.get(cell as usize)?;
+        if let Some(held) = slot.get() {
+            return held.as_deref();
+        }
+        let _ = slot.set(self.tabulate(level, cell).map(Box::new));
+        slot.get().and_then(Option::as_deref)
+    }
+}
+
+/// The same cells, read off a file rather than held.
+///
+/// The turns are worked out as a search walks them, exactly as they are held in
+/// memory. What differs is only where the tables come from: a
+/// [`PagedOverlay`](crate::paged_overlay::PagedOverlay) reads and decompresses
+/// a block when one is asked for, and throws a table away when the room is
+/// wanted. Everything about the arcs is answered here.
+pub struct PagedEdgeBasedOverlay<T: TurnCost> {
+    tables: PagedOverlay<StaticGraph<u32>, BorderLevels>,
+    graph: StaticGraph<u32>,
+    coordinates: Vec<FPCoordinate>,
+    turns: T,
+    tail: Vec<u32>,
+}
+
+impl<T: TurnCost> PagedEdgeBasedOverlay<T> {
+    #[must_use]
+    pub fn new(
+        tables: PagedOverlay<StaticGraph<u32>, BorderLevels>,
+        graph: StaticGraph<u32>,
+        coordinates: Vec<FPCoordinate>,
+        turns: T,
+    ) -> Self {
+        let mut tail = vec![0_u32; graph.number_of_edges()];
+        for node in graph.node_range() {
+            for arc in graph.edge_range(node) {
+                tail[arc] = u32::try_from(node).expect("the graph is too large");
+            }
+        }
+        Self {
+            tables,
+            graph,
+            coordinates,
+            turns,
+            tail,
+        }
+    }
+
+    /// The node an arc runs out of.
+    #[must_use]
+    pub fn tail(&self, arc: EdgeID) -> NodeID {
+        self.tail[arc] as NodeID
+    }
+
+    /// What the pool did, which says whether a run really read off the file.
+    #[must_use]
+    pub fn faults(&self) -> crate::paged_overlay::Faults {
+        self.tables.faults()
+    }
+}
+
+impl<T: TurnCost> Overlay for PagedEdgeBasedOverlay<T> {
+    type Graph = StaticGraph<u32>;
+    type Table<'a>
+        = <PagedOverlay<StaticGraph<u32>, BorderLevels> as Overlay>::Table<'a>
+    where
+        Self: 'a;
+    type Borders = BorderLevels;
+
+    fn graph(&self) -> &Self::Graph {
+        &self.graph
+    }
+
+    fn partition(&self) -> &PackedPartition {
+        self.tables.partition()
+    }
+
+    fn borders(&self) -> &Self::Borders {
+        self.tables.borders()
+    }
+
+    fn levels(&self) -> usize {
+        self.tables.levels()
+    }
+
+    fn cells_on_level(&self, level: usize) -> usize {
+        self.tables.cells_on_level(level)
+    }
+
+    fn word_of(&self, node: NodeID) -> u128 {
+        self.partition().word(self.tail(node))
+    }
+
+    fn for_each_arc(&self, node: NodeID, from: NodeID, mut f: impl FnMut(NodeID, u32)) {
+        let _ = from;
+        let travelled = *self.graph.data(node);
+        let expanded = EdgeBasedGraph::new(&self.graph, &self.coordinates, &self.turns);
+        expanded.for_each_turn_cost(node, self.tail(node), |onto, turn| {
+            f(onto, travelled + turn);
+        });
+    }
+
+    fn for_each_arc_out_of_cell(
+        &self,
+        node: NodeID,
+        from: NodeID,
+        level: usize,
+        f: impl FnMut(NodeID, u32),
+    ) {
+        if self.borders().leaves_cell(node, level) {
+            Overlay::for_each_arc(self, node, from, f);
+        }
+    }
+
+    fn distances_of(&self, level: usize, cell: CellId) -> Option<Self::Table<'_>> {
+        self.tables.distances_of(level, cell)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EdgeBasedOverlay;
+    use crate::{
+        cell_ordering::CellOrdering,
+        edge::InputEdge,
+        edge_based::{AnglePenalty, FreeTurns, NoUTurns, TurnCost},
+        geometry::FPCoordinate,
+        graph::{Graph, NodeID},
+        grid_graph::grid_directory,
+        level_directory::LevelDirectory,
+        mld_query::MldQuery,
+        node_ordering::{NodeOrdering, Numbering},
+        packed_partition::PackedPartition,
+        static_graph::StaticGraph,
+        unidirectional_dijkstra::UnidirectionalDijkstra,
+    };
+
+    fn grid_edges(side: usize) -> Vec<InputEdge<u32>> {
+        let mut edges = Vec::new();
+        for row in 0..side {
+            for column in 0..side {
+                let node = row * side + column;
+                let weight = (1 + (row * 7 + column * 3) % 9) as u32;
+                if column + 1 < side {
+                    edges.push(InputEdge::new(node, node + 1, weight));
+                    edges.push(InputEdge::new(node + 1, node, weight));
+                }
+                if row + 1 < side {
+                    edges.push(InputEdge::new(node, node + side, weight + 1));
+                    edges.push(InputEdge::new(node + side, node, weight + 1));
+                }
+            }
+        }
+        edges
+    }
+
+    /// A grid whose nodes are numbered so that each cell holds a run of them,
+    /// which is what a table of arcs named by their place in a cell wants.
+    fn laid_out(side: usize) -> (Vec<InputEdge<u32>>, LevelDirectory, Vec<FPCoordinate>) {
+        let edges = grid_edges(side);
+        let directory = grid_directory(side);
+        let directory =
+            CellOrdering::of(&directory, &PackedPartition::of(&directory)).renumber(&directory);
+        let graph = StaticGraph::new(edges.clone());
+        let ordering = NodeOrdering::in_order(
+            &graph,
+            &PackedPartition::of(&directory),
+            Numbering::CellPath,
+        );
+        // laid out on the ground the way the grid is, so that a turn has an
+        // angle worth pricing
+        let mut coordinates = vec![FPCoordinate::new(0, 0); side * side];
+        for row in 0..side {
+            for column in 0..side {
+                let at = ordering.new_of(row * side + column);
+                coordinates[at] = FPCoordinate::new(
+                    i32::try_from(row * 1000).unwrap(),
+                    i32::try_from(column * 1000).unwrap(),
+                );
+            }
+        }
+        (
+            ordering.renumber(&edges),
+            ordering.renumber_directory(&directory),
+            coordinates,
+        )
+    }
+
+    /// The one that matters: the same turns, priced the same way, answered by a
+    /// search over the cells and by a plain search over the whole graph.
+    fn agrees_with_a_plain_search<T: TurnCost + Clone>(turns: T) {
+        let side = 16;
+        let (edges, directory, coordinates) = laid_out(side);
+        let graph = StaticGraph::new(edges.clone());
+        let overlay = EdgeBasedOverlay::new(
+            StaticGraph::new(edges.clone()),
+            coordinates.clone(),
+            turns.clone(),
+            &directory,
+        );
+
+        let mut over_cells = MldQuery::new();
+        let mut plain = UnidirectionalDijkstra::new();
+        let mut pairs = 0;
+        for source in (0..side * side).step_by(5) {
+            for target in (0..side * side).step_by(7) {
+                if source == target {
+                    continue;
+                }
+                // A query is between nodes and this searches over arcs, so
+                // it starts on each arc leaving the source and finishes on the
+                // arcs leaving the target: standing on one of those is
+                // standing at the target, which is what its distance says.
+                let targets: Vec<NodeID> = graph.edge_range(target).collect();
+                let mut over_cells_said = usize::MAX;
+                for arc in graph.edge_range(source) {
+                    over_cells.run(&overlay, arc, &targets);
+                    for &at in &targets {
+                        over_cells_said = over_cells_said.min(over_cells.distance(at));
+                    }
+                }
+                // the same arcs, the same turns and the same prices, walked
+                // one at a time instead of stepped over: what the cells say has
+                // to be what this says
+                let sources: Vec<(NodeID, usize)> =
+                    graph.edge_range(source).map(|arc| (arc, 0)).collect();
+                plain.run_many(&overlay, &sources, |_| false);
+                let mut plain_said = usize::MAX;
+                for &at in &targets {
+                    plain_said = plain_said.min(plain.distance(at));
+                }
+                assert_eq!(over_cells_said, plain_said, "from {source} to {target}");
+                pairs += 1;
+            }
+        }
+        assert!(pairs > 500, "the sweep is worth running");
+    }
+
+    #[test]
+    fn free_turns_over_cells_answer_what_a_plain_search_does() {
+        agrees_with_a_plain_search(FreeTurns);
+    }
+
+    #[test]
+    fn refused_reversals_over_cells_answer_what_a_plain_search_does() {
+        agrees_with_a_plain_search(NoUTurns);
+    }
+
+    #[test]
+    fn priced_angles_over_cells_answer_what_a_plain_search_does() {
+        agrees_with_a_plain_search(AnglePenalty::new(30., 100));
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -59,6 +59,43 @@ pub trait Arcs<T> {
     }
 }
 
+/// What a search walks: the arcs leaving a node, and what each costs.
+///
+/// # Why this is not [`Arcs`]
+///
+/// [`Arcs`] answers arc at a time, by an id that stands on its own. A graph
+/// that works its arcs out as it is asked cannot always answer that way. An
+/// edge-based graph is the case in hand: what a turn costs depends on the arc
+/// it was arrived along, which an arc id on its own does not say, and a turn
+/// that may not be taken has to be left out rather than priced.
+///
+/// Both are answered by handing a node's arcs over one call at a time, which
+/// is what this asks for and all that a search needs. Every [`Arcs`] answers
+/// it without being written to.
+pub trait Adjacency<T> {
+    fn number_of_nodes(&self) -> usize;
+
+    /// Every arc leaving a node, as where it goes and what it costs.
+    ///
+    /// `from` is the node this one was reached from, or the node itself where
+    /// a search began. A graph holding its arcs has no use for it. One working
+    /// them out can: an edge-based graph is standing on an arc, and the node
+    /// that arc runs out of is where the arc it was reached from runs into, so
+    /// being told saves it looking. A caller that passes something other than a
+    /// node this one is really reachable from will be answered accordingly.
+    fn for_each_arc(&self, n: NodeID, from: NodeID, f: impl FnMut(NodeID, T));
+}
+
+impl<T, G: Arcs<T>> Adjacency<T> for G {
+    fn number_of_nodes(&self) -> usize {
+        Arcs::number_of_nodes(self)
+    }
+
+    fn for_each_arc(&self, n: NodeID, _from: NodeID, f: impl FnMut(NodeID, T)) {
+        Arcs::for_each_arc(self, n, f);
+    }
+}
+
 /// Every graph that keeps its arcs answers by lending one and copying it out.
 impl<T: Copy, G: Graph<T>> Arcs<T> for G {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod dimacs;
 pub mod dinic;
 pub mod dynamic_graph;
 pub mod edge;
+pub mod edge_based;
 pub mod edmonds_karp;
 pub mod enumerative_source_coding;
 pub mod fast_hash_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod dinic;
 pub mod dynamic_graph;
 pub mod edge;
 pub mod edge_based;
+pub mod edge_based_overlay;
 pub mod edmonds_karp;
 pub mod enumerative_source_coding;
 pub mod fast_hash_trait;

--- a/src/mld_query.rs
+++ b/src/mld_query.rs
@@ -33,9 +33,8 @@ use log::debug;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    border_levels::Borders,
     dense_heap::{DenseHeap, HashHeap, Queue},
-    graph::{Arcs, NodeID},
+    graph::NodeID,
     heap_stats::{Counters, HeapStats, Untracked},
     overlay::{CellTable, Overlay},
     packed_partition::PackedPartition,
@@ -88,6 +87,14 @@ pub struct MldSearch<S: HeapStats<NodeID>, Q: Queue<S> = DenseHeap<S>> {
     /// The cells the source sits in, as the one word that says all of them.
     source_word: u128,
     reached_target_count: usize,
+    /// Where the arcs of a node are put while they are handed over, kept so
+    /// that settling a node does not allocate.
+    ///
+    /// The overlay hands its arcs to a closure rather than lending a slice,
+    /// since a graph that works them out as it goes has no slice to lend. The
+    /// closure cannot relax as it goes, as that would be the search borrowed
+    /// twice, so what it is given lands here first.
+    reached: Vec<(NodeID, u32)>,
 }
 
 impl<S: HeapStats<NodeID>, Q: Queue<S>> Default for MldSearch<S, Q> {
@@ -104,6 +111,7 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
             holds: std::marker::PhantomData,
             holds_target: Vec::new(),
             holds_target_at: Vec::new(),
+            reached: Vec::new(),
             marked: Vec::new(),
             targets: FxHashSet::default(),
             source_word: 0,
@@ -230,7 +238,7 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
         let level_count = partition.levels();
         self.make_room_for(customization);
         for &target in &self.targets {
-            let word = partition.word(target);
+            let word = customization.word_of(target);
             for level in 0..level_count {
                 let place = self.holds_target_at[level] + partition.cell_in(word, level) as usize;
                 if !self.holds_target[place] {
@@ -242,9 +250,8 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
 
         // the source's cells never move during a run, so they are not asked
         // for once per settled node
-        self.source_word = partition.word(source);
+        self.source_word = customization.word_of(source);
 
-        let graph = customization.graph();
         self.queue.insert(source, 0, source);
 
         while !self.queue.is_empty() && self.reached_target_count < self.targets.len() {
@@ -256,7 +263,8 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
                 debug!("[done] reached {u} at {distance}");
             }
 
-            match self.level_to_step_over(partition, u) {
+            let came_from = self.queue.data(u);
+            match self.level_to_step_over(customization, u) {
                 Some(level) => {
                     // The cell is stepped over once for each way into it, not
                     // once for each of its border nodes. A node reached from
@@ -269,23 +277,174 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
                     // continent with a thousand nodes on its border that is a
                     // thousand relaxations for each of a thousand nodes, in
                     // place of a thousand for each way in.
-                    let came_from = self.queue.data(u);
                     if u == came_from
                         || !partition.same_cell_at(
-                            partition.word(u),
-                            partition.word(came_from),
+                            customization.word_of(u),
+                            customization.word_of(came_from),
                             level,
                         )
                     {
                         self.relax_across_cell(customization, partition, u, distance, level);
                     }
-                    self.relax_out_of_cell(graph, customization.borders(), u, distance, level);
+                    self.relax_out_of_cell(customization, u, came_from, distance, level);
                 }
-                None => self.relax_every_arc(graph, u, distance),
+                None => self.relax_every_arc(customization, u, came_from, distance),
             }
         }
 
         self.reached_target_count == self.targets.len()
+    }
+
+    /// A run from several nodes at once, each starting at a cost of its own.
+    ///
+    /// The sources have to lie in the same cell on every level, which is what a
+    /// query naming its end as a node of an edge-based graph has: the arcs
+    /// leaving one node all run out of it, so they all lie where it does. The
+    /// walk up the levels is worked out from the first of them.
+    ///
+    /// # Panics
+    ///
+    /// In a build that checks, if the sources do not all lie in the same cells.
+    pub fn run_many<O: Overlay>(
+        &mut self,
+        customization: &O,
+        sources: &[(NodeID, usize)],
+        targets: &[NodeID],
+    ) -> bool {
+        self.clear();
+        let Some(&(first, _)) = sources.first() else {
+            return targets.is_empty();
+        };
+        self.targets.extend(targets.iter().copied());
+
+        let partition = customization.partition();
+        let level_count = partition.levels();
+        self.make_room_for(customization);
+        for &target in &self.targets {
+            let word = customization.word_of(target);
+            for level in 0..level_count {
+                let place = self.holds_target_at[level] + partition.cell_in(word, level) as usize;
+                if !self.holds_target[place] {
+                    self.holds_target[place] = true;
+                    self.marked.push(place);
+                }
+            }
+        }
+
+        self.source_word = customization.word_of(first);
+        for &(node, cost) in sources {
+            debug_assert_eq!(
+                customization.word_of(node),
+                self.source_word,
+                "the sources do not all lie in the same cells"
+            );
+            self.queue.insert_or_decrease(node, cost, node);
+        }
+
+        while !self.queue.is_empty() && self.reached_target_count < self.targets.len() {
+            let u = self.queue.delete_min();
+            let distance = self.queue.weight(u);
+
+            if self.targets.contains(&u) {
+                self.reached_target_count += 1;
+            }
+
+            let came_from = self.queue.data(u);
+            match self.level_to_step_over(customization, u) {
+                Some(level) => {
+                    if u == came_from
+                        || !partition.same_cell_at(
+                            customization.word_of(u),
+                            customization.word_of(came_from),
+                            level,
+                        )
+                    {
+                        self.relax_across_cell(customization, partition, u, distance, level);
+                    }
+                    self.relax_out_of_cell(customization, u, came_from, distance, level);
+                }
+                None => self.relax_every_arc(customization, u, came_from, distance),
+            }
+        }
+
+        self.reached_target_count == self.targets.len()
+    }
+
+    /// A run from several nodes to several, each end carrying a cost of its
+    /// own, answering the least total over the targets.
+    ///
+    /// The targets of a query naming its ends as nodes of an edge-based graph
+    /// are the arcs arriving at one node, and what it cost to arrive is the
+    /// distance to such an arc plus what the arc itself costs. That extra is
+    /// what each target carries here.
+    ///
+    /// Where [`Self::run_many`] stops once every target is reached, this stops
+    /// once no target still on the queue can beat what has been found: a node
+    /// settled later is no nearer, and what a target adds on arrival is never
+    /// negative. Waiting for all of them instead means a search that exhausts
+    /// the graph whenever one target cannot be reached at all, which turns
+    /// occasional queries into hundredfold outliers.
+    pub fn run_to_arcs<O: Overlay>(
+        &mut self,
+        customization: &O,
+        sources: &[(NodeID, usize)],
+        targets: &[(NodeID, usize)],
+    ) -> usize {
+        self.clear();
+        let Some(&(first, _)) = sources.first() else {
+            return usize::MAX;
+        };
+        self.targets.extend(targets.iter().map(|&(node, _)| node));
+
+        let partition = customization.partition();
+        let level_count = partition.levels();
+        self.make_room_for(customization);
+        for &target in &self.targets {
+            let word = customization.word_of(target);
+            for level in 0..level_count {
+                let place = self.holds_target_at[level] + partition.cell_in(word, level) as usize;
+                if !self.holds_target[place] {
+                    self.holds_target[place] = true;
+                    self.marked.push(place);
+                }
+            }
+        }
+
+        self.source_word = customization.word_of(first);
+        for &(node, cost) in sources {
+            self.queue.insert_or_decrease(node, cost, node);
+        }
+
+        let mut best = usize::MAX;
+        while !self.queue.is_empty() {
+            let u = self.queue.delete_min();
+            let distance = self.queue.weight(u);
+            if distance >= best {
+                break;
+            }
+
+            if let Some(&(_, extra)) = targets.iter().find(|&&(node, _)| node == u) {
+                best = best.min(distance + extra);
+            }
+
+            let came_from = self.queue.data(u);
+            match self.level_to_step_over(customization, u) {
+                Some(level) => {
+                    if u == came_from
+                        || !partition.same_cell_at(
+                            customization.word_of(u),
+                            customization.word_of(came_from),
+                            level,
+                        )
+                    {
+                        self.relax_across_cell(customization, partition, u, distance, level);
+                    }
+                    self.relax_out_of_cell(customization, u, came_from, distance, level);
+                }
+                None => self.relax_every_arc(customization, u, came_from, distance),
+            }
+        }
+        best
     }
 
     /// The highest level whose cell around this node holds neither the source
@@ -296,8 +455,9 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
     /// are still asked cell by cell, and the walk runs no further than the
     /// level the source alone allows.
     #[inline(never)]
-    fn level_to_step_over(&self, partition: &PackedPartition, node: NodeID) -> Option<usize> {
-        let word = partition.word(node);
+    fn level_to_step_over<O: Overlay>(&self, customization: &O, node: NodeID) -> Option<usize> {
+        let partition = customization.partition();
+        let word = customization.word_of(node);
         let highest = partition.highest_different_level(word, self.source_word)?;
         (0..=highest).rev().find(|&level| {
             let place = self.holds_target_at[level] + partition.cell_in(word, level) as usize;
@@ -315,7 +475,7 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
         distance: usize,
         level: usize,
     ) {
-        let cell = partition.cell_of(node, level);
+        let cell = partition.cell_in(customization.word_of(node), level);
         // an index into the customization, which lends the table out rather
         // than counting it, so this is a load rather than a lock and a hash
         let Some(distances) = customization.distances_of(level, cell) else {
@@ -341,34 +501,44 @@ impl<S: HeapStats<NodeID>, Q: Queue<S>> MldSearch<S, Q> {
     /// The arcs of the graph that leave the cell, which is how the search gets
     /// out of one.
     #[inline(never)]
-    fn relax_out_of_cell<G: Arcs<u32>, B: Borders>(
+    fn relax_out_of_cell<O: Overlay>(
         &mut self,
-        graph: &G,
-        borders: &B,
+        customization: &O,
         node: NodeID,
+        from: NodeID,
         distance: usize,
         level: usize,
     ) {
-        for edge in graph.edge_range(node) {
-            // read in step with the arcs rather than asked of the partition,
-            // which would be a jump into an array as wide as the graph for
-            // every arc of every node the search settles
-            if !borders.leaves_cell(edge, level) {
-                continue;
-            }
-            let target = graph.target(edge);
-            self.relax(target, distance + graph.weight(edge) as usize, node);
+        let mut reached = std::mem::take(&mut self.reached);
+        reached.clear();
+        customization.for_each_arc_out_of_cell(node, from, level, |target, weight| {
+            reached.push((target, weight));
+        });
+        for &(target, weight) in &reached {
+            self.relax(target, distance + weight as usize, node);
         }
+        self.reached = reached;
     }
 
     /// Every arc of the graph, which is what a plain Dijkstra does and what
     /// this does inside a cell that holds the source or a target.
     #[inline(never)]
-    fn relax_every_arc<G: Arcs<u32>>(&mut self, graph: &G, node: NodeID, distance: usize) {
-        for edge in graph.edge_range(node) {
-            let target = graph.target(edge);
-            self.relax(target, distance + graph.weight(edge) as usize, node);
+    fn relax_every_arc<O: Overlay>(
+        &mut self,
+        customization: &O,
+        node: NodeID,
+        from: NodeID,
+        distance: usize,
+    ) {
+        let mut reached = std::mem::take(&mut self.reached);
+        reached.clear();
+        customization.for_each_arc(node, from, |target, weight| {
+            reached.push((target, weight));
+        });
+        for &(target, weight) in &reached {
+            self.relax(target, distance + weight as usize, node);
         }
+        self.reached = reached;
     }
 
     /// One look into the queue rather than up to four.

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -84,6 +84,52 @@ pub trait Overlay {
 
     fn cells_on_level(&self, level: usize) -> usize;
 
+    /// The cells a node of the searched graph lies in, as the packed word.
+    ///
+    /// A node the search walks is not always a node of the partition. Where the
+    /// graph is an edge-based one worked out as it is walked, a node there is
+    /// an arc here, and the cells it lies in are the cells of the node that arc
+    /// runs into.
+    fn word_of(&self, node: NodeID) -> u128 {
+        self.partition().word(node)
+    }
+
+    /// Every arc leaving a node, as where it goes and what it costs.
+    ///
+    /// `from` is the node this one was reached from, or the node itself where
+    /// the search began. A graph holding its arcs has no use for it; one
+    /// working them out as it goes needs it, since what an arc costs may depend
+    /// on the arc it was reached along.
+    fn for_each_arc(&self, node: NodeID, from: NodeID, mut f: impl FnMut(NodeID, u32)) {
+        let _ = from;
+        let graph = self.graph();
+        for edge in graph.edge_range(node) {
+            f(graph.target(edge), graph.weight(edge));
+        }
+    }
+
+    /// The same, but only the arcs that leave the cell the node lies in at this
+    /// level, which is how a search gets out of a cell it has stepped over.
+    fn for_each_arc_out_of_cell(
+        &self,
+        node: NodeID,
+        from: NodeID,
+        level: usize,
+        mut f: impl FnMut(NodeID, u32),
+    ) {
+        let _ = from;
+        let graph = self.graph();
+        let borders = self.borders();
+        for edge in graph.edge_range(node) {
+            // read in step with the arcs rather than asked of the partition,
+            // which would be a jump into an array as wide as the graph for
+            // every arc of every node the search settles
+            if borders.leaves_cell(edge, level) {
+                f(graph.target(edge), graph.weight(edge));
+            }
+        }
+    }
+
     /// The distances across a cell, and `None` for a cell with no border node
     /// and so no table.
     ///

--- a/src/paged_overlay.rs
+++ b/src/paged_overlay.rs
@@ -36,10 +36,13 @@ use std::sync::{
 /// How many blocks are kept in hand while their cells are unpacked.
 ///
 use crate::{
+    block_codec::Codec,
     block_map::BlockEntry,
-    block_store::{BlockStore, NotRead},
+    block_store::{BlockStore, BlockWriter, NotRead},
     border_levels::{BorderLevels, Borders},
+    cell_block::{CellBlock, CellEntry},
     cell_tree::CellTree,
+    customization::Customization,
     graph::{Arcs, NodeID},
     level_directory::CellId,
     overlay::{CellTable, Overlay},
@@ -602,7 +605,7 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> PagedOverlay<G, B> {
         } = &mut held;
         block.unpack_into(which, &widths, matrix);
         block.places_into(which, &widths, nodes);
-        let begins = self.store.tree().nodes_begin(level, cell);
+        let begins = self.store.counting_from(level, cell);
         if nodes.is_empty() {
             nodes.extend((0..widths[which] as u32).map(|at| begins + at));
         } else {
@@ -659,16 +662,143 @@ impl<G: Arcs<u32> + Sync, B: Borders + Sync> Overlay for PagedOverlay<G, B> {
     }
 }
 
+/// Writes the tables of a customization to a file, a run of cells at a time,
+/// and says where each block landed.
+///
+/// The blocks are what [`PagedOverlay`] reads, and the map is how it finds
+/// one. Both the map and the [`CellTree`] have to be kept beside the file, or
+/// the blocks cannot be found again.
+///
+/// A block holds `cells_a_block` cells of one level. Larger blocks read fewer
+/// times and throw away more of what they read. The finest level is packed
+/// with lz4 and the ones above it with zstd, since the finest is read most and
+/// the ones above it are read seldom enough to be worth the tighter packing.
+///
+/// # Errors
+///
+/// If the file cannot be written.
+pub fn pack_cells(
+    customization: &Customization,
+    tree: &CellTree,
+    path: &std::path::Path,
+    cells_a_block: usize,
+) -> std::io::Result<crate::block_map::BlockMap> {
+    pack_overlay(customization, tree, path, cells_a_block, |level, cell| {
+        (
+            tree.nodes_begin(level, cell),
+            level == 0,
+            tree.facts(level, cell).nodes as usize,
+        )
+    })
+}
+
+/// The same, for an overlay whose tables are named by something other than the
+/// nodes of a cell.
+///
+/// `begins` says, for a cell, what its ids count from, whether the ones on its
+/// border lead that run, and how many ids the cell holds. A table of nodes has
+/// the first two: a cell's nodes are consecutive and the border ones come
+/// first, so the finest level writes no places at all. A table of arcs has the
+/// first but not the second, since the arcs on a cell's border are the ones
+/// leaving a node the boundary runs through and those are scattered through the
+/// cell.
+///
+/// The third is what a place is written with room for. Written against the node
+/// count while the places were arc offsets, the wider ones were silently cut
+/// short and the tables read back against the wrong arcs.
+///
+/// # Errors
+///
+/// If the file cannot be written.
+pub fn pack_overlay<O: Overlay>(
+    customization: &O,
+    tree: &CellTree,
+    path: &std::path::Path,
+    cells_a_block: usize,
+    begins: impl Fn(usize, CellId) -> (u32, bool, usize),
+) -> std::io::Result<crate::block_map::BlockMap> {
+    let mut writer = BlockWriter::create(path)?;
+    for level in 0..tree.levels() {
+        let border_leads = level == 0;
+        let mut at = 0;
+        while at < tree.cells_on_level(level) {
+            let upto = (at + cells_a_block).min(tree.cells_on_level(level));
+            let mut matrices = Vec::new();
+            let mut widths = Vec::new();
+            let mut places = Vec::new();
+            let mut holds = Vec::new();
+            for cell in at..upto {
+                let cell = cell as CellId;
+                // The topmost cell holds the whole graph, so no arc leaves
+                // it and it has no border and no table. It goes into the
+                // block as a table of nothing rather than being left out,
+                // so that a block stays a run of cells.
+                let held = customization.distances_of(level, cell);
+                let wide = held.as_ref().map_or(0, |table| table.border_nodes().len());
+                let mut matrix = Vec::with_capacity(wide * wide);
+                if let Some(ref table) = held {
+                    for source in 0..wide {
+                        matrix.extend_from_slice(table.row(source));
+                    }
+                }
+                let (counts_from, _, ids_held) = begins(level, cell);
+                places.push(if border_leads {
+                    Vec::new()
+                } else {
+                    held.as_ref().map_or_else(Vec::new, |table| {
+                        table
+                            .border_nodes()
+                            .iter()
+                            .map(|&node| node - counts_from)
+                            .collect()
+                    })
+                });
+                matrices.push(matrix);
+                widths.push(wide);
+                holds.push(ids_held);
+            }
+            let entries = matrices
+                .iter()
+                .zip(&widths)
+                .zip(&places)
+                .zip(&holds)
+                .map(|(((matrix, &wide), places), &holds)| CellEntry {
+                    matrix,
+                    wide,
+                    places,
+                    holds,
+                })
+                .collect::<Vec<_>>();
+            let block = CellBlock::of(level, at as CellId, &entries, border_leads);
+            let keys = (
+                tree.range_of(level, at as CellId).0,
+                tree.range_of(level, (upto - 1) as CellId).1,
+            );
+            let nodes = (
+                tree.nodes_begin(level, at as CellId),
+                tree.nodes_begin(level, (upto - 1) as CellId)
+                    + tree.facts(level, (upto - 1) as CellId).nodes
+                    - tree.nodes_begin(level, at as CellId),
+            );
+            writer.push(
+                &block,
+                keys,
+                (at as CellId, (upto - at) as u32),
+                nodes,
+                if level == 0 { Codec::Lz4 } else { Codec::Zstd },
+                3,
+            )?;
+            at = upto;
+        }
+    }
+    writer.finish()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        block_codec::Codec,
-        block_store::BlockWriter,
-        cell_block::{CellBlock, CellEntry},
         cell_ordering::CellOrdering,
-        cell_tree::CellTree,
-        customization::Customization,
         edge::InputEdge,
         geometry::FPCoordinate,
         grid_graph::grid_directory,
@@ -716,91 +846,6 @@ mod tests {
     }
 
     /// Writes every cell of a customization into a store.
-    fn pack_cells(
-        customization: &Customization,
-        tree: &CellTree,
-        path: &std::path::Path,
-        cells_a_block: usize,
-    ) -> crate::block_map::BlockMap {
-        let mut writer = BlockWriter::create(path).expect("a file to write");
-        for level in 0..tree.levels() {
-            let border_leads = level == 0;
-            let mut at = 0;
-            while at < tree.cells_on_level(level) {
-                let upto = (at + cells_a_block).min(tree.cells_on_level(level));
-                let mut matrices = Vec::new();
-                let mut widths = Vec::new();
-                let mut places = Vec::new();
-                let mut holds = Vec::new();
-                for cell in at..upto {
-                    let cell = cell as CellId;
-                    // The topmost cell holds the whole graph, so no arc leaves
-                    // it and it has no border and no table. It goes into the
-                    // block as a table of nothing rather than being left out,
-                    // so that a block stays a run of cells.
-                    let held = customization.distances_of(level, cell);
-                    let wide = held.map_or(0, |table| table.border_nodes_of().len());
-                    let mut matrix = Vec::with_capacity(wide * wide);
-                    if let Some(table) = held {
-                        for source in 0..wide {
-                            matrix.extend_from_slice(table.row(source));
-                        }
-                    }
-                    let begins = tree.nodes_begin(level, cell);
-                    places.push(if border_leads {
-                        Vec::new()
-                    } else {
-                        held.map_or_else(Vec::new, |table| {
-                            table
-                                .border_nodes_of()
-                                .iter()
-                                .map(|&node| node - begins)
-                                .collect()
-                        })
-                    });
-                    matrices.push(matrix);
-                    widths.push(wide);
-                    holds.push(tree.facts(level, cell).nodes as usize);
-                }
-                let entries = matrices
-                    .iter()
-                    .zip(&widths)
-                    .zip(&places)
-                    .zip(&holds)
-                    .map(|(((matrix, &wide), places), &holds)| CellEntry {
-                        matrix,
-                        wide,
-                        places,
-                        holds,
-                    })
-                    .collect::<Vec<_>>();
-                let block = CellBlock::of(level, at as CellId, &entries, border_leads);
-                let keys = (
-                    tree.range_of(level, at as CellId).0,
-                    tree.range_of(level, (upto - 1) as CellId).1,
-                );
-                let nodes = (
-                    tree.nodes_begin(level, at as CellId),
-                    tree.nodes_begin(level, (upto - 1) as CellId)
-                        + tree.facts(level, (upto - 1) as CellId).nodes
-                        - tree.nodes_begin(level, at as CellId),
-                );
-                writer
-                    .push(
-                        &block,
-                        keys,
-                        (at as CellId, (upto - at) as u32),
-                        nodes,
-                        if level == 0 { Codec::Lz4 } else { Codec::Zstd },
-                        3,
-                    )
-                    .expect("a block to write");
-                at = upto;
-            }
-        }
-        writer.finish().expect("a file to close")
-    }
-
     /// The one that matters: the same search, unchanged, over the cells in
     /// memory and over the same cells read off a file, answering the same.
     #[test]
@@ -815,7 +860,7 @@ mod tests {
 
         let held = tempfile::tempdir().expect("a directory to write in");
         let path = held.path().join("blocks");
-        let map = pack_cells(&in_memory, &tree, &path, 3);
+        let map = pack_cells(&in_memory, &tree, &path, 3).expect("a store to write");
         assert!(map.len() > 1, "the store is worth more than one block");
 
         let store = BlockStore::open(&path, map, tree).expect("a store to open");
@@ -867,7 +912,7 @@ mod tests {
 
         let held = tempfile::tempdir().expect("a directory to write in");
         let path = held.path().join("blocks");
-        let map = pack_cells(&in_memory, &tree, &path, 3);
+        let map = pack_cells(&in_memory, &tree, &path, 3).expect("a store to write");
 
         // room enough for the two coarsest levels and no more, on top of what
         // the instance costs before any table: the budget is for the whole of
@@ -941,7 +986,7 @@ mod tests {
 
         let held = tempfile::tempdir().expect("a directory to write in");
         let tables = held.path().join("blocks");
-        let map = pack_cells(&in_memory, &tree, &tables, 3);
+        let map = pack_cells(&in_memory, &tree, &tables, 3).expect("a store to write");
         let arcs = held.path().join("arcs");
         let (arc_map, first_edges) = pack(
             &graph,

--- a/src/ranks/bin/command_line.rs
+++ b/src/ranks/bin/command_line.rs
@@ -38,6 +38,15 @@ pub enum Mode {
     /// definition, so only the searches over the cells are worth counting.
     Scans(Scans),
 
+    /// Writes the cell tables to a file, so that a search can read them off it
+    /// rather than hold them.
+    ///
+    /// The tables are customized in memory once and packed a run of cells at a
+    /// time. What comes out is three files: the blocks themselves, the map that
+    /// says where each block landed, and the tree of cells the blocks are
+    /// ordered by. All three are wanted to read one table back.
+    Pack(Pack),
+
     /// Times the pairs, and counts nothing while doing it.
     ///
     /// A run that is being counted is not a run worth timing, so this reads
@@ -119,6 +128,37 @@ pub struct Scans {
 }
 
 #[derive(Parser, Debug)]
+pub struct Pack {
+    /// path to the input graph
+    #[clap(short, long, action)]
+    pub graph: String,
+
+    /// path to the input coordinates, which order the cells of a level
+    #[clap(short, long, action)]
+    pub coordinates: String,
+
+    /// path to the level directory that chipper wrote
+    #[clap(short, long, action)]
+    pub directory: String,
+
+    /// where to write the blocks, the map and the tree, as `<out>.blocks`,
+    /// `<out>.map` and `<out>.tree`
+    #[clap(short, long, action)]
+    pub out: String,
+
+    /// How many cells of a level go in one block. A larger block is read fewer
+    /// times and throws away more of what it read.
+    #[clap(long, default_value_t = 8, action)]
+    pub cells_a_block: usize,
+
+    /// Tabulate the cells over the arcs of the graph rather than its nodes,
+    /// pricing the turns between them. What comes out is read by the
+    /// edge-based-paged-mld engine and by nothing else.
+    #[clap(long, action)]
+    pub edge_based: bool,
+}
+
+#[derive(Parser, Debug)]
 pub struct Time {
     /// path to the input graph
     #[clap(short, long, action)]
@@ -160,6 +200,21 @@ pub struct Time {
     /// what puts them into the numbering and reads the answers back out.
     #[clap(long, default_value_t = String::new(), action)]
     pub ordering: String,
+
+    /// path to the input coordinates, which the edge-based engines price their
+    /// turns by
+    #[clap(short, long, default_value_t = String::new(), action)]
+    pub coordinates: String,
+
+    /// What the pack mode wrote, for the paged-mld engine. The three files are
+    /// read as `<tables>.blocks`, `<tables>.map` and `<tables>.tree`.
+    #[clap(long, default_value_t = String::new(), action)]
+    pub tables: String,
+
+    /// How many bytes the tables read off a file may take before one of them is
+    /// thrown away to make room. Says nothing for the engines that hold theirs.
+    #[clap(long, default_value_t = 256 << 20, action)]
+    pub budget: usize,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -172,6 +227,13 @@ pub enum Engine {
     Mld,
     /// a search over the cells of the partition, run from both ends
     BidirectionalMld,
+    /// a search over cells that are read off a file rather than held
+    PagedMld,
+    /// a search over cells whose nodes are the arcs of the graph, with the
+    /// turns between them priced as the search walks them
+    EdgeBasedMld,
+    /// the same, over cells read off a file rather than held
+    EdgeBasedPagedMld,
 }
 
 impl Display for Engine {
@@ -181,6 +243,9 @@ impl Display for Engine {
             Engine::Bidirectional => write!(f, "bidirectional"),
             Engine::Mld => write!(f, "mld"),
             Engine::BidirectionalMld => write!(f, "bidirectional-mld"),
+            Engine::PagedMld => write!(f, "paged-mld"),
+            Engine::EdgeBasedMld => write!(f, "edge-based-mld"),
+            Engine::EdgeBasedPagedMld => write!(f, "edge-based-paged-mld"),
         }
     }
 }
@@ -211,6 +276,15 @@ impl Display for Arguments {
                 writeln!(f, "level directory: {}", check.directory)?;
                 writeln!(f, "in: {}", check.input)
             }
+            Mode::Pack(pack) => {
+                writeln!(f, "mode: pack")?;
+                writeln!(f, "graph: {}", pack.graph)?;
+                writeln!(f, "coordinates: {}", pack.coordinates)?;
+                writeln!(f, "level directory: {}", pack.directory)?;
+                writeln!(f, "out: {}", pack.out)?;
+                writeln!(f, "cells a block: {}", pack.cells_a_block)?;
+                writeln!(f, "edge based: {}", pack.edge_based)
+            }
             Mode::Time(time) => {
                 writeln!(f, "mode: time")?;
                 writeln!(f, "graph: {}", time.graph)?;
@@ -221,7 +295,10 @@ impl Display for Arguments {
                 writeln!(f, "warmup: {} pairs", time.warmup)?;
                 writeln!(f, "seed: {}", time.seed)?;
                 writeln!(f, "renumbered: {}", time.renumber)?;
-                writeln!(f, "ordering: {}", time.ordering)
+                writeln!(f, "ordering: {}", time.ordering)?;
+                writeln!(f, "coordinates: {}", time.coordinates)?;
+                writeln!(f, "tables: {}", time.tables)?;
+                writeln!(f, "budget: {} bytes", time.budget)
             }
         }
     }

--- a/src/ranks/bin/main.rs
+++ b/src/ranks/bin/main.rs
@@ -28,7 +28,7 @@ use std::{
     time::Instant,
 };
 
-use command_line::{Arguments, Check, Engine, Mode, Sample, Scans, Time};
+use command_line::{Arguments, Check, Engine, Mode, Pack, Sample, Scans, Time};
 use env_logger::{Builder, Env};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{info, warn};
@@ -54,22 +54,35 @@ fn bar_of(count: usize, what: &str) -> ProgressBar {
 use toolbox_rs::{
     bidirectional_dijkstra::BidirectionalDijkstra,
     bidirectional_mld_query::{BidirectionalMldQuery, TrackedBidirectionalMldQuery},
+    block_map::BlockMap,
+    block_store::BlockStore,
     border_levels::BorderLevels,
+    cell_tree::CellTree,
     customization::Customization,
     edge::InputEdge,
+    edge_based::AnglePenalty,
+    edge_based_overlay::{EdgeBasedOverlay, PagedEdgeBasedOverlay},
+    geometry::FPCoordinate,
     graph::{Graph, NodeID},
     heap_stats::{Counters, RankTargets},
     io,
-    level_directory::LevelDirectory,
+    level_directory::{CellId, LevelDirectory},
     mld_query::{MldQuery, TrackedMldQuery},
     node_ordering::NodeOrdering,
+    overlay::Overlay,
     packed_partition::PackedPartition,
+    paged_overlay::{PagedOverlay, pack_cells, pack_overlay},
+    pool::Pool,
     static_graph::StaticGraph,
     unidirectional_dijkstra::{UnidirectionalDijkstra, UnidirectionalSearch},
 };
 
 /// A pair to time, and the rank its target sits at.
 type ToTime = (NodeID, NodeID, usize);
+
+/// The arcs a route may leave the source on, each at what it has cost so far,
+/// and the arcs it may arrive at the target by.
+type ArcEnds = (Vec<(NodeID, usize)>, Vec<(NodeID, usize)>);
 
 /// What one pair cost: the pair itself, its rank, the nanoseconds, and what
 /// the search said the distance was. The pair is carried through so the two
@@ -100,6 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Mode::Check(check) => run_check(check),
         Mode::Time(time) => run_time(time),
         Mode::Scans(scans) => run_scans(scans),
+        Mode::Pack(pack) => run_pack(pack),
     }
 }
 
@@ -299,8 +313,28 @@ fn run_check(args: &Check) -> Result<(), Box<dyn Error>> {
 fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
     readable(&args.graph, "graph")?;
     readable(&args.input, "input")?;
-    if args.engine == Engine::Mld {
+    if matches!(
+        args.engine,
+        Engine::Mld | Engine::PagedMld | Engine::EdgeBasedMld | Engine::EdgeBasedPagedMld
+    ) {
         readable(&args.directory, "level directory")?;
+    }
+    if matches!(
+        args.engine,
+        Engine::EdgeBasedMld | Engine::EdgeBasedPagedMld
+    ) {
+        if args.coordinates.is_empty() {
+            return Err("the edge-based engine wants --coordinates, to price its turns by".into());
+        }
+        readable(&args.coordinates, "coordinates")?;
+    }
+    if matches!(args.engine, Engine::PagedMld | Engine::EdgeBasedPagedMld) {
+        if args.tables.is_empty() {
+            return Err("the paged-mld engine wants --tables, as the pack mode wrote them".into());
+        }
+        for suffix in ["blocks", "map", "tree"] {
+            readable(&format!("{}.{suffix}", args.tables), "packed tables")?;
+        }
     }
     let mut graph = load_graph(&args.graph);
     let mut pairs = read_pairs(&args.input)?;
@@ -346,7 +380,11 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
     }
 
     let directory = match args.engine {
-        Engine::Mld | Engine::BidirectionalMld => {
+        Engine::Mld
+        | Engine::BidirectionalMld
+        | Engine::PagedMld
+        | Engine::EdgeBasedMld
+        | Engine::EdgeBasedPagedMld => {
             let directory: LevelDirectory = io::read_from_file(&args.directory);
             info!(
                 "loaded a directory of {} levels over {} nodes",
@@ -410,6 +448,18 @@ fn run_time(args: &Time) -> Result<(), Box<dyn Error>> {
             let reverse = reverse_of(&graph);
             info!("turned {} arcs around", reverse.number_of_edges());
             time_bidirectional_mld(graph, reverse, directory, &pairs, args.warmup)
+        }
+        Engine::PagedMld => {
+            let directory = directory.expect("a directory was read for the cells");
+            time_paged_mld(graph, &directory, args, &pairs)?
+        }
+        Engine::EdgeBasedMld => {
+            let directory = directory.expect("a directory was read for the cells");
+            time_edge_based_mld(graph, &directory, args, &pairs)
+        }
+        Engine::EdgeBasedPagedMld => {
+            let directory = directory.expect("a directory was read for the cells");
+            time_edge_based_paged_mld(graph, &directory, args, &pairs)?
         }
     };
 
@@ -678,6 +728,423 @@ fn time_mld(
         .collect();
     bar.finish_and_clear();
     timings
+}
+
+/// Checks that each cell's nodes run consecutively, which is what a store of
+/// blocks is written against.
+///
+/// A block says where a cell's nodes begin and how many it holds, and a table
+/// names its border nodes by how far into the cell they sit. Both are a running
+/// total of what the cells hold, so both are answers only where a cell's nodes
+/// are consecutive. Packed against a numbering where they are not, every table
+/// is written down against the wrong nodes and every query is quietly wrong
+/// rather than refused: 3605 of 4800 pairs of a continent disagreed with the
+/// same query over the same cells held in memory.
+fn contiguous_cells(
+    partition: &PackedPartition,
+    directory: &LevelDirectory,
+) -> Result<(), Box<dyn Error>> {
+    for level in 0..directory.levels() {
+        let mut seen = vec![false; directory.cells_on_level(level)];
+        let mut last = usize::MAX;
+        for node in 0..directory.number_of_nodes() {
+            let cell = partition.cell_of(node, level) as usize;
+            if cell == last {
+                continue;
+            }
+            if seen[cell] {
+                return Err(format!(
+                    "the nodes of cell {cell} on level {level} do not run consecutively, so the \
+                     instance is not laid out for a store of blocks. Run the renumber binary over \
+                     it first, with --cells-in-key-order --numbering cell-path, and pack what \
+                     that writes"
+                )
+                .into());
+            }
+            seen[cell] = true;
+            last = cell;
+        }
+    }
+    Ok(())
+}
+
+/// Customizes the cells once and writes them to a file, so that a search can
+/// read them off it rather than hold them.
+///
+/// Three files come out and all three are wanted to read a table back: the
+/// blocks, the map that says where each block landed, and the tree of cells the
+/// blocks are ordered by.
+fn run_pack(args: &Pack) -> Result<(), Box<dyn Error>> {
+    readable(&args.graph, "graph")?;
+    readable(&args.coordinates, "coordinates")?;
+    readable(&args.directory, "level directory")?;
+
+    let graph = load_graph(&args.graph);
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&args.coordinates);
+    let directory: LevelDirectory = io::read_from_file(&args.directory);
+    assert_eq!(
+        graph.number_of_nodes(),
+        directory.number_of_nodes(),
+        "the directory was built over another graph"
+    );
+    info!(
+        "loaded a directory of {} levels over {} nodes",
+        directory.levels(),
+        directory.number_of_nodes()
+    );
+
+    let partition = PackedPartition::of(&directory);
+    contiguous_cells(&partition, &directory)?;
+    let tree = CellTree::of(&directory, &partition, &graph, &coordinates);
+
+    if args.edge_based {
+        return pack_edge_based(args, graph, coordinates, &directory, &tree);
+    }
+    let started = Instant::now();
+    let customization = Customization::new(load_graph(&args.graph), directory);
+    info!(
+        "customized {} cells in {:.1} s",
+        customization.customized_cells(),
+        started.elapsed().as_secs_f64()
+    );
+
+    let blocks = format!("{}.blocks", args.out);
+    let started = Instant::now();
+    let map = pack_cells(
+        &customization,
+        &tree,
+        std::path::Path::new(&blocks),
+        args.cells_a_block,
+    )?;
+    info!(
+        "wrote {} blocks to {blocks} in {:.1} s",
+        map.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    io::write_to_file(&format!("{}.map", args.out), &map);
+    io::write_to_file(&format!("{}.tree", args.out), &tree);
+    info!("wrote the map and the tree beside it");
+    Ok(())
+}
+
+/// The arcs a route may leave each source on, and the ones it may arrive at
+/// each target by.
+///
+/// Which arcs run into a node has to be gathered, since an adjacency array says
+/// only which run out. Asking instead for the reverse of each arc leaving the
+/// target would answer only on a graph holding every arc both ways, and would
+/// quietly report no route where it does not.
+fn arc_ends(graph: &StaticGraph<u32>, pairs: &[ToTime]) -> Vec<ArcEnds> {
+    let mut into = vec![Vec::new(); Graph::number_of_nodes(graph)];
+    for node in graph.node_range() {
+        for arc in graph.edge_range(node) {
+            into[graph.target(arc)].push(arc);
+        }
+    }
+    pairs
+        .iter()
+        .map(|&(source, target, _)| {
+            (
+                graph.edge_range(source).map(|arc| (arc, 0)).collect(),
+                // what it cost to arrive is the distance to the arc plus what
+                // travelling the arc itself costs
+                into[target]
+                    .iter()
+                    .map(|&arc| (arc, *graph.data(arc) as usize))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+/// Tabulates the cells over the arcs of the graph and writes them to a file.
+///
+/// The tables name arcs rather than nodes, so a block counts its ids from the
+/// cell's first arc rather than its first node, and the store is told so when
+/// it is opened again. Nothing else about the store differs.
+fn pack_edge_based(
+    _args: &Pack,
+    _graph: StaticGraph<u32>,
+    _coordinates: Vec<FPCoordinate>,
+    _directory: &LevelDirectory,
+    _tree: &CellTree,
+) -> Result<(), Box<dyn Error>> {
+    Err(
+        "an edge-based table is not square and a block of the store is: its ways in \
+         outnumber its ways out by nearly three to one, and the format names one list \
+         of border ids to serve as both. Packing one wants the rows and the columns \
+         written apart"
+            .into(),
+    )
+}
+
+#[allow(dead_code)]
+fn pack_edge_based_once_blocks_hold_rectangles(
+    args: &Pack,
+    graph: StaticGraph<u32>,
+    coordinates: Vec<FPCoordinate>,
+    directory: &LevelDirectory,
+    tree: &CellTree,
+) -> Result<(), Box<dyn Error>> {
+    let started = Instant::now();
+    let overlay = EdgeBasedOverlay::new(graph, coordinates, AnglePenalty::new(30., 100), directory);
+    let bar = bar_of(overlay.levels(), "tabulating the cells");
+    for level in 0..overlay.levels() {
+        for cell in 0..overlay.cells_on_level(level) {
+            let _ = overlay.distances_of(level, cell as CellId);
+        }
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+    info!(
+        "tabulated every cell in {:.1} s",
+        started.elapsed().as_secs_f64()
+    );
+
+    let begins = overlay.arcs_begin();
+    let holds = overlay.arcs_held();
+    let widths = overlay.border_widths();
+    let blocks = format!("{}.blocks", args.out);
+    let started = Instant::now();
+    let map = pack_overlay(
+        &overlay,
+        tree,
+        std::path::Path::new(&blocks),
+        args.cells_a_block,
+        // a cell's arcs run consecutively, and the ones on its border are
+        // scattered through them rather than leading
+        |level, cell| {
+            (
+                begins[level][cell as usize],
+                false,
+                holds[level][cell as usize],
+            )
+        },
+    )?;
+    info!(
+        "wrote {} blocks to {blocks} in {:.1} s",
+        map.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    io::write_to_file(&format!("{}.map", args.out), &map);
+    io::write_to_file(&format!("{}.tree", args.out), tree);
+    io::write_vec_to_file(&format!("{}.begins", args.out), &begins);
+    io::write_vec_to_file(&format!("{}.widths", args.out), &widths);
+    info!("wrote the map, the tree, the arc offsets and the widths beside it");
+    Ok(())
+}
+
+/// The same pairs over cells whose nodes are the arcs of the graph, read off a
+/// file rather than held.
+fn time_edge_based_paged_mld(
+    graph: StaticGraph<u32>,
+    directory: &LevelDirectory,
+    args: &Time,
+    pairs: &[ToTime],
+) -> Result<Vec<Timing>, Box<dyn Error>> {
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&args.coordinates);
+    let map: BlockMap = io::read_from_file(&format!("{}.map", args.tables));
+    let tree: CellTree = io::read_from_file(&format!("{}.tree", args.tables));
+    let begins: Vec<Vec<u32>> = io::read_vec_from_file(&format!("{}.begins", args.tables));
+    let widths: Vec<Vec<u32>> = io::read_vec_from_file(&format!("{}.widths", args.tables));
+    info!(
+        "read a map of {} blocks over {} levels",
+        map.len(),
+        tree.levels()
+    );
+
+    let ends = arc_ends(&graph, pairs);
+    let partition = PackedPartition::of(directory);
+    let borders = BorderLevels::of(&graph, &partition);
+    let store = BlockStore::open_counting_from(
+        std::path::Path::new(&format!("{}.blocks", args.tables)),
+        map,
+        tree,
+        begins,
+        widths,
+    )?;
+    let tables = PagedOverlay::new(
+        store,
+        load_graph(&args.graph),
+        partition,
+        borders,
+        Pool::of(args.budget),
+    );
+    let overlay =
+        PagedEdgeBasedOverlay::new(tables, graph, coordinates, AnglePenalty::new(30., 100));
+    info!("holding at most {} bytes of tables", args.budget);
+
+    let mut query = MldQuery::new();
+    let bar = bar_of(args.warmup.min(pairs.len()), "warming the pool");
+    for (leaving, arriving) in ends.iter().take(args.warmup) {
+        query.run_to_arcs(&overlay, leaving, arriving);
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
+        .iter()
+        .zip(&ends)
+        .map(|(&(source, target, rank), (leaving, arriving))| {
+            query.clear();
+            let started = Instant::now();
+            let distance = query.run_to_arcs(&overlay, leaving, arriving);
+            let elapsed = started.elapsed().as_nanos();
+            bar.inc(1);
+            (source, target, rank, elapsed, distance)
+        })
+        .collect();
+    bar.finish_and_clear();
+
+    let faults = overlay.faults();
+    info!(
+        "{} tables were found already held, {} were read off the file, {} were thrown away",
+        faults.hits, faults.misses, faults.evicted
+    );
+    Ok(timings)
+}
+
+/// The same pairs over cells whose nodes are the arcs of the graph.
+///
+/// A query names its ends as nodes and this searches over arcs. A node of the
+/// overlay is the tail of its arc, so it starts on every arc leaving the source
+/// at no cost, and finishes on the arcs running *into* the target, whose
+/// distance plus their own weight is what it cost to arrive.
+///
+/// Finishing on the arcs *leaving* the target instead would ask for a way to
+/// carry on out of it, which a dead end refusing reversals does not have: 996
+/// of 4800 pairs came back unreachable that way, all of them at low ranks.
+///
+/// What comes back is what it costs to reach the target with every turn on the
+/// way priced, which is not the number the node-based engines report and is not
+/// meant to be.
+fn time_edge_based_mld(
+    graph: StaticGraph<u32>,
+    directory: &LevelDirectory,
+    args: &Time,
+    pairs: &[ToTime],
+) -> Vec<Timing> {
+    let coordinates = io::read_vec_from_file::<FPCoordinate>(&args.coordinates);
+    let ends = arc_ends(&graph, pairs);
+
+    let started = Instant::now();
+    let overlay = EdgeBasedOverlay::new(graph, coordinates, AnglePenalty::new(30., 100), directory);
+    info!(
+        "built the overlay in {:.1} s",
+        started.elapsed().as_secs_f64()
+    );
+
+    // Every cell, not only the ones a warmup happens to walk through. A cell is
+    // tabulated the first time it is asked for, so a query reaching one nobody
+    // has asked for yet pays to build it with the clock running: left to a
+    // warmup of a hundred pairs, the low ranks came out with medians of a
+    // thirtieth of a millisecond and whiskers at sixty, which is cell building
+    // and not query time.
+    let started = Instant::now();
+    let bar = bar_of(overlay.levels(), "tabulating the cells");
+    for level in 0..overlay.levels() {
+        for cell in 0..overlay.cells_on_level(level) {
+            let _ = overlay.distances_of(level, cell as CellId);
+        }
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+    info!(
+        "tabulated every cell in {:.1} s",
+        started.elapsed().as_secs_f64()
+    );
+
+    let mut query = MldQuery::new();
+    let bar = bar_of(args.warmup.min(pairs.len()), "warming");
+    for (leaving, arriving) in ends.iter().take(args.warmup) {
+        query.run_to_arcs(&overlay, leaving, arriving);
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
+        .iter()
+        .zip(&ends)
+        .map(|(&(source, target, rank), (leaving, arriving))| {
+            query.clear();
+            let started = Instant::now();
+            let distance = query.run_to_arcs(&overlay, leaving, arriving);
+            let elapsed = started.elapsed().as_nanos();
+            bar.inc(1);
+            (source, target, rank, elapsed, distance)
+        })
+        .collect();
+    bar.finish_and_clear();
+    timings
+}
+
+/// The same pairs over cells that are read off a file rather than held.
+///
+/// What is being timed here is not another algorithm. It is the same query
+/// over the same tables, with a budget on how much of them may be in memory at
+/// once, so what the rows say is what reading a table off a file costs a query
+/// that would otherwise have found it already there.
+fn time_paged_mld(
+    graph: StaticGraph<u32>,
+    directory: &LevelDirectory,
+    args: &Time,
+    pairs: &[ToTime],
+) -> Result<Vec<Timing>, Box<dyn Error>> {
+    let map: BlockMap = io::read_from_file(&format!("{}.map", args.tables));
+    let tree: CellTree = io::read_from_file(&format!("{}.tree", args.tables));
+    info!(
+        "read a map of {} blocks over {} levels",
+        map.len(),
+        tree.levels()
+    );
+
+    let partition = PackedPartition::of(directory);
+    let borders = BorderLevels::of(&graph, &partition);
+    let store = BlockStore::open(
+        std::path::Path::new(&format!("{}.blocks", args.tables)),
+        map,
+        tree,
+    )?;
+    let overlay = PagedOverlay::new(store, graph, partition, borders, Pool::of(args.budget));
+    info!("holding at most {} bytes of tables", args.budget);
+
+    let mut query = MldQuery::new();
+    let bar = bar_of(args.warmup.min(pairs.len()), "warming the pool");
+    for &(source, target, _) in pairs.iter().take(args.warmup) {
+        query.run(&overlay, source, &[target]);
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+
+    let bar = bar_of(pairs.len(), "timing");
+    let timings = pairs
+        .iter()
+        .map(|&(source, target, rank)| {
+            query.clear();
+            let started = Instant::now();
+            let reached = query.run(&overlay, source, &[target]);
+            let elapsed = started.elapsed().as_nanos();
+            let distance = if reached {
+                query.distance(target)
+            } else {
+                usize::MAX
+            };
+            bar.inc(1);
+            (source, target, rank, elapsed, distance)
+        })
+        .collect();
+    bar.finish_and_clear();
+
+    let faults = overlay.faults();
+    info!(
+        "{} tables were found already held, {} were read off the file, {} were thrown away",
+        faults.hits, faults.misses, faults.evicted
+    );
+    Ok(timings)
 }
 
 /// The same pairs over the cells, with a front growing from each end.

--- a/src/unidirectional_dijkstra.rs
+++ b/src/unidirectional_dijkstra.rs
@@ -12,7 +12,7 @@
 /// ratio between them is partly a ratio between two ways of finding a node.
 use crate::{
     dense_heap::DenseHeap,
-    graph::{Arcs, NodeID},
+    graph::{Adjacency, INVALID_NODE_ID, NodeID},
     heap_stats::{Counters, HeapStats, Untracked},
 };
 
@@ -31,6 +31,9 @@ pub type TrackedUnidirectionalDijkstra = UnidirectionalSearch<Counters>;
 pub struct UnidirectionalSearch<S: HeapStats<NodeID>> {
     queue: DenseHeap<S>,
     upper_bound: usize,
+    /// the node the last run stopped on, which a run with several targets has
+    /// no other way of saying
+    met: NodeID,
 }
 
 impl<S: HeapStats<NodeID>> Default for UnidirectionalSearch<S> {
@@ -46,6 +49,7 @@ impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
         Self {
             queue,
             upper_bound: usize::MAX,
+            met: INVALID_NODE_ID,
         }
     }
 
@@ -60,6 +64,18 @@ impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
     pub fn clear(&mut self) {
         self.queue.clear();
         self.upper_bound = usize::MAX;
+        self.met = INVALID_NODE_ID;
+    }
+
+    /// The node the last run stopped on, or [`INVALID_NODE_ID`] if it stopped
+    /// because there was nothing left to settle.
+    ///
+    /// [`Self::run`] stops on the target it was given and this says nothing
+    /// new. [`Self::run_many`] is given a test rather than a node, and this is
+    /// which node answered it.
+    #[must_use]
+    pub fn met(&self) -> NodeID {
+        self.met
     }
 
     /// What it cost to reach a node, and `usize::MAX` for one the last run
@@ -82,7 +98,7 @@ impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
     /// run a path computation from s to t on some graph. The object is reusable
     /// to run consecutive searches, even on different graphs. It is cleared on
     /// every run, which saves on allocations.
-    pub fn run<G: Arcs<u32>>(&mut self, graph: &G, s: NodeID, t: NodeID) -> usize {
+    pub fn run<G: Adjacency<u32>>(&mut self, graph: &G, s: NodeID, t: NodeID) -> usize {
         // clear the search space
         self.clear();
 
@@ -103,18 +119,59 @@ impl<S: HeapStats<NodeID>> UnidirectionalSearch<S> {
             // check if target is reached
             if u == t {
                 self.upper_bound = distance;
+                self.met = u;
                 debug!("[done] reached {t} at {distance}");
                 return self.upper_bound;
             }
 
-            // relax outgoing edges
-            for edge in graph.edge_range(u) {
-                debug!("[relax] edge {edge}");
-                let v = graph.target(edge);
-                let new_distance = distance + graph.weight(edge) as usize;
-
+            // Relax outgoing arcs. Asked a node at a time rather than an arc
+            // at a time, since a graph that works its arcs out as it goes can
+            // only answer that way, and one reading them off a file answers it
+            // an order of magnitude faster.
+            let from = self.queue.data(u);
+            graph.for_each_arc(u, from, |v, weight| {
+                let new_distance = distance + weight as usize;
                 self.queue.insert_or_decrease(v, new_distance, u);
+            });
+        }
+
+        self.upper_bound
+    }
+
+    /// A run from several nodes at once, each starting at a cost of its own,
+    /// that stops on the first node it settles that `reached` accepts.
+    ///
+    /// [`Self::run`] is the case of one source and one target. This is what a
+    /// search over a graph whose nodes are another graph's arcs needs, since
+    /// standing at a node there means standing on any of the arcs leaving it,
+    /// and arriving at one means arriving on any of the arcs that run into it.
+    pub fn run_many<G: Adjacency<u32>>(
+        &mut self,
+        graph: &G,
+        sources: &[(NodeID, usize)],
+        reached: impl Fn(NodeID) -> bool,
+    ) -> usize {
+        self.clear();
+
+        for &(node, cost) in sources {
+            self.queue.insert_or_decrease(node, cost, node);
+        }
+
+        while !self.queue.is_empty() && self.upper_bound == usize::MAX {
+            let u = self.queue.delete_min();
+            let distance = self.queue.weight(u);
+
+            if reached(u) {
+                self.upper_bound = distance;
+                self.met = u;
+                return self.upper_bound;
             }
+
+            let from = self.queue.data(u);
+            graph.for_each_arc(u, from, |v, weight| {
+                let new_distance = distance + weight as usize;
+                self.queue.insert_or_decrease(v, new_distance, u);
+            });
         }
 
         self.upper_bound


### PR DESCRIPTION
## What moved

**New trait `Adjacency<T>` in `graph.rs`**, with `number_of_nodes()` and `for_each_arc(n, from, f)`. `from` is the node `n` was reached from, or `n` itself where a search began. Every `Arcs<T>` implements it through a blanket impl that ignores `from`, so no existing caller changes.

It exists because an edge-based graph cannot answer `Arcs`. `Arcs` answers an arc at a time by an id that stands on its own; here a turn's cost depends on the arc it was arrived along, which an arc id does not say, and a turn that may not be taken has to be absent rather than expensive.

**`UnidirectionalSearch`** relaxes through `for_each_arc` instead of walking `edge_range` and asking for each target and weight. Gains `run_many(graph, sources, reached)`, which runs from several nodes at once each at a cost of its own and stops on the first settled node `reached` accepts, and `met()`, which says which node that was.

**New module `edge_based`.**

- `EdgeBasedGraph<'a, G, T>` holds references to a graph and its coordinates plus a turn cost. A node of it is an arc of the graph, by the same id, since `StaticGraph` numbers arcs densely from zero. The turns leaving an arc are the arcs leaving its head, so a turn is named by the arc it lands on. Written out, europe would be 42 million nodes and 98 million arcs; none of it is built.
- `Turn` is the two segments meeting at a turn, with `cross`, `dot` and `degrees`.
- `TurnCost::cost(&Turn) -> Option<u32>` prices a turn or refuses it. `FreeTurns`, `NoUTurns`, and `AnglePenalty::new(free_within, sharpest)`.
- `between_nodes` searches from every arc leaving a node to every arc running into another. `node_path` turns a route of arcs into the nodes it runs through. `tail` finds the node an arc runs out of.
- `examples/edge_based_probe.rs` runs one search to exhaustion per turn cost and reports time, search space, offsets read, and what each cost changed.

## Numbers

europe.ptv, least of three rounds from one source, against a node-based search of 3.075s over 18,010,173 nodes:

| turns | time | search space | offsets read | slower |
|---|---|---|---|---|
| node-based | 3.075s | 18,010,173 | - | 1.00x |
| free | 7.999s | 42,188,664 | 30 in 6 | 2.60x |
| no u-turns | 7.474s | 36,511,027 | 30 in 6 | 2.43x |
| angle 30/100 | 9.964s | 36,511,027 | 30 in 6 | 3.24x |

The edge-based search space is 2.34x the node-based one, so free turns at 2.60x cost close to nothing per node settled beyond the graph being bigger. The ratio is the noisiest figure here: across two runs the edge-based times held (7.911/7.999, 7.727/7.474, 10.182/9.964) while the 3-second baseline moved 3.595s to 3.075s.

What the turn costs changed, against free turns:

| turns | dearer | shut out | mean rise | worst rise |
|---|---|---|---|---|
| no u-turns | 0 | 0 | 0.00% | 0 |
| angle 30/100 | 18,010,167 | 0 | 1.18% | 12,715 |

Refusing reversals changes no distance, and cannot: a u-turn is a detour any shortest path drops. It constrains where a route may start, which is what the arc-id entry point is for.

## Correctness

Free turns forbid nothing and cost nothing, so the expansion must answer what the graph underneath answers. It does, for all 18,010,173 nodes, and the probe asserts it rather than reporting it. Seven unit tests cover tails, tails under a carried hint, free turns over every pair of a small graph, a dead end sealed by refusing reversals, a corner charged where straight on is not, and path unpacking. 714 lib tests pass.

## What this leaves

Bidirectional search is not supported. `bidirectional_dijkstra` takes a forward and a reverse graph and the same arc has different ids in each, so edge-based node ids would not line up and the meeting test would break.

`tail` remains a binary search of the offsets, for callers with no predecessor to hand. Reaching it through `Adjacency` costs two searches a query rather than one per node settled; an earlier version widened a bracket around the last answer instead and was worse, 42.6 offsets a lookup against 24, since a Dijkstra settles in order of distance and not in order of arc.

`for_each_arc`'s `from` is a contract. A caller passing a node that `n` is not really reachable from gets wrong turn costs and no complaint.

The expansion iterates `edge_range` rather than the graph's own `for_each_arc`, which hands over where an arc goes and not which arc it is. An `EdgeBasedGraph` over a `PagedGraph` therefore gives up what `for_each_arc` buys a file-backed graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)